### PR TITLE
fix: allow Chip labels to wrap text instead of overflowing

### DIFF
--- a/client/src/components/Chip.module.css
+++ b/client/src/components/Chip.module.css
@@ -2,6 +2,11 @@
   display: none;
 }
 
+.label {
+  white-space: normal;
+  height: auto;
+}
+
 .label[data-checked] {
   padding-inline: var(--chip-padding);
 }


### PR DESCRIPTION
## Description
Fixes chip text overflow in forms by allowing labels to wrap instead of overflowing horizontally-- should apply globally/throughout the app

## Changes
- changed global styles Mantine Chip component css in `client/src/components/Chip.module.css` 

## Testing
- Verified chips with long text now wrap properly in Deflection Details form

## Screenshots
<img width="1351" height="1440" alt="Screenshot 2026-01-28 183758" src="https://github.com/user-attachments/assets/786ed4b2-f245-4b51-884f-ac385fd7fe07" />


Closes #165 