### PR TITLE
Enable Posthog session recording in non-dev environments

### DIFF
--- a/client/src/analytics/PosthogProvider.jsx
+++ b/client/src/analytics/PosthogProvider.jsx
@@ -27,7 +27,7 @@ function PosthogProvider () {
       const { default: posthog } = await import('posthog-js');
       if (!isMounted) return;
 
-      const isDev = import.meta?.env?.DEV;
+      const isDev = !!import.meta?.env?.DEV;
       posthog.init(apiKey, {
         api_host: apiHost || DEFAULT_API_HOST,
         capture_pageview: true,


### PR DESCRIPTION
See this re: checking if in dev w/ vite:
- https://vite.dev/guide/env-and-mode

Per the docs, I think we can only enable session recordings via this config, and then in the Posthog UI we set up sampling rate % / record on all errors:
- https://posthog.com/docs/session-replay/how-to-control-which-sessions-you-record#sampling

