### PR TITLE
fix(lesc): use primary button style for 'I've left' button

### DIFF
--- a/client/src/lesc/components/Facility.jsx
+++ b/client/src/lesc/components/Facility.jsx
@@ -58,7 +58,7 @@ function Facility ({
         </Stack>
         <Group gap='sm' grow wrap='nowrap'>
           {(!hasArrived || hasLeft) && <Button px='sm' variant='secondary' onClick={onArrivedClick} disabled={isArrivedButtonDisabled}>I've arrived</Button>}
-          {hasArrived && !hasLeft && <Button px='sm' color='indigo.0' c='black' onClick={onLeftClick}>I've left</Button>}
+          {hasArrived && !hasLeft && <Button px='sm' onClick={onLeftClick}>I've left</Button>}
           <Button px='sm' onClick={onHoldClick} disabled={isHoldButtonDisabled}>Hold a {t(`bedType.${bedTypes?.[0].type}`).toLocaleLowerCase()}</Button>
         </Group>
         {hasArrived && !hasLeft && <Text align='center' size='md' c='gray.5'>Arrived at {DateTime.fromISO(arrivedAt).toLocaleString(DateTime.TIME_SIMPLE)}</Text>}


### PR DESCRIPTION
Closes #174

## Summary
- Removed custom `color='indigo.0'` and `c='black'` props from the "I've left" button
- Button now uses the default primary styling (`indigo.6`) from the theme

## Screenshots
**storybook:**
<img width="413" height="304" alt="careconnect-174" src="https://github.com/user-attachments/assets/595ddc7a-36c9-40b6-9209-7cc1e6d9a5ed" />

**In app [local]:**
<img width="588" height="253" alt="careconnect-174-1" src="https://github.com/user-attachments/assets/becc6afe-09ea-423c-a2d6-5997d240bad5" />