### PR TITLE
Add missing Prisma migration step to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ Please read CONTRIBUTING.md for information on how to contribute to this project
 
    ```
    cd server
+   npx prisma migrate deploy
    npx prisma db seed
    ```
+
+   The first command creates the database and applies all migrations. The second command populates it with development data.
 
    This will populate the database with a complete setup for development, including an admin user that you can use to log in to the web app.
 


### PR DESCRIPTION
Added 'npx prisma migrate deploy' command before 'npx prisma db seed' in the one-time setup instructions.  This step is required to create the database and apply migrations before seeding can succeed.  Without this step, users encounter a 'Database does not exist' error when attempting to seed.