### PR TITLE
From /feedback page, allow user to tap 'Go back'

### DIFF
--- a/client/src/Feedback/FeedbackForm.jsx
+++ b/client/src/Feedback/FeedbackForm.jsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router';
 import { useMutation } from '@tanstack/react-query';
-import { Button, Stack, Text, Textarea, TextInput, Alert } from '@mantine/core';
+import { Button, SimpleGrid, Stack, Text, Textarea, TextInput, Alert } from '@mantine/core';
 
 import Api from '@/Api';
 
 function FeedbackForm ({ onSuccess }) {
+  const navigate = useNavigate();
   const [message, setMessage] = useState('');
   const [userEmail, setUserEmail] = useState('');
   const [success, setSuccess] = useState(false);
@@ -91,21 +93,36 @@ function FeedbackForm ({ onSuccess }) {
           </Alert>
         )}
 
-        <Button
-          type='submit'
-          disabled={!message.trim() || mutation.isPending}
-          loading={mutation.isPending}
-          styles={{
-            root: {
-              backgroundColor: '#000000',
-              color: '#ffffff',
-              borderRadius: '24px',
-              padding: '8px 20px',
-            },
-          }}
-        >
-          Share feedback
-        </Button>
+        <SimpleGrid cols={{ base: 1, sm: 2 }}>
+          <Button
+            type='submit'
+            disabled={!message.trim() || mutation.isPending}
+            loading={mutation.isPending}
+            styles={{
+              root: {
+                backgroundColor: '#000000',
+                color: '#ffffff',
+                borderRadius: '24px',
+                padding: '8px 20px',
+              },
+            }}
+          >
+            Share feedback
+          </Button>
+          <Button
+            variant='default'
+            onClick={() => window.history.length > 1 ? navigate(-1) : navigate('/')}
+            disabled={mutation.isPending}
+            styles={{
+              root: {
+                borderRadius: '24px',
+                padding: '8px 20px',
+              },
+            }}
+          >
+            Go back
+          </Button>
+        </SimpleGrid>
       </Stack>
     </form>
   );


### PR DESCRIPTION
Resolves #320.

Uses the browser's built-in navigation for simplicity of implementation. AFAIK there are currently three pages from which you can navigate to feedback:

- /holds (SFPD)
- /custody (SFSO)
- /account

This implementation ensures that you go back to whichever page you came from.

On Mobile, use full-width buttons so they remain easy to tap:
![WhatsApp Image 2026-02-18 at 18 24 53](https://github.com/user-attachments/assets/bd74dca5-fd8b-4775-af30-0541c482e59b)


On Web, it shows side-by-side:
<img width="866" height="473" alt="image" src="https://github.com/user-attachments/assets/ec9745f3-949a-42e5-bab2-b09c373305bb" />
