### PR TITLE
Fix: SFPD Unit Numbers Pagination

### DIFF
--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -408,8 +408,8 @@ const Api = {
       },
     },
     units: {
-      index (organizationId, page = 1) {
-        return instance.get(`/api/organizations/${organizationId}/units`, { params: { page } });
+      index (organizationId, page = 1, perPage = 25) {
+        return instance.get(`/api/organizations/${organizationId}/units`, { params: { page, perPage } });
       },
       get (organizationId, id) {
         return instance.get(`/api/organizations/${organizationId}/units/${id}`);

--- a/client/src/UnitSelector.jsx
+++ b/client/src/UnitSelector.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, Container, Stack, Title, Autocomplete } from '@mantine/core';
+import { Box, Button, Container, Stack, Title, Autocomplete, Loader } from '@mantine/core';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router';
 
@@ -16,10 +16,12 @@ function UnitSelector () {
 
   const from = location.state?.from || '/';
 
-  const { data: units = [] } = useQuery({
+  const { data: units = [], isLoading } = useQuery({
     queryKey: ['organizations', user?.organizationId, 'units'],
-    queryFn: () => Api.organizations.units.index(user.organizationId).then((response) => response.data),
+    queryFn: () => Api.organizations.units.index(user.organizationId, 1, 1000)
+      .then((response) => response.data),
     enabled: !!user?.organizationId,
+    staleTime: 5 * 60 * 1000, // 5 minutes - prevent unnecessary refetches
   });
 
   const onSubmitMutation = useMutation({
@@ -59,6 +61,8 @@ function UnitSelector () {
           value={unitName}
           onChange={handleOptionSubmit}
           clearable
+          disabled={isLoading}
+          rightSection={isLoading ? <Loader size='sm' /> : null}
           nothingfound='No units found'
         />
         <Box flex='0 0'>


### PR DESCRIPTION
# Fix: SFPD Unit Numbers Pagination

closes #319 

## Problem

First responders could only see 25 out of 969 SFPD units in the unit dropdown because the frontend was fetching paginated results without specifying a higher `perPage` limit. The remaining 944 units were inaccessible.

## Solution

Modified the frontend to fetch all units at once using `perPage=1000` and added a loading indicator.

## Changes

- `client/src/Api.js:411-412`: Added `perPage` parameter to `units.index()` method (default: 25)
- `client/src/UnitSelector.jsx`:
  - Call API with `perPage=1000` to fetch all units
  - Added `staleTime: 5 minutes` to cache results
  - Added loading state with `Loader` indicator during fetch

## Testing

1. **Automated**: All 359 tests pass (91 client + 268 server)
2. **API verification**: `curl` confirmed default returns 25 units, `perPage=1000` returns 969
3. **Browser testing** (agent-browser):
   - Logged in as SFPD user
   - Opened unit dropdown: counted 969 options
   - Typed "6T": filtered to 15 matching units (no matches in the first 25 items, see comment with screencap on #319 ) 
   - Selected unit "6T70": Confirm button enabled
4. **Network inspection**: Confirmed API call includes `?page=1&perPage=1000`
5. **MANUAL TESTING** -- verified (see screencap below) that the dropdown is scrollable and has way more than 25 units

Screencap

https://github.com/user-attachments/assets/3f0d7478-d33c-4a03-8ecc-7db7fa6732b9



## Notes

Future enhancement could add server-side search for larger datasets, but client-side filtering is getting the job done for now.