### PR TITLE
[Draft] Enable address autocomplete in Incident field

### DIFF
--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -359,6 +359,11 @@ const Api = {
     },
   },
   geocode: {
+    autocomplete (text) {
+      return instance.get('/api/geocode/autocomplete', {
+        params: { text }
+      }).catch(handleError);
+    },
     reverse (latitude, longitude) {
       return instance.get('/api/geocode/reverse', {
         params: { latitude, longitude }

--- a/client/src/components/AddressAutocomplete.jsx
+++ b/client/src/components/AddressAutocomplete.jsx
@@ -1,0 +1,100 @@
+import { useEffect, useRef, useState } from 'react';
+import { Autocomplete, Loader } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+
+import Api from '@/Api';
+
+function AddressAutocomplete ({ form, field, rightSection, ...props }) {
+  const [value, setValue] = useState(form.getValues()[field] ?? '');
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const resultsRef = useRef([]);
+  const abortControllerRef = useRef(null);
+  const [debounced] = useDebouncedValue(value, 300);
+
+  useEffect(() => {
+    if (!debounced || debounced.length < 3) {
+      setData([]);
+      resultsRef.current = [];
+      return;
+    }
+
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+
+    setLoading(true);
+    Api.geocode.autocomplete(debounced)
+      .then((response) => {
+        if (controller.signal.aborted) return;
+        const results = response?.data ?? [];
+        resultsRef.current = results;
+        const seen = new Set();
+        setData(results
+          .filter((r) => r.addressLine1)
+          .filter((r) => {
+            if (seen.has(r.addressLine1)) return false;
+            seen.add(r.addressLine1);
+            return true;
+          })
+          .map((r) => ({
+            value: r.addressLine1,
+            label: r.neighborhood
+              ? `${r.addressLine1} (${r.neighborhood})`
+              : r.addressLine1,
+          })));
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setData([]);
+        resultsRef.current = [];
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) {
+          setLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [debounced]);
+
+  function handleChange (val) {
+    setValue(val);
+  }
+
+  function handleBlur () {
+    form.setFieldValue(field, value);
+  }
+
+  function handleOptionSubmit (val) {
+    const match = resultsRef.current.find((r) => r.addressLine1 === val);
+    if (match) {
+      form.setValues({
+        [field]: match.addressLine1 ?? '',
+        city: match.city ?? '',
+        state: match.state ?? '',
+        postalCode: match.postalCode ?? '',
+        latitude: match.latitude ?? '',
+        longitude: match.longitude ?? '',
+      });
+      setValue(match.addressLine1 ?? '');
+    }
+  }
+
+  return (
+    <Autocomplete
+      {...props}
+      value={value}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      onOptionSubmit={handleOptionSubmit}
+      data={data}
+      filter={({ options }) => options}
+      rightSection={loading ? <Loader size={24} /> : rightSection}
+    />
+  );
+}
+
+export default AddressAutocomplete;

--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -19,6 +19,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DateTime } from 'luxon';
 
 import Api from '@/Api';
+import AddressAutocomplete from '@/components/AddressAutocomplete';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useFacilityContext } from '@/FacilityContext';
@@ -207,10 +208,11 @@ function IncidentForm () {
               )}
               {showAddressForm && (
                 <>
-                  <TextInput
+                  <AddressAutocomplete
                     ref={addressRef}
+                    form={form}
+                    field='addressLine1'
                     key={form.key('addressLine1')}
-                    {...form.getInputProps('addressLine1')}
                     label={
                       <>
                         Arrest address line 1<span>*</span>

--- a/server/routes/api/geocode/autocomplete.js
+++ b/server/routes/api/geocode/autocomplete.js
@@ -1,0 +1,70 @@
+import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod';
+
+const DATASF_URL = 'https://data.sfgov.org/resource/3mea-di5p.json';
+
+function toTitleCase (str) {
+  return str
+    .toLowerCase()
+    .replace(/(?:^|\s)\S/g, (ch) => ch.toUpperCase());
+}
+
+export default async function (fastify, opts) {
+  fastify.get('/autocomplete',
+    {
+      schema: {
+        description: 'Autocomplete address using DataSF address database.',
+        querystring: z.object({
+          text: z.string().min(1),
+        }),
+        response: {
+          [StatusCodes.OK]: z.array(z.object({
+            addressLine1: z.string(),
+            city: z.string(),
+            state: z.string(),
+            postalCode: z.string().nullable(),
+            latitude: z.number().nullable(),
+            longitude: z.number().nullable(),
+            neighborhood: z.string().nullable(),
+          })),
+        },
+      },
+    },
+    async function (request, reply) {
+      const { text } = request.query;
+
+      try {
+        const url = new URL(DATASF_URL);
+        url.searchParams.set('$where', `starts_with(address, '${text.toUpperCase().replace(/'/g, "''")}')`);
+        url.searchParams.set('$select', 'address, zip_code, latitude, longitude, nhood');
+        url.searchParams.set('$order', 'address');
+        url.searchParams.set('$limit', '5');
+
+        const response = await fetch(url, {
+          headers: { Accept: 'application/json' },
+        });
+
+        if (!response.ok) {
+          const responseText = await response.text();
+          fastify.log.error(`DataSF autocomplete request failed (${response.status}): ${responseText}`);
+          return reply.code(StatusCodes.INTERNAL_SERVER_ERROR).send();
+        }
+
+        const data = await response.json();
+        const results = data.map((row) => ({
+          addressLine1: toTitleCase(row.address),
+          city: 'San Francisco',
+          state: 'CA',
+          postalCode: row.zip_code ?? null,
+          latitude: row.latitude ? parseFloat(row.latitude) : null,
+          longitude: row.longitude ? parseFloat(row.longitude) : null,
+          neighborhood: row.nhood ?? null,
+        }));
+
+        return reply.send(results);
+      } catch (error) {
+        fastify.log.error(error, 'Error during address autocomplete');
+        return reply.code(StatusCodes.INTERNAL_SERVER_ERROR).send();
+      }
+    });
+}


### PR DESCRIPTION
Intended to address #326.

In this draft, we directly hit the DataSF address database as the user types, using the results to populate an `AutoComplete` element. If the user selects an address from the list, that address is populated into the Address and Zip fields (city and state are always pre-set to SFCA anyway.)

<img width="568" height="520" alt="image" src="https://github.com/user-attachments/assets/75970c2a-c51f-4f1b-8c35-c94884a11c4d" />

<img width="545" height="518" alt="image" src="https://github.com/user-attachments/assets/9d884e42-71b4-4c3b-b3e0-e1335d1144bd" />

# Implementation Notes

- Since we already rely on OpenRouteService, I first tried implementing it with that (and I have a working branch that uses it). There's something weird with the ORS data - it very rarely brings in a zip code. The app doesn't treat Zip as a required field, but I felt we could do better.
- So this draft relies on DataSF, but I'm wary of hitting this external API in production. The relevant DataSF database is very small and we could serve it ourselves. This would both eliminate an external dependency and dramatically reduce latency, from a few hundred ms to probably < 50? And we'd never have to worry about rate limiting, etc. I started working on this; I'm trying to get my head around Prisma which is new to me, and I may need help figuring out how we'd handle initializing this data in the production DB. 