### PR TITLE
Enable address autocomplete for the Subject details page

### DIFF
--- a/client/src/lesc/components/SubjectForm.jsx
+++ b/client/src/lesc/components/SubjectForm.jsx
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { DateTime } from 'luxon';
 import { useTranslation } from 'react-i18next';
 import { formatInputDob } from '@/utils/format';
+import AddressAutocomplete from '@/components/AddressAutocomplete';
 import Api from '@/Api';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
@@ -333,11 +334,11 @@ function SubjectForm () {
                   </Accordion.Control>
                   <Accordion.Panel>
                     <Stack gap='xl'>
-                      <TextInput
+                      <AddressAutocomplete
+                        form={form}
+                        field='addressLine1'
                         key={form.key('addressLine1')}
                         label='Street address'
-                        placeholder='Enter street address'
-                        {...form.getInputProps('addressLine1')}
                       />
                       <TextInput
                         key={form.key('addressLine2')}


### PR DESCRIPTION
Resolves #405.
On the Subject details page, the Street address field now supports autocomplete. This functionality already existed for the Incident details page; we're just reusing it here.

<img width="590" height="1278" alt="IMG_8892" src="https://github.com/user-attachments/assets/7385eb26-04ed-47f2-bbd1-4fddfc964c22" />


