### PR TITLE
required fields marked as required

### DIFF
--- a/client/src/Admin/Enums/DeflectionCancelReasons/AdminDeflectionCancelReasonForm.jsx
+++ b/client/src/Admin/Enums/DeflectionCancelReasons/AdminDeflectionCancelReasonForm.jsx
@@ -95,6 +95,8 @@ function AdminDeflectionCancelReasonForm () {
                 {...form.getInputProps('id')}
                 key={form.key('id')}
                 label='ID (Slug)'
+                required
+                withAsterisk={false}
                 placeholder='e.g. resident_left_before_treatment'
                 disabled={!isNew}
               />
@@ -103,6 +105,8 @@ function AdminDeflectionCancelReasonForm () {
                 {...form.getInputProps('name')}
                 key={form.key('name')}
                 label='Name'
+                required
+                withAsterisk={false}
                 placeholder='e.g. Resident left before treatment'
               />
 

--- a/client/src/Admin/Enums/FacilityStatusReasons/AdminFacilityStatusReasonForm.jsx
+++ b/client/src/Admin/Enums/FacilityStatusReasons/AdminFacilityStatusReasonForm.jsx
@@ -96,6 +96,8 @@ function AdminFacilityStatusReasonForm () {
                 {...form.getInputProps('id')}
                 key={form.key('id')}
                 label='ID (Slug)'
+                required
+                withAsterisk={false}
                 placeholder='e.g. no_beds_available'
                 disabled={!isNew}
               />
@@ -117,6 +119,8 @@ function AdminFacilityStatusReasonForm () {
                 {...form.getInputProps('description')}
                 key={form.key('description')}
                 label='Description'
+                required
+                withAsterisk={false}
                 placeholder='e.g. No beds available'
               />
 

--- a/client/src/Admin/Invites/AdminInviteForm.jsx
+++ b/client/src/Admin/Invites/AdminInviteForm.jsx
@@ -60,16 +60,22 @@ function AdminInviteForm () {
                 {...form.getInputProps('firstName')}
                 key='firstName'
                 label='First name'
+                required
+                withAsterisk={false}
               />
               <TextInput
                 {...form.getInputProps('lastName')}
                 key='lastName'
                 label='Last name'
+                required
+                withAsterisk={false}
               />
               <TextInput
                 {...form.getInputProps('email')}
                 key='email'
                 label='Email'
+                required
+                withAsterisk={false}
                 type='email'
               />
               <Select

--- a/client/src/Admin/Organizations/AdminOrganizationForm.jsx
+++ b/client/src/Admin/Organizations/AdminOrganizationForm.jsx
@@ -79,6 +79,8 @@ function OrganizationForm () {
                 {...form.getInputProps('id')}
                 key={form.key('id')}
                 label='ID'
+                required
+                withAsterisk={false}
                 placeholder='e.g. sfpd'
                 disabled={!isNew}
               />
@@ -86,6 +88,8 @@ function OrganizationForm () {
                 {...form.getInputProps('name')}
                 key={form.key('name')}
                 label='Name'
+                required
+                withAsterisk={false}
                 placeholder='e.g. San Francisco Police Department'
               />
               <Group>

--- a/client/src/Admin/Organizations/Titles/AdminTitleForm.jsx
+++ b/client/src/Admin/Organizations/Titles/AdminTitleForm.jsx
@@ -100,6 +100,8 @@ function AdminTitleForm () {
                 {...form.getInputProps('id')}
                 key={form.key('id')}
                 label='ID'
+                required
+                withAsterisk={false}
                 placeholder='e.g. officer'
                 disabled={!isNew}
               />
@@ -107,6 +109,8 @@ function AdminTitleForm () {
                 {...form.getInputProps('name')}
                 key={form.key('name')}
                 label='Name'
+                required
+                withAsterisk={false}
                 placeholder='e.g. Officer'
               />
               <Group>

--- a/client/src/Admin/Organizations/Units/AdminUnitForm.jsx
+++ b/client/src/Admin/Organizations/Units/AdminUnitForm.jsx
@@ -100,6 +100,8 @@ function AdminUnitForm () {
                 {...form.getInputProps('id')}
                 key={form.key('id')}
                 label='ID'
+                required
+                withAsterisk={false}
                 placeholder='e.g. patrol'
                 disabled={!isNew}
               />
@@ -107,6 +109,8 @@ function AdminUnitForm () {
                 {...form.getInputProps('name')}
                 key={form.key('name')}
                 label='Name'
+                required
+                withAsterisk={false}
                 placeholder='e.g. Patrol'
               />
               <Group>

--- a/client/src/Admin/Users/AdminUserForm.jsx
+++ b/client/src/Admin/Users/AdminUserForm.jsx
@@ -104,18 +104,24 @@ function AdminUserForm () {
                 {...form.getInputProps('firstName')}
                 key={form.key('firstName')}
                 label='First name'
+                required
+                withAsterisk={false}
                 disabled
               />
               <TextInput
                 {...form.getInputProps('lastName')}
                 key={form.key('lastName')}
                 label='Last name'
+                required
+                withAsterisk={false}
                 disabled
               />
               <TextInput
                 {...form.getInputProps('email')}
                 key={form.key('email')}
                 label='Email'
+                required
+                withAsterisk={false}
                 type='email'
                 disabled
               />

--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -96,6 +96,8 @@ function Login () {
                 key={form.key('email')}
                 {...form.getInputProps('email')}
                 label='Email'
+                required
+                withAsterisk={false}
                 placeholder='youremail@example.com'
                 leftSection={<IconMail size={20} color='var(--mantine-color-dark-1)' />}
               />
@@ -103,6 +105,8 @@ function Login () {
                 key={form.key('password')}
                 {...form.getInputProps('password')}
                 label='Password'
+                required
+                withAsterisk={false}
                 placeholder='Enter password'
                 leftSection={<IconLock size={20} color='var(--mantine-color-dark-1)' />}
               />

--- a/client/src/Passwords/ForgotPassword.jsx
+++ b/client/src/Passwords/ForgotPassword.jsx
@@ -48,6 +48,7 @@ function ForgotPassword () {
                   <TextInput
                     {...form.getInputProps('email')}
                     key='email'
+                    required
                     placeholder='youremail@example.com'
                     type='email'
                   />

--- a/client/src/Passwords/ResetPassword.jsx
+++ b/client/src/Passwords/ResetPassword.jsx
@@ -91,6 +91,7 @@ function ResetPassword () {
                       <PasswordInput
                         {...form.getInputProps('password')}
                         key='password'
+                        required
                         placeholder='Enter new password'
                       />
                       <PasswordStrength password={form.getValues().password} />

--- a/client/src/RegistrationForm.jsx
+++ b/client/src/RegistrationForm.jsx
@@ -58,12 +58,16 @@ function RegistrationForm ({ invite, onSubmitMutation }) {
                 {...form.getInputProps('firstName')}
                 key={form.key('firstName')}
                 label='First name'
+                required
+                withAsterisk={false}
                 placeholder='Enter first name'
               />
               <TextInput
                 {...form.getInputProps('lastName')}
                 key={form.key('lastName')}
                 label='Last name'
+                required
+                withAsterisk={false}
                 placeholder='Enter last name'
               />
             </>
@@ -73,6 +77,8 @@ function RegistrationForm ({ invite, onSubmitMutation }) {
             key={form.key('email')}
             type='email'
             label='Email'
+            required
+            withAsterisk={false}
             placeholder='youremail@example.com'
             disabled={!!invite}
             leftSection={<IconMail size={20} color='var(--mantine-color-dark-1)' />}
@@ -85,6 +91,8 @@ function RegistrationForm ({ invite, onSubmitMutation }) {
             }}
             key={form.key('password')}
             label='Password'
+            required
+            withAsterisk={false}
             placeholder='Enter password'
             leftSection={<IconLock size={20} color='var(--mantine-color-dark-1)' />}
           />

--- a/client/src/components/Input.module.css
+++ b/client/src/components/Input.module.css
@@ -2,8 +2,9 @@
   font-weight: 600;
   line-height: 1.5555em;
 
-  span {
+  :global(.mantine-InputWrapper-required) {
     color: var(--mantine-color-red-6);
+    margin-inline-start: -0.2em;
   }
 }
 

--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -249,11 +249,8 @@ function IncidentForm () {
             <Stack gap='xl'>
               {!showAddressForm && (
                 <TextInput
-                  label={
-                    <>
-                      Arrest location<span>*</span>
-                    </>
-                  }
+                  label='Arrest location'
+                  required
                   rightSection={
                     !isInitialized ? <Loader size={24} /> : <LocationButton />
                   }
@@ -272,11 +269,8 @@ function IncidentForm () {
                     form={form}
                     field='addressLine1'
                     key={form.key('addressLine1')}
-                    label={
-                      <>
-                        Arrest address line 1<span>*</span>
-                      </>
-                    }
+                    label='Arrest address line 1'
+                    required
                     rightSection={
                       !isInitialized ? <Loader size={24} /> : <LocationButton />
                     }
@@ -289,21 +283,15 @@ function IncidentForm () {
                   <TextInput
                     key={form.key('city')}
                     {...form.getInputProps('city')}
-                    label={
-                      <>
-                        Arrest city<span>*</span>
-                      </>
-                    }
+                    label='Arrest city'
+                    required
                   />
                   <Group wrap='nowrap'>
                     <TextInput
                       key={form.key('state')}
                       {...form.getInputProps('state')}
-                      label={
-                        <>
-                          Arrest state<span>*</span>
-                        </>
-                      }
+                      label='Arrest state'
+                      required
                     />
                     <TextInput
                       key={form.key('postalCode')}
@@ -318,18 +306,16 @@ function IncidentForm () {
               <TextInput
                 key={form.key('arrestedAt')}
                 {...form.getInputProps('arrestedAt')}
-                label={
-                  <>
-                    Arrest date & time<span>*</span>
-                  </>
-                }
+                label='Arrest date & time'
+                required
                 type='datetime-local'
                 onFocus={() => setShowAddressForm(false)}
               />
               <ChipInput
                 {...form.getInputProps('encounteredVia')}
                 key={form.key('encounteredVia')}
-                label={<>Encountered via<span>*</span></>}
+                label='Encountered via'
+                required
                 options={['ON_VIEW', 'DISPATCHED'].map(value => ({
                   value,
                   label: t(`encounteredVia.${value}`),
@@ -339,11 +325,8 @@ function IncidentForm () {
                 <TextInput
                   key={form.key('cadNumber')}
                   {...cadNumberInputProps}
-                  label={
-                    <>
-                      CAD number<span>*</span>
-                    </>
-                  }
+                  label='CAD number'
+                  required
                   placeholder='Enter CAD number'
                   type='text'
                   inputMode='text'
@@ -368,7 +351,8 @@ function IncidentForm () {
                 <TextInput
                   key={form.key('supervisorBadgeNumber')}
                   {...form.getInputProps('supervisorBadgeNumber')}
-                  label={<>Supervising Sergeant’s Star Number<span>*</span></>}
+                  label="Supervising Sergeant's Star Number"
+                  required
                   placeholder='Enter star number'
                   maxLength={4}
                   inputMode='numeric'

--- a/client/src/lesc/components/NarcoticsForm.jsx
+++ b/client/src/lesc/components/NarcoticsForm.jsx
@@ -89,12 +89,14 @@ function NarcoticsForm () {
               <BooleanInput
                 {...form.getInputProps('narcoticsSubstance')}
                 key={form.key('narcoticsSubstance')}
-                label={<>Possesses a controlled substance<span>*</span></>}
+                label='Possesses a controlled substance'
+                required
               />
               <BooleanInput
                 {...form.getInputProps('narcoticsParaphernalia')}
                 key={form.key('narcoticsParaphernalia')}
-                label={<>Possesses narcotics paraphernalia<span>*</span></>}
+                label='Possesses narcotics paraphernalia'
+                required
               />
               <Button type='submit'>
                 Save narcotics details

--- a/client/src/lesc/components/PropertyForm.jsx
+++ b/client/src/lesc/components/PropertyForm.jsx
@@ -196,7 +196,8 @@ function PropertyForm () {
               <ChipInput
                 {...form.getInputProps('property')}
                 key={form.key('property')}
-                label={<>How much property is the person bringing?<span>*</span></>}
+                label='How much property is the person bringing?'
+                required
                 options={['NONE', 'SMALL', 'MEDIUM', 'LARGE'].map(value => ({
                   value,
                   label: t(`property.${value}`),

--- a/client/src/lesc/components/SubjectForm.jsx
+++ b/client/src/lesc/components/SubjectForm.jsx
@@ -243,13 +243,15 @@ function SubjectForm () {
             <Stack gap='xl'>
               <TextInput
                 key={form.key('firstName')}
-                label={<>First name<span>*</span></>}
+                label='First name'
+                required
                 placeholder='Enter first name'
                 {...form.getInputProps('firstName')}
               />
               <TextInput
                 key={form.key('lastName')}
-                label={<>Last name<span>*</span></>}
+                label='Last name'
+                required
                 placeholder='Enter last name'
                 {...form.getInputProps('lastName')}
               />
@@ -260,7 +262,8 @@ function SubjectForm () {
                 {...form.getInputProps('middleInitial')}
               />
               <TextInput
-                label={<>Date of birth<span>*</span></>}
+                label='Date of birth'
+                required
                 type='text'
                 inputMode='numeric'
                 maxLength={10}
@@ -277,7 +280,8 @@ function SubjectForm () {
                 }}
               />
               <ChipInput
-                label={<>Sex<span>*</span></>}
+                label='Sex'
+                required
                 options={['MALE', 'FEMALE', 'OTHER', 'UNKNOWN'].map((sex) => ({
                   value: sex,
                   label: t(`sex.${sex}`),
@@ -286,7 +290,8 @@ function SubjectForm () {
                 key={form.key('sex')}
               />
               <ChipInput
-                label={<>Race<span>*</span></>}
+                label='Race'
+                required
                 options={['WHITE', 'BLACK', 'HISPANIC', 'ASIAN', 'OTHER', 'UNKNOWN'].map((race) => ({
                   value: race,
                   label: t(`race.${race}`),
@@ -358,12 +363,14 @@ function SubjectForm () {
                         <BooleanInput
                           {...form.getInputProps('narcoticsSubstance')}
                           key={form.key('narcoticsSubstance')}
-                          label={<>Possesses a controlled substance<span>*</span></>}
+                          label='Possesses a controlled substance'
+                          required
                         />
                         <BooleanInput
                           {...form.getInputProps('narcoticsParaphernalia')}
                           key={form.key('narcoticsParaphernalia')}
-                          label={<>Possesses narcotics paraphernalia<span>*</span></>}
+                          label='Possesses narcotics paraphernalia'
+                          required
                         />
                         <Divider />
                         <Stack gap='xl' data-section='drug-use'>


### PR DESCRIPTION
This work was not ticketed so feel free to ignore or defer.

I noticed that sometimes we take advantage of Mantine's built in * label additions when fields are required. This PR:

- Makes all required fields use the required attribute
- Removes the "span *" from labels on required fields which had it before
- Adds withAsterisk={false} to required fields which didn't have the span * already
- Adds CSS rule to tighten up spacing between Mantine * and rest of label to match our designs

If this works out we have the option of automatically adding the (optional) to the fields which aren't required if we wanted to.