### PR TITLE
add optional to labels on optional fields on sfpd forms

### DIFF
--- a/client/src/lesc/components/DeflectionForm.jsx
+++ b/client/src/lesc/components/DeflectionForm.jsx
@@ -253,7 +253,7 @@ function DeflectionForm () {
               <BooleanInput
                 {...form.getInputProps('volunteeredToReset')}
                 key={form.key('volunteeredToReset')}
-                label='Person volunteered to be taken to RESET'
+                label='Person volunteered to be taken to RESET (optional)'
               />
               <Input.Wrapper label='647(f) narrative'>
                 <Text size='md' mb='xs' c='dimmed'>This text will be inserted in the 647(f). Add to it using the form below.</Text>

--- a/client/src/lesc/components/DrugUseForm.jsx
+++ b/client/src/lesc/components/DrugUseForm.jsx
@@ -99,10 +99,10 @@ function DrugUseForm () {
               <BooleanInput
                 {...form.getInputProps('drugUseEvidence')}
                 key={form.key('drugUseEvidence')}
-                label='Evidence of drug use'
+                label='Evidence of drug use (optional)'
               />
               {showDrugTypeQuestion && (
-                <Input.Wrapper label='Drug type'>
+                <Input.Wrapper label='Drug type (optional)'>
                   <Chip.Group
                     key={form.key('drugType')}
                     {...form.getInputProps('drugType')}

--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -284,7 +284,7 @@ function IncidentForm () {
                   <TextInput
                     key={form.key('addressLine2')}
                     {...form.getInputProps('addressLine2')}
-                    label='Arrest address line 2'
+                    label='Arrest address line 2 (optional)'
                   />
                   <TextInput
                     key={form.key('city')}
@@ -308,7 +308,7 @@ function IncidentForm () {
                     <TextInput
                       key={form.key('postalCode')}
                       {...form.getInputProps('postalCode')}
-                      label='Arrest ZIP code'
+                      label='Arrest ZIP code (optional)'
                       type='number'
                       inputMode='numeric'
                     />

--- a/client/src/lesc/components/PropertyForm.jsx
+++ b/client/src/lesc/components/PropertyForm.jsx
@@ -215,7 +215,7 @@ function PropertyForm () {
                   {deflection.propertyPhotos.map(photo => (
                     <PhotoInput
                       key={photo.id}
-                      label='Photo'
+                      label='Photo (optional)'
                       id='file'
                       name='file'
                       value={photo.file}
@@ -240,7 +240,7 @@ function PropertyForm () {
               <Textarea
                 key={form.key('propertyDetails')}
                 {...form.getInputProps('propertyDetails')}
-                label='Description'
+                label='Description (optional)'
                 placeholder='E.g., black backpack with clothing and toiletries.'
               />
               <Button type='submit' mb='xl'>

--- a/client/src/lesc/components/PropertyForm.jsx
+++ b/client/src/lesc/components/PropertyForm.jsx
@@ -229,7 +229,7 @@ function PropertyForm () {
               )}
               {!deflection?.propertyPhotos?.length && (
                 <PhotoInput
-                  label='Photo'
+                  label='Photo (optional)'
                   id='file'
                   name='file'
                   onChange={(file) => onChangePhoto(null, file)}

--- a/client/src/lesc/components/SubjectForm.jsx
+++ b/client/src/lesc/components/SubjectForm.jsx
@@ -255,7 +255,7 @@ function SubjectForm () {
               />
               <TextInput
                 key={form.key('middleInitial')}
-                label='Middle initial'
+                label='Middle initial (optional)'
                 placeholder='Optional'
                 {...form.getInputProps('middleInitial')}
               />
@@ -296,13 +296,13 @@ function SubjectForm () {
               />
               <TextInput
                 key={form.key('driverLicense')}
-                label="Driver's license number"
+                label="Driver's license number (optional)"
                 placeholder='Optional'
                 {...form.getInputProps('driverLicense')}
               />
               <TextInput
                 key={form.key('localId')}
-                label='SF Number (if available)'
+                label='SF Number (optional)'
                 placeholder='Optional'
                 {...form.getInputProps('localId')}
               />
@@ -319,29 +319,29 @@ function SubjectForm () {
                         form={form}
                         field='addressLine1'
                         key={form.key('addressLine1')}
-                        label='Street address'
+                        label='Street address (optional)'
                       />
                       <TextInput
                         key={form.key('addressLine2')}
-                        label='Street address (line 2)'
+                        label='Street address line 2 (optional)'
                         placeholder='Optional'
                         {...form.getInputProps('addressLine2')}
                       />
                       <TextInput
                         key={form.key('city')}
-                        label='City'
+                        label='City (optional)'
                         placeholder='Enter city'
                         {...form.getInputProps('city')}
                       />
                       <TextInput
                         key={form.key('state')}
-                        label='State'
+                        label='State (optional)'
                         placeholder='Optional'
                         {...form.getInputProps('state')}
                       />
                       <TextInput
                         key={form.key('postalCode')}
-                        label='ZIP code'
+                        label='ZIP code (optional)'
                         placeholder='Enter ZIP code'
                         {...form.getInputProps('postalCode')}
                       />
@@ -372,10 +372,10 @@ function SubjectForm () {
                             <BooleanInput
                               {...form.getInputProps('drugUseEvidence')}
                               key={form.key('drugUseEvidence')}
-                              label='Evidence of drug use'
+                              label='Evidence of drug use (optional)'
                             />
                             {showDrugTypeQuestion && (
-                              <Input.Wrapper label='Drug type'>
+                              <Input.Wrapper label='Drug type (optional)'>
                                 <Chip.Group
                                   key={form.key('drugType')}
                                   {...form.getInputProps('drugType')}


### PR DESCRIPTION
## Code changes

This adds the text (optional) to the fields on the SFPD forms that aren't required.

This is the simplest way to make the change and help the officers complete the form faster. Fixes issue #411 

## Sidenote

I was messing around with making all required fields required but that isn't compatible with current app flows which allow form submission without all required fields being filled out which makes sense if officers are distracted in the field, so will close investigative PR #472