### PR TITLE
Fix incident number, location sent to, and drug type fields in 849(b)

### DIFF
--- a/server/lib/forms/pdf/Form849b.jsx
+++ b/server/lib/forms/pdf/Form849b.jsx
@@ -37,7 +37,6 @@ export const metadata = {
     arrestLocation: z.string(),
     officerName: z.string(),
     officerBadge: z.string(),
-    caseNumber: z.string(),
     subjectName: z.string(),
     subjectFullName: z.string(),
     subjectRace: z.string(),
@@ -114,7 +113,7 @@ export const metadata = {
   async generatePdf (deflectionData, user) {
     const templatePath = join(process.cwd(), 'lib/forms/pdf/templates/Form849b.pdf');
     const templateBytes = await readFile(templatePath);
-    const isDrugTypeCNSDepressants = deflectionData.subjectDrugType === DrugTypeEnum.INTOXICATING_LIQUOR;
+    const isDrugTypeCNSDepressants = deflectionData.subjectDrugType === DrugTypeEnum.CNS_DEPRESSANTS;
 
     // Map deflection data to 849b form fields
     const formData = {


### PR DESCRIPTION
- Use incident.caseNumber instead of incident.id.
- Set locationSentTo based on incident.encounteredVia. 
- Set premiseType to always be blank.
- Set primaryIncidentType and incidentCodes based on subject.drugType.

The logic in #395 mentions "CNS Depressants":

> Primary incident type -> if Drug type selected by PD was "CNS Depressants": "Alcohol, Under Influence in Public Place, Investigative Detention"; if Drug type selected by PD was anything else: "Drugs, Under Influence in a Public Place, Investigative Detention"

That string doesn't seem to appear anywhere in the code base, so this PR checks the drug type against `DrugTypeEnum.INTOXICATING_LIQUOR`.  If that's not right, then the prisma `DrugTypeEnum` may need updating.

Closes #395.

