### PR TITLE
Add synthetic historical data seed

### DIFF
--- a/docs/SYNTHETIC_DATA_GUIDELINES.md
+++ b/docs/SYNTHETIC_DATA_GUIDELINES.md
@@ -1,0 +1,516 @@
+# Synthetic Data Guidelines for Care Connect
+
+This document captures the business rules, state machines, and constraints for generating realistic synthetic data to test the Care Connect system and downstream analytics.
+
+---
+
+## Overview
+
+Care Connect tracks people through sobering center and drop-in facility workflows. The core entities are:
+
+- **Incident** — A field encounter (e.g., a detox/welfare check). One incident can have multiple deflections.
+- **Deflection** (aka "Hold") — A reservation/hold placed for one person at one facility bed.
+- **Subject** — The person associated with a deflection (optional; only created when subject details are entered).
+- **Facility** — A LESC (Law Enforcement Sobering Center) or DIDO (Drop-In, Drop-Off) facility.
+- **BedType** — A specific bed category within a facility (type: `BED` or `CHAIR`).
+
+---
+
+## Facility Rules
+
+### Facility Types
+- `LESC` — Law Enforcement Sobering Center
+- `DIDO` — Drop-In, Drop-Off center
+
+### Facility Status
+```
+CLOSED              → No operations possible
+OPEN_NOT_ACCEPTING  → Facility open but not taking new holds
+OPEN_ACCEPTING      → Normal operation; accepts new deflections
+```
+
+**Rules:**
+- Deflections can only be created when facility status = `OPEN_ACCEPTING`
+- Facility status changes are audit-logged in `FacilityUpdate`
+
+### Bed Type Capacity Fields
+Each `BedType` tracks these counters (all integers ≥ 0):
+
+| Field | Meaning |
+|-------|---------|
+| `capacity` | Total beds of this type |
+| `available` | Beds available for new holds |
+| `holds` | Holds placed but not yet intake-complete |
+| `inTransit` | Subset of holds where subject is in transit (not yet transferred to custody) |
+| `occupied` | Beds occupied by admitted/post-intake subjects |
+| `unavailableOccupied` | Beds marked unavailable but currently occupied |
+| `unavailableUnoccupied` | Beds marked unavailable and empty |
+
+**Invariant:** `capacity = available + holds + occupied + unavailableOccupied + unavailableUnoccupied`
+
+**Capacity changes by operation:**
+
+| Operation | holds | inTransit | occupied | available |
+|-----------|-------|-----------|----------|-----------|
+| Create deflection | +1 | +1 | — | -1 |
+| Transfer to custody | — | -1 | — | — |
+| Intake complete (admitted) | -1 | — | +1 | — |
+| Release/Exit from `IN_CHAIR` | — | — | -1 | +1 |
+| Release/Exit from hold states | -1 | — | — | +1 |
+| Cancel (from `DETAINED`/`ONSITE_AWAITING_TRANSFER`) | -1 | -1 | — | +1 |
+| Cancel (from `AWAITING_INTAKE` or later hold states) | -1 | — | — | +1 |
+| Cancel (from `IN_CHAIR`) | — | — | -1 | +1 |
+| Death | same as corresponding release/exit |
+
+---
+
+## Incident Rules
+
+### Fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | Int | Auto-increment |
+| `facilityId` | UUID | The associated facility |
+| `arrivedAt` | DateTime? | When responder arrived at facility; null until arrival |
+| `leftAt` | DateTime? | When person left the location |
+| `completedAt` | DateTime? | Set when incident is fully closed |
+| `addressLine1/2`, `city`, `state`, `postalCode` | String? | Location of incident |
+| `latitude`, `longitude` | Decimal? | GPS coordinates |
+| `arrestedAt` | DateTime? | Time of arrest, if applicable |
+| `encounteredVia` | Enum | `ON_VIEW` or `DISPATCHED` |
+| `cadNumber` | String? | Computer-aided dispatch number |
+| `caseNumber` | String? | Case/report number |
+| `supervisorBadgeNumber` | String? | Supervising officer's badge |
+| `createdBy` | User FK | Officer who created the incident |
+| `createdByOrganization/Title/Unit/BadgeNumber` | String | Snapshotted at creation |
+
+### Incident Lifecycle (implicit states via timestamps)
+
+```
+[Created]
+    ↓  (arrivedAt = null, completedAt = null)
+[Active / In-Progress]
+    ↓  PATCH /arrived → arrivedAt set
+[Arrived at Facility]
+    ↓  completedAt set (auto or explicit cancel)
+[Completed]
+```
+
+**State determination logic:**
+- `arrivedAt == null && completedAt == null` → Active, not yet at facility
+- `arrivedAt != null && completedAt == null` → Active, at facility
+- `completedAt != null` → Completed/closed
+
+### Incident Business Rules
+
+1. An incident can have one or more deflections.
+2. **Cancel**: Only allowed if `arrivedAt == null` (never arrived at facility).
+3. **Cancel with subject details**: If any deflection has a `subjectId`, a cancel reason is required.
+4. **Auto-completion**: Incident auto-completes when all its deflections are cancelled/expired AND `arrivedAt == null`.
+5. **Arrived**: Setting `arrivedAt` cascades all deflections in `DETAINED` status → `ONSITE_AWAITING_TRANSFER`.
+6. Incidents are created with an optional first deflection.
+
+### Realistic Timing Patterns
+
+- `arrivedAt` typically 5–30 minutes after incident creation
+- `leftAt` typically 10–60 minutes after `arrivedAt`
+- Completed incidents have `completedAt` set to the last deflection's exit/completion time
+- `arrestedAt` (if present) is typically at or before incident creation time
+
+---
+
+## Deflection (Hold) Rules
+
+### Fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | Int | Auto-increment |
+| `incidentId` | Int | Parent incident |
+| `facilityId` | UUID | Facility for this hold |
+| `bedTypeId` | UUID | Which bed type is reserved |
+| `subjectId` | UUID? | Subject record (nullable; added when details entered) |
+| `status` | HoldStatusEnum | `ACTIVE`, `CANCELLED`, `EXPIRED`, `COMPLETED` |
+| `subjectStatus` | SubjectStatusEnum | Person's current state (see below) |
+| `expiresAt` | DateTime | Default: 1 hour after creation |
+| `extensionCount` | Int | Number of times hold was extended (default 0) |
+
+### Hold Status Values
+
+```
+ACTIVE      → Hold is open and in progress
+CANCELLED   → Cancelled by a user
+EXPIRED     → Automatically expired (expiresAt passed without completion)
+COMPLETED   → Person has exited/been released (terminal state)
+```
+
+### Subject Status Values (Person's journey through the facility)
+
+```
+DETAINED                   (1) Initial state; person detained in field
+ONSITE_AWAITING_TRANSFER   (2) At facility; waiting for custody transfer
+AWAITING_INTAKE            (3) Transferred to custody; waiting for intake
+READY_FOR_INTAKE           (4) Passed safety check; ready for medical intake
+FAILED_INTAKE              (5) Did not pass intake; still in hold
+ADMITTED                   (6) Admitted to facility (assessment complete)
+IN_CHAIR                   (7) Occupying bed/chair (intake workflow complete)
+RELEASED                   (8) Legally released (pending exit processing)
+EXITED                     (9) Left the facility — terminal state
+DEATH_IN_FACILITY          (10) Died while in facility care — terminal state
+DEATH_IN_CUSTODY           (11) Died while in custody — terminal state
+```
+
+### Subject Status State Machine
+
+```
+DETAINED
+  └─ (incident.arrivedAt set) ──────────────────→ ONSITE_AWAITING_TRANSFER
+                                                         │
+                                                  [/transfer]
+                                                         ↓
+                                                  AWAITING_INTAKE
+                                                         │
+                                                  [/safety-check]
+                                                         ↓
+                                                  READY_FOR_INTAKE
+                                                         │
+                                                    [/admit]
+                                                         ↓
+                                                     ADMITTED
+                                                         │
+                                              [/intake-complete]
+                                            ┌────────────┴────────────┐
+                                     completed=true             completed=false
+                                            ↓                        ↓
+                                         IN_CHAIR              FAILED_INTAKE
+                                            │                        │
+                                      [/release]               [/release]
+                                            ↓                        ↓
+                                        RELEASED ◄─────────────────-┘
+                                            │
+                                        [/exit]
+                                            ↓
+                                         EXITED
+
+Direct Exit Paths (bypass release):
+  AWAITING_INTAKE, READY_FOR_INTAKE, ADMITTED, FAILED_INTAKE, IN_CHAIR
+    └─ [/exit-to-hospital] ────────────────────────────────→ EXITED
+    └─ [/exit-to-jail] ────────────────────────────────────→ EXITED
+
+Release Short-Circuit (auto-exit on certain release reasons):
+  [/release] with reason = "medical_issue" or "other" ────→ EXITED immediately
+  [/release] with reason = "sobered" ─────────────────────→ RELEASED (then needs /exit)
+
+Death Paths (from any in-custody or released state):
+  AWAITING_INTAKE, READY_FOR_INTAKE, ADMITTED, FAILED_INTAKE, IN_CHAIR
+    └─ [/record-death] ────────────────────────────────────→ DEATH_IN_CUSTODY
+  RELEASED
+    └─ [/record-death] ────────────────────────────────────→ DEATH_IN_FACILITY
+
+Cancellation (from ACTIVE hold, any subject status):
+  ACTIVE hold ──────────────────────────────────────────→ status = CANCELLED
+
+Auto-expiration (from ACTIVE hold, if expiresAt passes):
+  ACTIVE hold ──────────────────────────────────────────→ status = EXPIRED
+  (nightly job: expireHolds.js)
+
+Reopen (only from CANCELLED or EXPIRED):
+  CANCELLED/EXPIRED ─────────────────────────────────────→ ACTIVE
+```
+
+### Hold Status Groupings (used in business logic)
+
+```javascript
+// Subjects physically in custody (count toward capacity holds)
+IN_CUSTODY_STATUSES = [
+  AWAITING_INTAKE, FAILED_INTAKE, READY_FOR_INTAKE, ADMITTED, IN_CHAIR
+]
+
+// Subjects eligible for legal release
+RELEASABLE_STATUSES = [
+  AWAITING_INTAKE, READY_FOR_INTAKE, ADMITTED, IN_CHAIR, FAILED_INTAKE
+]
+
+// Terminal subject statuses (deflection is done)
+TERMINAL_STATUSES = [EXITED, DEATH_IN_FACILITY, DEATH_IN_CUSTODY]
+```
+
+---
+
+## Deflection Detail Fields (by operation)
+
+### Creation
+Required:
+- `incidentId`, `facilityId`, `bedTypeId`
+
+Optional:
+- `subjectId` (or inline subject details)
+- `narcoticsSubstance` (Boolean)
+- `narcoticsParaphernalia` (Boolean)
+- `drugUseEvidence` (Boolean)
+- `drugType`: `CNS_DEPRESSANTS`, `CNS_STIMULANTS`, `HALLUCINOGENS`, `DISSOCIATIVE_ANESTHETICS`, `NARCOTIC_ANALGESICS`, `INHALANTS`, `CANNABIS`
+- `behavior` (String)
+- `behaviorAdditions` (String)
+- `property`: `NONE`, `SMALL`, `MEDIUM`, `LARGE`
+- `propertyDetails` (String)
+- `deflectionDetails` (array of detail IDs)
+
+### Transfer (`/transfer`)
+Required:
+- `transferredByBadgeNumber`
+- `transferredByProp115Certified` (Boolean)
+- `transferredByOrganizationId`, `transferredByUnitId`, `transferredByTitleId`
+
+### Safety Check (`/safety-check`)
+No additional required fields (transitions `AWAITING_INTAKE → READY_FOR_INTAKE`).
+
+### Admit (`/admit`)
+Role required: `CARE`
+No additional required fields (transitions `READY_FOR_INTAKE → ADMITTED`).
+
+### Intake Complete (`/intake-complete`)
+- `completed` (Boolean): `true` → `IN_CHAIR`, `false` → `FAILED_INTAKE`
+
+### Release (`/release`)
+Role required: `CUSTODY`
+Required:
+- `releaseReasonId` (FK to `DeflectionReleaseReason`)
+
+Conditional:
+- If reason = `medical_issue`: `exitDestinationId` required
+- If reason = `other`: `otherReleaseReason` + `otherReleaseDestination` required
+
+### Exit (`/exit`)
+Required (from `IN_CHAIR` or `RELEASED`):
+- `exitDestinationId` (FK to `DeflectionExitDestination`)
+- `exitHousingStatusId` (FK to `DeflectionExitHousingStatus`)
+- `exitConnectedToCare`: `YES`, `NO`, or `UNKNOWN`
+- `exitSFResident`: `YES`, `NO`, or `UNKNOWN`
+
+### Exit to Hospital / Exit to Jail (`/exit-to-hospital`, `/exit-to-jail`)
+Required:
+- `refusalReasonId` (FK to `DeflectionRefusalReason`)
+
+### Record Death (`/record-death`)
+- No additional fields beyond identifying the deflection
+
+### Property Return (`/property-return`)
+Required:
+- `propertyReturned` (Boolean)
+
+Conditional:
+- If `propertyReturned = false`: `propertyNotReturnedReason` required (`ABANDONED`, `DESTROYED`, `OTHER`)
+- If reason = `OTHER`: `propertyNotReturnedOtherReason` required
+
+Constraints:
+- Subject status must be `RELEASED`
+- Can only be recorded once
+- Deflection must have property (volume ≠ `NONE`, or description, or photos)
+
+---
+
+## User Roles
+
+Three roles govern which operations a user can perform:
+
+| Role | Description | Key Permissions |
+|------|-------------|-----------------|
+| `FIELD` | Street outreach / field officers | Create incidents and deflections, mark arrived |
+| `CUSTODY` | Custody/detention staff | Transfer, safety check, release |
+| `CARE` | Medical/care staff | Admit, intake-complete, exit |
+
+---
+
+## Subject (Person) Fields
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `firstName`, `lastName` | String? | Full name |
+| `dateOfBirth` | Date? | DOB |
+| `sex` | Enum? | `MALE`, `FEMALE`, `OTHER` |
+| `race` | Enum? | Standard race/ethnicity codes |
+| `dlNumber`, `dlState` | String? | Driver's license |
+| `addressLine1/2`, `city`, `state`, `postalCode` | String? | Home address |
+
+Subjects can be created standalone or inline during deflection creation.
+
+---
+
+## Synthetic Data Generation Guidelines
+
+### Realistic Scenario Flows
+
+#### Scenario A: Full Successful Admission (most common happy path)
+```
+1. Create incident (encounteredVia: ON_VIEW or DISPATCHED)
+2. Create deflection (facility OPEN_ACCEPTING, bedType with available > 0)
+   → subjectStatus: DETAINED, holdStatus: ACTIVE
+3. PATCH incident /arrived (5–30 min after creation)
+   → subjectStatus: ONSITE_AWAITING_TRANSFER
+4. POST deflection /transfer (5–30 min after arrived)
+   → subjectStatus: AWAITING_INTAKE, inTransit decrements
+5. POST deflection /safety-check (5–20 min after transfer)
+   → subjectStatus: READY_FOR_INTAKE
+6. POST deflection /admit (5–30 min after safety-check)
+   → subjectStatus: ADMITTED
+7. POST deflection /intake-complete with completed=true (15–60 min after admit)
+   → subjectStatus: IN_CHAIR, holds-1, occupied+1
+8. POST deflection /release with reason="sobered" (1–6 hours after intake-complete)
+   → subjectStatus: RELEASED
+9. POST deflection /exit (15–60 min after release)
+   → subjectStatus: EXITED, occupied-1, available+1
+   → holdStatus: COMPLETED
+```
+
+#### Scenario B: Cancelled / No Capacity Scenario
+```
+1. Create incident
+2. Create deflection → subjectStatus: DETAINED, holdStatus: ACTIVE
+3. DELETE deflection (cancel with reason)
+   → holdStatus: CANCELLED, holds-1, available+1
+4. If no remaining active deflections and arrivedAt==null → incident auto-completes
+```
+
+#### Scenario C: Expired Hold
+```
+1. Create incident + deflection
+2. No further actions taken within 1 hour
+3. Nightly job expires the hold → holdStatus: EXPIRED
+4. Optionally: reopen hold → holdStatus: ACTIVE again
+```
+
+#### Scenario D: Direct Hospital Exit
+```
+1–5. Same as Scenario A steps 1–5 (up to READY_FOR_INTAKE)
+6. POST deflection /exit-to-hospital (with refusalReasonId)
+   → subjectStatus: EXITED, holds-1, available+1
+   → holdStatus: COMPLETED
+```
+
+#### Scenario E: Failed Intake
+```
+1–6. Same as Scenario A steps 1–6 (up to ADMITTED)
+7. POST deflection /intake-complete with completed=false
+   → subjectStatus: FAILED_INTAKE
+8. POST deflection /release (with appropriate reason)
+   → subjectStatus: RELEASED or EXITED
+```
+
+#### Scenario F: Death in Custody
+```
+1–7. Same as Scenario A steps 1–7 (up to IN_CHAIR)
+8. POST deflection /record-death
+   → subjectStatus: DEATH_IN_CUSTODY
+   → holdStatus: COMPLETED
+```
+
+---
+
+### Field Value Distributions (suggested for realistic data)
+
+#### `encounteredVia`
+- `ON_VIEW`: ~60%
+- `DISPATCHED`: ~40%
+
+#### `drugType` (when drug use evidence present)
+- `CNS_DEPRESSANTS` (alcohol/benzodiazepines): ~40%
+- `CNS_STIMULANTS` (meth/cocaine): ~30%
+- `NARCOTIC_ANALGESICS` (opioids): ~20%
+- Others: ~10% combined
+
+#### `property`
+- `NONE`: ~40%
+- `SMALL`: ~35%
+- `MEDIUM`: ~20%
+- `LARGE`: ~5%
+
+#### `exitConnectedToCare` / `exitSFResident`
+- Distribute `YES`/`NO`/`UNKNOWN` realistically (e.g., 30%/50%/20%)
+
+#### Subject Status Terminal Distribution
+- `EXITED`: ~80% of completed holds
+- `DEATH_IN_CUSTODY`/`DEATH_IN_FACILITY`: ~1% (rare)
+- `CANCELLED`: ~10–15% of all holds
+- `EXPIRED`: ~5–10% of all holds
+
+---
+
+### Temporal Constraints
+
+All timestamps must be chronologically consistent:
+
+```
+incidentCreatedAt
+  < arrivedAt (if set)
+  < deflectionTransferredAt (if set)
+  < safetyCheckAt (if set)
+  < admittedAt (if set)
+  < intakeCompletedAt (if set)
+  < releasedAt (if set)
+  < exitedAt (if set)
+
+deflectionCreatedAt
+  < deflectionExpiresAt (= createdAt + 1 hour, unless extended)
+
+arrestedAt (if set) ≤ incidentCreatedAt
+```
+
+### Typical Duration Ranges
+
+| Phase | Typical Duration |
+|-------|-----------------|
+| Creation → Arrived | 5–30 minutes |
+| Arrived → Transfer | 5–30 minutes |
+| Transfer → Safety Check | 5–20 minutes |
+| Safety Check → Admit | 5–30 minutes |
+| Admit → Intake Complete | 15–60 minutes |
+| Intake Complete → Release | 1–8 hours |
+| Release → Exit | 15–60 minutes |
+| Total hold duration | 2–12 hours |
+
+---
+
+### Referential Integrity Rules
+
+1. Every `deflection.incidentId` must reference a valid `incident.id`
+2. Every `deflection.facilityId` must reference a valid `facility.id` with status `OPEN_ACCEPTING` at time of creation
+3. Every `deflection.bedTypeId` must reference a `bedType` belonging to `deflection.facilityId` with `available > 0` at time of creation
+4. If `deflection.subjectId` is set, it must reference a valid `subject.id`
+5. Cancel/release/exit reason IDs must reference valid lookup table entries
+6. `transferredByOrganizationId`, `transferredByUnitId`, `transferredByTitleId` must reference valid org chart entries
+7. BedType capacity invariant must be maintained: `capacity = available + holds + occupied + unavailableOccupied + unavailableUnoccupied`
+
+---
+
+### Audit Trail Records
+
+Every state transition creates audit records:
+- `DeflectionUpdate`: records the before/after of any deflection field change
+- `BedTypeUpdate`: records capacity counter changes with each operation
+- `FacilityUpdate`: records facility status changes
+
+When generating synthetic data, generate corresponding audit records to ensure analytics queries work correctly.
+
+---
+
+## Key Enums Reference
+
+```
+HoldStatusEnum:       ACTIVE | CANCELLED | EXPIRED | COMPLETED
+SubjectStatusEnum:    DETAINED | ONSITE_AWAITING_TRANSFER | AWAITING_INTAKE |
+                      READY_FOR_INTAKE | FAILED_INTAKE | ADMITTED | IN_CHAIR |
+                      RELEASED | EXITED | DEATH_IN_FACILITY | DEATH_IN_CUSTODY
+PropertyEnum:         NONE | SMALL | MEDIUM | LARGE
+PropertyNotReturnedReasonEnum: ABANDONED | DESTROYED | OTHER
+DrugTypeEnum:         CNS_DEPRESSANTS | CNS_STIMULANTS | HALLUCINOGENS |
+                      DISSOCIATIVE_ANESTHETICS | NARCOTIC_ANALGESICS |
+                      INHALANTS | CANNABIS
+EncounteredViaEnum:   ON_VIEW | DISPATCHED
+FacilityStatusEnum:   CLOSED | OPEN_NOT_ACCEPTING | OPEN_ACCEPTING
+FacilityTypeEnum:     DIDO | LESC
+BedTypeEnum:          BED | CHAIR
+TernaryEnum:          YES | NO | UNKNOWN
+RoleEnum:             FIELD | CUSTODY | CARE
+SexEnum:              MALE | FEMALE | OTHER
+```

--- a/docs/SYNTHETIC_DATA_GUIDELINES.md
+++ b/docs/SYNTHETIC_DATA_GUIDELINES.md
@@ -10,6 +10,7 @@ Care Connect tracks people through sobering center and drop-in facility workflow
 
 - **Incident** — A field encounter (e.g., a detox/welfare check). One incident can have multiple deflections.
 - **Deflection** (aka "Hold") — A reservation/hold placed for one person at one facility bed.
+- **IncidentOfficer** — Per-officer participation record for an incident, including arresting vs receiving role, arrival/leave times, and handoff metadata.
 - **Subject** — The person associated with a deflection (optional; only created when subject details are entered).
 - **Facility** — A LESC (Law Enforcement Sobering Center) or DIDO (Drop-In, Drop-Off) facility.
 - **BedType** — A specific bed category within a facility (type: `BED` or `CHAIR`).
@@ -84,8 +85,23 @@ Each `BedType` tracks these counters (all integers ≥ 0):
 | `supervisorBadgeNumber` | String? | Supervising officer's badge |
 | `createdBy` | User FK | Officer who created the incident |
 | `createdByOrganization/Title/Unit/BadgeNumber` | String | Snapshotted at creation |
+| `incidentOfficers[]` | Relation | Per-officer records; source of current arrival/leave/handoff tracking |
 
-### Incident Lifecycle (implicit states via timestamps)
+### Incident Officer Tracking
+
+Each incident now has one or more `IncidentOfficer` rows:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `incidentId`, `facilityId`, `officerId` | FK set | Unique per incident/facility/officer |
+| `role` | Enum | `ARRESTING` or `RECEIVING` |
+| `arrivedAt` | DateTime? | Officer-specific arrival time |
+| `leftAt` | DateTime? | Officer-specific leave time |
+| `handoffReceivedAt` | DateTime? | When this officer accepted a handoff |
+| `handoffReceivedFromId` | User FK? | Officer who handed off control |
+| `badgeNumber`, `organizationId`, `unitId`, `titleId` | Snapshot fields | Copied from the officer profile at create/handoff |
+
+### Incident Lifecycle (legacy top-level timestamps + current per-officer state)
 
 ```
 [Created]
@@ -105,11 +121,14 @@ Each `BedType` tracks these counters (all integers ≥ 0):
 ### Incident Business Rules
 
 1. An incident can have one or more deflections.
-2. **Cancel**: Only allowed if `arrivedAt == null` (never arrived at facility).
+2. **Incident cancel**: The current `DELETE /incidents/:id` route allows cancellation of any active incident by the creator, an admin, or a full-handoff recipient who controls all remaining active holds.
 3. **Cancel with subject details**: If any deflection has a `subjectId`, a cancel reason is required.
-4. **Auto-completion**: Incident auto-completes when all its deflections are cancelled/expired AND `arrivedAt == null`.
-5. **Arrived**: Setting `arrivedAt` cascades all deflections in `DETAINED` status → `ONSITE_AWAITING_TRANSFER`.
-6. Incidents are created with an optional first deflection.
+4. **Auto-completion**: Incident auto-completes when all pre-transfer deflections are cancelled/expired AND legacy `incident.arrivedAt == null`.
+5. **Arrived**: `PATCH /incidents/:id/arrived` updates the requesting officer's `IncidentOfficer.arrivedAt` and only that officer's active deflections move `DETAINED → ONSITE_AWAITING_TRANSFER`.
+6. **Legacy incident arrival field**: `incident.arrivedAt` is only set when the creator marks arrived; downstream logic still uses it for some completion checks.
+7. **Leave**: `PATCH /incidents/:id/left` updates the requesting officer's `IncidentOfficer.leftAt`; `incident.completedAt` is set once no active holds remain.
+8. **Handoff-aware ownership**: Active deflections are controlled by `deflection.currentOfficerId`, not necessarily `incident.createdById`.
+9. Incidents are created with an optional first deflection.
 
 ### Realistic Timing Patterns
 
@@ -135,6 +154,7 @@ Each `BedType` tracks these counters (all integers ≥ 0):
 | `subjectStatus` | SubjectStatusEnum | Person's current state (see below) |
 | `expiresAt` | DateTime | Default: 1 hour after creation |
 | `extensionCount` | Int | Number of times hold was extended (default 0) |
+| `currentOfficerId` | UUID? | FIELD officer who currently controls the hold |
 
 ### Hold Status Values
 
@@ -144,6 +164,8 @@ CANCELLED   → Cancelled by a user
 EXPIRED     → Automatically expired (expiresAt passed without completion)
 COMPLETED   → Person has exited/been released (terminal state)
 ```
+
+Note: the enum still includes `COMPLETED`, but the current API routes primarily represent finished journeys via terminal `subjectStatus` values (`EXITED`, `DEATH_IN_FACILITY`, `DEATH_IN_CUSTODY`) while `status` often remains `ACTIVE`. Synthetic data should match persisted code behavior, not the older conceptual model.
 
 ### Subject Status Values (Person's journey through the facility)
 
@@ -165,7 +187,8 @@ DEATH_IN_CUSTODY           (11) Died while in custody — terminal state
 
 ```
 DETAINED
-  └─ (incident.arrivedAt set) ──────────────────→ ONSITE_AWAITING_TRANSFER
+  └─ [/handoff] ─────────────────────────────────────→ DETAINED with new `currentOfficerId`
+  └─ (controlling officer marks arrived) ───────→ ONSITE_AWAITING_TRANSFER
                                                          │
                                                   [/transfer]
                                                          ↓
@@ -195,11 +218,10 @@ DETAINED
 
 Direct Exit Paths (bypass release):
   AWAITING_INTAKE, READY_FOR_INTAKE, ADMITTED, FAILED_INTAKE, IN_CHAIR
-    └─ [/exit-to-hospital] ────────────────────────────────→ EXITED
-    └─ [/exit-to-jail] ────────────────────────────────────→ EXITED
+    └─ [/exit-to-jail] ────────────────────────────────────→ EXITED without release
 
 Release Short-Circuit (auto-exit on certain release reasons):
-  [/release] with reason = "medical_issue" or "other" ────→ EXITED immediately
+  [/release] with reason = "medical_issue" or "other" ────→ RELEASED and EXITED immediately
   [/release] with reason = "sobered" ─────────────────────→ RELEASED (then needs /exit)
 
 Death Paths (from any in-custody or released state):
@@ -211,8 +233,8 @@ Death Paths (from any in-custody or released state):
 Cancellation (from ACTIVE hold, any subject status):
   ACTIVE hold ──────────────────────────────────────────→ status = CANCELLED
 
-Auto-expiration (from ACTIVE hold, if expiresAt passes):
-  ACTIVE hold ──────────────────────────────────────────→ status = EXPIRED
+Auto-expiration (job only expires DETAINED holds whose expiresAt passed):
+  ACTIVE + DETAINED ────────────────────────────────────→ status = EXPIRED
   (nightly job: expireHolds.js)
 
 Reopen (only from CANCELLED or EXPIRED):
@@ -257,10 +279,35 @@ Optional:
 - `deflectionDetails` (array of detail IDs)
 
 ### Transfer (`/transfer`)
-Required:
-- `transferredByBadgeNumber`
-- `transferredByProp115Certified` (Boolean)
-- `transferredByOrganizationId`, `transferredByUnitId`, `transferredByTitleId`
+Role required: `CUSTODY`
+
+No request body is currently required.
+
+Persisted by the current route:
+- `transferredAt`
+- `transferredById`
+
+Additional transfer-related columns exist on the model (`transferredByBadgeNumber`, `transferredByProp115Certified`, `transferredByOrganizationId`, `transferredByUnitId`, `transferredByTitleId`), but the current API route does not require or populate them.
+
+### Officer Handoff (`/handoff`)
+Role required: `FIELD`
+
+Effects:
+- Reassigns `currentOfficerId` to the receiving officer
+- Creates or updates an `IncidentOfficer` row for the receiving officer with:
+  - `role = RECEIVING`
+  - `handoffReceivedAt`
+  - `handoffReceivedFromId`
+
+Constraints:
+- Hold must exist and be `ACTIVE`
+- Receiving officer cannot already control the hold
+- Incident details must be complete before handoff:
+  - `addressLine1`, `city`, `state`
+  - `arrestedAt`, `encounteredVia`
+  - `cadNumber`, `caseNumber`, `supervisorBadgeNumber`
+- Receiving officer cannot already have a different active incident at the same facility
+- Capacity counters do not change
 
 ### Safety Check (`/safety-check`)
 No additional required fields (transitions `AWAITING_INTAKE → READY_FOR_INTAKE`).
@@ -281,16 +328,31 @@ Conditional:
 - If reason = `medical_issue`: `exitDestinationId` required
 - If reason = `other`: `otherReleaseReason` + `otherReleaseDestination` required
 
+Effects:
+- `sobered` → `RELEASED`
+- `medical_issue` → immediately records `RELEASED` and `EXITED`
+- `other` → immediately records `RELEASED` and `EXITED`
+
 ### Exit (`/exit`)
 Required (from `IN_CHAIR` or `RELEASED`):
 - `exitDestinationId` (FK to `DeflectionExitDestination`)
 - `exitHousingStatusId` (FK to `DeflectionExitHousingStatus`)
 - `exitConnectedToCare`: `YES`, `NO`, or `UNKNOWN`
-- `exitSFResident`: `YES`, `NO`, or `UNKNOWN`
+- `exitSFResident`: `YES`, `NO`, `UNKNOWN`, or `DECLINED_CONSENT`
 
-### Exit to Hospital / Exit to Jail (`/exit-to-hospital`, `/exit-to-jail`)
-Required:
-- `refusalReasonId` (FK to `DeflectionRefusalReason`)
+Note: `DECLINED_CONSENT` is stored as `UNKNOWN` in the database.
+
+### Exit to Jail (`/exit-to-jail`)
+Role required: `CUSTODY`
+
+No request body is currently required.
+
+Effects:
+- Sets `subjectStatus = EXITED`
+- Sets `exitDestinationId = jail`
+- Derives `refusalReasonId = medical_issue` internally via destination mapping
+
+Note: there is no dedicated `/exit-to-hospital` route in the current API. Hospital exits happen via `/release` with `releaseReasonId = medical_issue` and `exitDestinationId = hospital`.
 
 ### Record Death (`/record-death`)
 - No additional fields beyond identifying the deflection
@@ -312,13 +374,15 @@ Constraints:
 
 ## User Roles
 
-Three roles govern which operations a user can perform:
+Operational roles for workflow transitions:
 
 | Role | Description | Key Permissions |
 |------|-------------|-----------------|
-| `FIELD` | Street outreach / field officers | Create incidents and deflections, mark arrived |
-| `CUSTODY` | Custody/detention staff | Transfer, safety check, release |
-| `CARE` | Medical/care staff | Admit, intake-complete, exit |
+| `FIELD` | Street outreach / field officers | Create incidents/holds, handoff holds, extend their pre-transfer holds, mark arrived/left |
+| `CUSTODY` | Custody/detention staff | Transfer, safety-check, release, exit-to-jail, property return, record death |
+| `CARE` | Medical/care staff | Admit, intake-complete, save exit details, final exit |
+
+Administrative roles also exist in code (`ORG_ADMIN`, `FACILITY_ADMIN`), but they are not the primary workflow actors for synthetic scenario generation.
 
 ---
 
@@ -328,8 +392,8 @@ Three roles govern which operations a user can perform:
 |-------|------|-------|
 | `firstName`, `lastName` | String? | Full name |
 | `dateOfBirth` | Date? | DOB |
-| `sex` | Enum? | `MALE`, `FEMALE`, `OTHER` |
-| `race` | Enum? | Standard race/ethnicity codes |
+| `sex` | Enum? | `MALE`, `FEMALE`, `OTHER`, `UNKNOWN` |
+| `race` | Enum? | `WHITE`, `BLACK`, `HISPANIC`, `ASIAN`, `OTHER`, `UNKNOWN` |
 | `dlNumber`, `dlState` | String? | Driver's license |
 | `addressLine1/2`, `city`, `state`, `postalCode` | String? | Home address |
 
@@ -345,7 +409,7 @@ Subjects can be created standalone or inline during deflection creation.
 ```
 1. Create incident (encounteredVia: ON_VIEW or DISPATCHED)
 2. Create deflection (facility OPEN_ACCEPTING, bedType with available > 0)
-   → subjectStatus: DETAINED, holdStatus: ACTIVE
+   → subjectStatus: DETAINED, holdStatus: ACTIVE, currentOfficerId = creator
 3. PATCH incident /arrived (5–30 min after creation)
    → subjectStatus: ONSITE_AWAITING_TRANSFER
 4. POST deflection /transfer (5–30 min after arrived)
@@ -360,7 +424,7 @@ Subjects can be created standalone or inline during deflection creation.
    → subjectStatus: RELEASED
 9. POST deflection /exit (15–60 min after release)
    → subjectStatus: EXITED, occupied-1, available+1
-   → holdStatus: COMPLETED
+   → hold status typically remains ACTIVE in the current codebase
 ```
 
 #### Scenario B: Cancelled / No Capacity Scenario
@@ -369,23 +433,23 @@ Subjects can be created standalone or inline during deflection creation.
 2. Create deflection → subjectStatus: DETAINED, holdStatus: ACTIVE
 3. DELETE deflection (cancel with reason)
    → holdStatus: CANCELLED, holds-1, available+1
-4. If no remaining active deflections and arrivedAt==null → incident auto-completes
+4. If no remaining active pre-transfer deflections and incident.arrivedAt==null → incident auto-completes
 ```
 
 #### Scenario C: Expired Hold
 ```
 1. Create incident + deflection
 2. No further actions taken within 1 hour
-3. Nightly job expires the hold → holdStatus: EXPIRED
+3. Nightly job expires the hold only if it is still `DETAINED` → holdStatus: EXPIRED
 4. Optionally: reopen hold → holdStatus: ACTIVE again
 ```
 
 #### Scenario D: Direct Hospital Exit
 ```
 1–5. Same as Scenario A steps 1–5 (up to READY_FOR_INTAKE)
-6. POST deflection /exit-to-hospital (with refusalReasonId)
+6. POST deflection /release with releaseReasonId="medical_issue" and exitDestinationId="hospital"
    → subjectStatus: EXITED, holds-1, available+1
-   → holdStatus: COMPLETED
+   → hold status typically remains ACTIVE in the current codebase
 ```
 
 #### Scenario E: Failed Intake
@@ -402,7 +466,40 @@ Subjects can be created standalone or inline during deflection creation.
 1–7. Same as Scenario A steps 1–7 (up to IN_CHAIR)
 8. POST deflection /record-death
    → subjectStatus: DEATH_IN_CUSTODY
-   → holdStatus: COMPLETED
+   → hold status typically remains ACTIVE in the current codebase
+```
+
+#### Scenario G: Originating Officer Hands Off Hold, Receiving Officer Completes Happy Path
+```
+1. Officer A creates incident and first deflection
+   → deflection.currentOfficerId = Officer A
+   → create IncidentOfficer(role=ARRESTING) for Officer A
+2. Officer A completes required incident details needed for handoff:
+   → addressLine1, city, state
+   → arrestedAt, encounteredVia
+   → cadNumber, caseNumber, supervisorBadgeNumber
+3. Officer B has no other active incident at the same facility
+4. Officer B POSTs deflection /handoff using Officer A's QR/manual code
+   → deflection.currentOfficerId = Officer B
+   → create/update IncidentOfficer(role=RECEIVING, handoffReceivedAt, handoffReceivedFromId=Officer A)
+5. Officer B PATCHes incident /arrived
+   → only Officer B's active holds move to ONSITE_AWAITING_TRANSFER
+   → Officer B's IncidentOfficer.arrivedAt is set
+6. POST deflection /transfer
+   → subjectStatus: AWAITING_INTAKE
+7. POST deflection /safety-check
+   → subjectStatus: READY_FOR_INTAKE
+8. POST deflection /admit
+   → subjectStatus: ADMITTED
+9. POST deflection /intake-complete with completed=true
+   → subjectStatus: IN_CHAIR, holds-1, occupied+1
+10. POST deflection /release with reason="sobered"
+    → subjectStatus: RELEASED
+11. POST deflection /exit
+    → subjectStatus: EXITED, occupied-1, available+1
+12. Officer B PATCHes incident /left after all active holds are resolved
+    → Officer B's IncidentOfficer.leftAt is set
+    → incident.completedAt is set when no active holds remain
 ```
 
 ---
@@ -453,6 +550,10 @@ incidentCreatedAt
 deflectionCreatedAt
   < deflectionExpiresAt (= createdAt + 1 hour, unless extended)
 
+handoffReceivedAt (if set)
+  >= deflectionCreatedAt
+  <= officerArrivedAt (if the receiving officer later arrives)
+
 arrestedAt (if set) ≤ incidentCreatedAt
 ```
 
@@ -479,7 +580,9 @@ arrestedAt (if set) ≤ incidentCreatedAt
 4. If `deflection.subjectId` is set, it must reference a valid `subject.id`
 5. Cancel/release/exit reason IDs must reference valid lookup table entries
 6. `transferredByOrganizationId`, `transferredByUnitId`, `transferredByTitleId` must reference valid org chart entries
-7. BedType capacity invariant must be maintained: `capacity = available + holds + occupied + unavailableOccupied + unavailableUnoccupied`
+7. If `currentOfficerId` is set, it must reference a valid FIELD user
+8. `IncidentOfficer` rows should exist for the arresting officer on incident creation and for any receiving officer after handoff
+9. BedType capacity invariant must be maintained: `capacity = available + holds + occupied + unavailableOccupied + unavailableUnoccupied`
 
 ---
 

--- a/server/prisma/seed.js
+++ b/server/prisma/seed.js
@@ -17,6 +17,7 @@ import seedDeflectionExitHousingStatuses from './seeds/deflectionExitHousingStat
 import seedDeflectionReleaseReasons from './seeds/deflectionReleaseReasons.js';
 import seedDeflectionRefusalReasons from './seeds/deflectionRefusalReasons.js';
 import seedTestDeflections from './seeds/testDeflections.js';
+import seedHistoricalData from './seeds/historicalData.js';
 import { createBoss } from '#lib/jobQueue/pgBoss.js';
 
 try {
@@ -42,6 +43,7 @@ try {
   await seedDeflectionReleaseReasons(prisma);
   await seedDeflectionRefusalReasons(prisma);
   await seedTestDeflections(prisma);
+  await seedHistoricalData(prisma);
 } catch (error) {
   console.error('Error seeding:', error);
   process.exit(1);

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -72,10 +72,10 @@ function makeSubject () {
     dateOfBirth: new Date(
       `${randInt(1960, 2000)}-${String(randInt(1, 12)).padStart(2, '0')}-${String(randInt(1, 28)).padStart(2, '0')}`
     ),
-    sex: weightedPick([{ v: 'MALE', w: 65 }, { v: 'FEMALE', w: 25 }, { v: 'OTHER', w: 10 }]),
+    sex: weightedPick([{ v: 'MALE', w: 60 }, { v: 'FEMALE', w: 25 }, { v: 'OTHER', w: 10 }, { v: 'UNKNOWN', w: 5 }]),
     race: weightedPick([
       { v: 'WHITE', w: 30 }, { v: 'BLACK', w: 25 }, { v: 'HISPANIC', w: 25 },
-      { v: 'ASIAN', w: 10 }, { v: 'OTHER', w: 10 },
+      { v: 'ASIAN', w: 10 }, { v: 'OTHER', w: 7 }, { v: 'UNKNOWN', w: 3 },
     ]),
   };
 }
@@ -85,11 +85,12 @@ function makeIncidentData (facilityId, fieldUser, baseTime, arrivedAt, leftAt, c
   return {
     facilityId,
     ...addr,
+    arrestedAt: addMins(baseTime, -randInt(1, 20)),
     encounteredVia: weightedPick([{ v: 'ON_VIEW', w: 60 }, { v: 'DISPATCHED', w: 40 }]),
-    cadNumber: Math.random() > 0.3 ? `26-${String(10000 + idx).slice(1)}` : null,
-    caseNumber: Math.random() > 0.5 ? `SF-2025-${String(50000 + idx).slice(1)}` : null,
-    supervisorBadgeNumber: Math.random() > 0.4 ? String(1000 + randInt(0, 8999)) : null,
-    createdByBadgeNumber: String(1000 + randInt(0, 8999)),
+    cadNumber: `26-${String(10000 + idx).slice(1)}`,
+    caseNumber: `SF-2026-${String(50000 + idx).slice(1)}`,
+    supervisorBadgeNumber: String(1000 + randInt(0, 8999)),
+    createdByBadgeNumber: fieldUser.badgeNumber ?? String(1000 + randInt(0, 8999)),
     arrivedAt: arrivedAt ?? null,
     leftAt: leftAt ?? null,
     completedAt: completedAt ?? null,
@@ -120,6 +121,7 @@ function makeDeflectionBase (facilityId, bedTypeId, fieldUser, baseTime) {
       { v: 'NONE', w: 40 }, { v: 'SMALL', w: 35 },
       { v: 'MEDIUM', w: 20 }, { v: 'LARGE', w: 5 },
     ]),
+    currentOfficerId: fieldUser.id,
     expiresAt: addHrs(baseTime, 1),
     status: 'ACTIVE',
     subjectStatus: 'DETAINED',
@@ -149,13 +151,42 @@ function exitData (careUser, exitDestId, housingStatusId, t) {
     exitConnectedToCare: weightedPick([
       { v: 'YES', w: 30 }, { v: 'NO', w: 50 }, { v: 'UNKNOWN', w: 20 },
     ]),
+    // Route input may include DECLINED_CONSENT, but the stored DB value is UNKNOWN.
     exitSFResident: weightedPick([
-      { v: 'YES', w: 55 }, { v: 'NO', w: 35 }, { v: 'UNKNOWN', w: 10 },
+      { v: 'YES', w: 50 }, { v: 'NO', w: 30 }, { v: 'UNKNOWN', w: 20 },
     ]),
     subjectStatus: 'EXITED',
-    status: 'COMPLETED',
-    completedAt: t,
   };
+}
+
+async function createIncidentOfficer (prisma, {
+  incidentId,
+  facilityId,
+  officer,
+  role,
+  arrivedAt = null,
+  leftAt = null,
+  handoffReceivedAt = null,
+  handoffReceivedFromId = null,
+}) {
+  if (!officer) return;
+  await prisma.incidentOfficer.create({
+    data: {
+      incidentId,
+      facilityId,
+      officerId: officer.id,
+      role,
+      arrivedAt,
+      leftAt,
+      handoffReceivedAt,
+      handoffReceivedFromId,
+      badgeNumber: officer.badgeNumber ?? null,
+      organizationId: officer.organizationId ?? null,
+      unitId: officer.unitId ?? null,
+      titleId: officer.titleId ?? null,
+      createdAt: handoffReceivedAt ?? arrivedAt ?? leftAt ?? new Date(),
+    },
+  });
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
@@ -165,10 +196,11 @@ export default async function main (prisma) {
 
   // ── Look up required references ──
   const fieldUser = await prisma.user.findUnique({ where: { email: 'sfpd@careconnectsf.org' } });
+  const fieldUser2 = await prisma.user.findUnique({ where: { email: 'sfpd2@careconnectsf.org' } });
   const custodyUser = await prisma.user.findUnique({ where: { email: 'sfso@careconnectsf.org' } });
   const careUser = await prisma.user.findUnique({ where: { email: 'care@careconnectsf.org' } });
 
-  if (!fieldUser || !custodyUser || !careUser) {
+  if (!fieldUser || !fieldUser2 || !custodyUser || !careUser) {
     console.warn('Required test users not found; skipping historical data seed.');
     return;
   }
@@ -200,8 +232,8 @@ export default async function main (prisma) {
   const cancelReasons = await prisma.deflectionCancelReason.findMany();
   const releaseReasonSobered = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'sobered' } });
   const releaseReasonMedical = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'medical_issue' } });
+  const releaseReasonDeathCustody = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'death_in_custody' } });
   const refusalReasonMedical = await prisma.deflectionRefusalReason.findUnique({ where: { id: 'medical_issue' } });
-  const refusalReasonAggressive = await prisma.deflectionRefusalReason.findUnique({ where: { id: 'aggressive_behavior' } });
 
   const exitDestinations = await prisma.deflectionExitDestination.findMany();
   const exitHousingStatuses = await prisma.deflectionExitHousingStatus.findMany();
@@ -224,8 +256,10 @@ export default async function main (prisma) {
   // ── Build scenario list ──
   // Each entry: { type, daysAgoMin, daysAgoMax }
   const scenarios = [
-    // 22 full happy-path exits
-    ...Array.from({ length: 22 }, () => ({ type: 'full_exit', daysAgoMin: 3, daysAgoMax: 90 })),
+    // 20 full happy-path exits
+    ...Array.from({ length: 20 }, () => ({ type: 'full_exit', daysAgoMin: 3, daysAgoMax: 90 })),
+    // 2 officer handoff happy paths
+    ...Array.from({ length: 2 }, () => ({ type: 'handoff_full_exit', daysAgoMin: 3, daysAgoMax: 90 })),
     // 7 cancelled before arrival
     ...Array.from({ length: 7 }, () => ({ type: 'cancelled_early', daysAgoMin: 2, daysAgoMax: 90 })),
     // 3 cancelled after transfer to custody
@@ -306,6 +340,14 @@ export default async function main (prisma) {
           ...(isSentinel ? { cadNumber: 'HIST-SENTINEL' } : {}),
         },
       });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tExit,
+      });
       await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
@@ -313,8 +355,6 @@ export default async function main (prisma) {
           subjectId: subject.id,
           ...transferData(custodyUser, sfsoUnit, tTransfer),
           subjectStatus: 'EXITED',
-          status: 'COMPLETED',
-          completedAt: tExit,
           admittedAt: tAdmit,
           admittedById: careUser.id,
           releasedAt: tRelease,
@@ -326,11 +366,68 @@ export default async function main (prisma) {
       });
     }
 
+    else if (type === 'handoff_full_exit') {
+      const tHandoff = addMins(base, randInt(10, Math.max(11, arrivedDelta - 1)));
+      const incident = await prisma.incident.create({
+        data: {
+          ...makeIncidentData(facility.id, fieldUser, base, null, null, tExit, idx),
+          ...(isSentinel ? { cadNumber: 'HIST-SENTINEL' } : {}),
+        },
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser2,
+        role: 'RECEIVING',
+        arrivedAt: tArrived,
+        leftAt: tExit,
+        handoffReceivedAt: tHandoff,
+        handoffReceivedFromId: fieldUser.id,
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          currentOfficerId: fieldUser2.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          admittedAt: tAdmit,
+          admittedById: careUser.id,
+          releasedAt: tRelease,
+          releasedById: custodyUser.id,
+          releaseReasonId: releaseReasonSobered.id,
+          ...exitData(careUser, pick(commonExitDests)?.id ?? 'street', pick(housingStatuses)?.id ?? 'unknown', tExit),
+          ...(detail ? { deflectionDetails: detail } : {}),
+        },
+      });
+      await prisma.incident.update({
+        where: { id: incident.id },
+        data: {
+          arrivedAt: tArrived,
+          leftAt: tExit,
+          completedAt: tExit,
+        },
+      });
+    }
+
     else if (type === 'cancelled_early') {
       const tCancel = addMins(base, randInt(5, 60));
       const cancelReason = pick(cancelReasons);
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, null, null, tCancel, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
       });
       await prisma.deflection.create({
         data: {
@@ -352,6 +449,13 @@ export default async function main (prisma) {
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, null, tCancel, idx),
       });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+      });
       await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
@@ -363,16 +467,22 @@ export default async function main (prisma) {
           cancelReasonId: cancelReason.id,
           cancelledAt: tCancel,
           cancelledById: custodyUser.id,
-          completedAt: tCancel,
         },
       });
     }
 
     else if (type === 'hospital_exit') {
-      const refusal = refusalReasonMedical ?? refusalReasonAggressive;
       const tHospital = addMins(tSafetyCheck, randInt(5, 30));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tHospital, tHospital, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tHospital,
       });
       await prisma.deflection.create({
         data: {
@@ -381,11 +491,12 @@ export default async function main (prisma) {
           subjectId: subject.id,
           ...transferData(custodyUser, sfsoUnit, tTransfer),
           subjectStatus: 'EXITED',
-          status: 'COMPLETED',
-          refusalReasonId: refusal?.id ?? null,
+          releaseReasonId: releaseReasonMedical?.id ?? releaseReasonSobered.id,
+          releasedAt: tHospital,
+          releasedById: custodyUser.id,
           exitedAt: tHospital,
           exitedById: custodyUser.id,
-          completedAt: tHospital,
+          exitDestinationId: exitDestHospital?.id ?? null,
         },
       });
     }
@@ -394,6 +505,14 @@ export default async function main (prisma) {
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tExit, tExit, idx),
       });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tExit,
+      });
       await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
@@ -401,7 +520,6 @@ export default async function main (prisma) {
           subjectId: subject.id,
           ...transferData(custodyUser, sfsoUnit, tTransfer),
           subjectStatus: 'EXITED',
-          status: 'COMPLETED',
           admittedAt: tAdmit,
           admittedById: careUser.id,
           rejectedAt: tIntake,
@@ -419,6 +537,14 @@ export default async function main (prisma) {
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tRelease, tRelease, idx),
       });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tRelease,
+      });
       await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
@@ -426,7 +552,6 @@ export default async function main (prisma) {
           subjectId: subject.id,
           ...transferData(custodyUser, sfsoUnit, tTransfer),
           subjectStatus: 'EXITED',
-          status: 'COMPLETED',
           admittedAt: tAdmit,
           admittedById: careUser.id,
           releasedAt: tRelease,
@@ -435,16 +560,22 @@ export default async function main (prisma) {
           exitedAt: tRelease,
           exitedById: custodyUser.id,
           exitDestinationId: exitDestHospital?.id ?? null,
-          completedAt: tRelease,
         },
       });
     }
 
     else if (type === 'jail_exit') {
-      const refusal = refusalReasonAggressive ?? refusalReasonMedical;
       const tJail = addMins(tTransfer, randInt(15, 60));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tJail, tJail, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tJail,
       });
       await prisma.deflection.create({
         data: {
@@ -453,11 +584,10 @@ export default async function main (prisma) {
           subjectId: subject.id,
           ...transferData(custodyUser, sfsoUnit, tTransfer),
           subjectStatus: 'EXITED',
-          status: 'COMPLETED',
-          refusalReasonId: refusal?.id ?? null,
+          refusalReasonId: refusalReasonMedical?.id ?? null,
           exitedAt: tJail,
           exitedById: custodyUser.id,
-          completedAt: tJail,
+          exitDestinationId: 'jail',
         },
       });
     }
@@ -466,7 +596,13 @@ export default async function main (prisma) {
       // Hold created but no follow-up; expired after 1 hour
       const tExpiry = addHrs(base, 1);
       const incident = await prisma.incident.create({
-        data: makeIncidentData(facility.id, fieldUser, base, null, null, null, idx),
+        data: makeIncidentData(facility.id, fieldUser, base, null, null, tExpiry, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
       });
       await prisma.deflection.create({
         data: {
@@ -485,6 +621,14 @@ export default async function main (prisma) {
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tDeath, tDeath, idx),
       });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tDeath,
+      });
       await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
@@ -492,10 +636,9 @@ export default async function main (prisma) {
           subjectId: subject.id,
           ...transferData(custodyUser, sfsoUnit, tTransfer),
           subjectStatus: 'DEATH_IN_CUSTODY',
-          status: 'COMPLETED',
           admittedAt: tAdmit,
           admittedById: careUser.id,
-          completedAt: tDeath,
+          releaseReasonId: releaseReasonDeathCustody?.id ?? 'death_in_custody',
         },
       });
     }
@@ -505,6 +648,12 @@ export default async function main (prisma) {
     else if (type === 'in_progress_detained') {
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, null, null, null, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
       });
       await prisma.deflection.create({
         data: {
@@ -523,6 +672,13 @@ export default async function main (prisma) {
       const tOnsite = addMins(base, randInt(10, 20));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tOnsite,
       });
       await prisma.deflection.create({
         data: {
@@ -543,6 +699,13 @@ export default async function main (prisma) {
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
       });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tOnsite,
+      });
       await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
@@ -560,6 +723,13 @@ export default async function main (prisma) {
       const tTrans = addMins(tOnsite, randInt(5, 15));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tOnsite,
       });
       await prisma.deflection.create({
         data: {
@@ -579,6 +749,13 @@ export default async function main (prisma) {
       const tAdm = addMins(tTrans, randInt(10, 35));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tOnsite,
       });
       await prisma.deflection.create({
         data: {

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -466,7 +466,7 @@ export default async function main (prisma) {
       const exitDest = pick(allExitDests) ?? exitDestStreet;
       const housingStatus = pick(allHousingStatuses) ?? housingStatusUnknown;
       const exitFields = exitData(careUser, exitDest?.id ?? 'street', housingStatus?.id ?? 'unknown', tExit);
-      const tHandoff = addMins(base, randInt(10, Math.max(11, arrivedDelta - 1)));
+      const tHandoff = addMins(base, randInt(1, Math.max(2, arrivedDelta - 2)));
       const incident = await prisma.incident.create({
         data: {
           ...makeIncidentData(facility.id, fieldUser, base, null, null, tExit, idx),

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -621,9 +621,9 @@ export default async function main (prisma) {
         { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
         { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
         { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'RELEASED', releaseReasonId: releaseReasonMedical?.id, updatedAt: tHospital, updatedById: custodyUser.id },
         {
           subjectStatus: 'EXITED',
-          releaseReasonId: releaseReasonMedical?.id,
           exitDestinationId: exitDestHospital?.id,
           updatedAt: tHospital,
           updatedById: custodyUser.id
@@ -714,9 +714,9 @@ export default async function main (prisma) {
         { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
         { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
         { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+        { subjectStatus: 'RELEASED', releaseReasonId: releaseReasonMedical?.id, updatedAt: tRelease, updatedById: custodyUser.id },
         {
           subjectStatus: 'EXITED',
-          releaseReasonId: releaseReasonMedical?.id,
           exitDestinationId: exitDestHospital?.id,
           updatedAt: tRelease,
           updatedById: custodyUser.id

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -1,0 +1,614 @@
+// Generates 50 synthetic scenarios (45 historical + 5 in-progress) for dashboard testing.
+// Idempotent: skips if sentinel cadNumber already exists.
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function addMins (date, m) { return new Date(date.getTime() + m * 60_000); }
+function addHrs (date, h) { return new Date(date.getTime() + h * 3_600_000); }
+function addDays (date, d) { return new Date(date.getTime() + d * 86_400_000); }
+function randInt (min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
+function pick (arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+function weightedPick (items) {
+  const total = items.reduce((s, i) => s + i.w, 0);
+  let r = Math.random() * total;
+  for (const item of items) { r -= item.w; if (r <= 0) return item.v; }
+  return items.at(-1).v;
+}
+
+// Random timestamp in the past, spread across daylight hours
+function randomPastTime (daysAgoMin, daysAgoMax) {
+  const now = Date.now();
+  const base = now - randInt(daysAgoMin, daysAgoMax) * 86_400_000;
+  const d = new Date(base);
+  d.setHours(randInt(6, 23), randInt(0, 59), randInt(0, 59), 0);
+  return d;
+}
+
+// ─── Data pools ──────────────────────────────────────────────────────────────
+
+const FIRST_NAMES = [
+  'James', 'Maria', 'Robert', 'Patricia', 'Michael', 'Jennifer', 'William', 'Linda',
+  'David', 'Barbara', 'Richard', 'Susan', 'Joseph', 'Jessica', 'Thomas', 'Sarah',
+  'Charles', 'Karen', 'Christopher', 'Lisa', 'Daniel', 'Nancy', 'Matthew', 'Betty',
+  'Anthony', 'Margaret', 'Mark', 'Sandra', 'Steven', 'Dorothy', 'Paul', 'Kimberly',
+  'Andrew', 'Emily', 'Kenneth', 'Donna', 'Brian', 'Amanda', 'George', 'Melissa',
+];
+
+const LAST_NAMES = [
+  'Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Garcia', 'Miller', 'Davis',
+  'Rodriguez', 'Martinez', 'Hernandez', 'Lopez', 'Gonzalez', 'Wilson', 'Anderson',
+  'Thomas', 'Taylor', 'Moore', 'Jackson', 'Martin', 'Lee', 'Thompson', 'White',
+  'Harris', 'Sanchez', 'Clark', 'Lewis', 'Robinson', 'Walker', 'Perez',
+];
+
+const SF_ADDRESSES = [
+  { addressLine1: '850 Bryant St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
+  { addressLine1: '6th St & Howard St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
+  { addressLine1: '7th St & Market St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+  { addressLine1: 'Civic Center Plaza', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+  { addressLine1: 'UN Plaza', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+  { addressLine1: '16th St & Mission St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
+  { addressLine1: '100 Larkin St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+  { addressLine1: 'Market St & 5th St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
+  { addressLine1: '200 McAllister St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+  { addressLine1: 'Turk St & Hyde St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+];
+
+const BEHAVIORS = [
+  'Cooperative', 'Cooperative', 'Cooperative',
+  'Lethargic, slurred speech',
+  'Agitated but manageable',
+  'Unresponsive, breathing',
+  'Confused, disoriented',
+  'Verbally combative',
+];
+
+// ─── Scenario factory helpers ─────────────────────────────────────────────────
+
+function makeSubject () {
+  return {
+    firstName: pick(FIRST_NAMES),
+    lastName: pick(LAST_NAMES),
+    dateOfBirth: new Date(
+      `${randInt(1960, 2000)}-${String(randInt(1, 12)).padStart(2, '0')}-${String(randInt(1, 28)).padStart(2, '0')}`
+    ),
+    sex: weightedPick([{ v: 'MALE', w: 65 }, { v: 'FEMALE', w: 25 }, { v: 'OTHER', w: 10 }]),
+    race: weightedPick([
+      { v: 'WHITE', w: 30 }, { v: 'BLACK', w: 25 }, { v: 'HISPANIC', w: 25 },
+      { v: 'ASIAN', w: 10 }, { v: 'OTHER', w: 10 },
+    ]),
+  };
+}
+
+function makeIncidentData (facilityId, fieldUser, baseTime, arrivedAt, leftAt, completedAt, idx) {
+  const addr = pick(SF_ADDRESSES);
+  return {
+    facilityId,
+    ...addr,
+    encounteredVia: weightedPick([{ v: 'ON_VIEW', w: 60 }, { v: 'DISPATCHED', w: 40 }]),
+    cadNumber: Math.random() > 0.3 ? `26-${String(10000 + idx).slice(1)}` : null,
+    caseNumber: Math.random() > 0.5 ? `SF-2025-${String(50000 + idx).slice(1)}` : null,
+    supervisorBadgeNumber: Math.random() > 0.4 ? String(1000 + randInt(0, 8999)) : null,
+    createdByBadgeNumber: String(1000 + randInt(0, 8999)),
+    arrivedAt: arrivedAt ?? null,
+    leftAt: leftAt ?? null,
+    completedAt: completedAt ?? null,
+    createdById: fieldUser.id,
+    createdByOrganizationId: fieldUser.organizationId,
+    updatedById: fieldUser.id,
+    createdAt: baseTime,
+  };
+}
+
+function makeDeflectionBase (facilityId, bedTypeId, fieldUser, baseTime) {
+  const hasDrug = Math.random() > 0.4;
+  return {
+    facilityId,
+    bedTypeId,
+    createdById: fieldUser.id,
+    narcoticsSubstance: Math.random() > 0.5,
+    narcoticsParaphernalia: Math.random() > 0.7,
+    drugUseEvidence: hasDrug,
+    drugType: hasDrug ? weightedPick([
+      { v: 'CNS_DEPRESSANTS', w: 40 }, { v: 'CNS_STIMULANTS', w: 30 },
+      { v: 'NARCOTIC_ANALGESICS', w: 20 }, { v: 'HALLUCINOGENS', w: 5 },
+      { v: 'CANNABIS', w: 5 },
+    ]) : null,
+    behavior: pick(BEHAVIORS),
+    behaviorAdditions: Math.random() > 0.7 ? 'Difficulty maintaining balance' : null,
+    property: weightedPick([
+      { v: 'NONE', w: 40 }, { v: 'SMALL', w: 35 },
+      { v: 'MEDIUM', w: 20 }, { v: 'LARGE', w: 5 },
+    ]),
+    expiresAt: addHrs(baseTime, 1),
+    status: 'ACTIVE',
+    subjectStatus: 'DETAINED',
+    createdAt: baseTime,
+  };
+}
+
+// Returns transfer fields only — subjectStatus must be set explicitly by each caller
+function transferData (custodyUser, sfsoUnit, t) {
+  return {
+    transferredAt: t,
+    transferredById: custodyUser.id,
+    transferredByBadgeNumber: String(5000 + randInt(0, 3999)),
+    transferredByProp115Certified: Math.random() > 0.1,
+    transferredByOrganizationId: custodyUser.organizationId,
+    transferredByUnitId: sfsoUnit?.id ?? null,
+    transferredByTitleId: 'deputy',
+  };
+}
+
+function exitData (careUser, exitDestId, housingStatusId, t) {
+  return {
+    exitedAt: t,
+    exitedById: careUser.id,
+    exitDestinationId: exitDestId,
+    exitHousingStatusId: housingStatusId,
+    exitConnectedToCare: weightedPick([
+      { v: 'YES', w: 30 }, { v: 'NO', w: 50 }, { v: 'UNKNOWN', w: 20 },
+    ]),
+    exitSFResident: weightedPick([
+      { v: 'YES', w: 55 }, { v: 'NO', w: 35 }, { v: 'UNKNOWN', w: 10 },
+    ]),
+    subjectStatus: 'EXITED',
+    status: 'COMPLETED',
+    completedAt: t,
+  };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+export default async function main (prisma) {
+  console.log('Seeding historical data...');
+
+  // ── Look up required references ──
+  const fieldUser = await prisma.user.findUnique({ where: { email: 'sfpd@careconnectsf.org' } });
+  const custodyUser = await prisma.user.findUnique({ where: { email: 'sfso@careconnectsf.org' } });
+  const careUser = await prisma.user.findUnique({ where: { email: 'care@careconnectsf.org' } });
+
+  if (!fieldUser || !custodyUser || !careUser) {
+    console.warn('Required test users not found; skipping historical data seed.');
+    return;
+  }
+
+  const facility = await prisma.facility.findUnique({ where: { subdomain: 'reset' } });
+  if (!facility) {
+    console.warn('RESET facility not found; skipping historical data seed.');
+    return;
+  }
+
+  const bedType = await prisma.bedType.findFirst({ where: { facilityId: facility.id } });
+  if (!bedType) {
+    console.warn('No bed type found for RESET; skipping historical data seed.');
+    return;
+  }
+
+  // Idempotency check
+  const sentinel = await prisma.incident.findFirst({
+    where: { cadNumber: 'HIST-SENTINEL' },
+  });
+  if (sentinel) {
+    console.log('Historical data already seeded; skipping.');
+    return;
+  }
+
+  // ── Look up lookup tables ──
+  const sfsoUnit = await prisma.unit.findFirst({ where: { organizationId: 'sfso' } });
+
+  const cancelReasons = await prisma.deflectionCancelReason.findMany();
+  const releaseReasonSobered = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'sobered' } });
+  const releaseReasonMedical = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'medical_issue' } });
+  const refusalReasonMedical = await prisma.deflectionRefusalReason.findUnique({ where: { id: 'medical_issue' } });
+  const refusalReasonAggressive = await prisma.deflectionRefusalReason.findUnique({ where: { id: 'aggressive_behavior' } });
+
+  const exitDestinations = await prisma.deflectionExitDestination.findMany();
+  const exitHousingStatuses = await prisma.deflectionExitHousingStatus.findMany();
+  const deflectionDetails = await prisma.deflectionDetail.findMany();
+
+  const exitDestStreet = exitDestinations.find(d => d.id === 'street');
+  const exitDestHome = exitDestinations.find(d => d.id === 'home');
+  const exitDestServices = exitDestinations.find(d => d.id === 'services_non_hospital');
+  const exitDestHospital = exitDestinations.find(d => d.id === 'hospital');
+  const exitDestDeclined = exitDestinations.find(d => d.id === 'declined_consent');
+
+  const commonExitDests = [exitDestStreet, exitDestHome, exitDestServices, exitDestDeclined].filter(Boolean);
+  const housingStatuses = exitHousingStatuses;
+
+  if (!releaseReasonSobered || cancelReasons.length === 0) {
+    console.warn('Missing reference data; skipping historical data seed.');
+    return;
+  }
+
+  // ── Build scenario list ──
+  // Each entry: { type, daysAgoMin, daysAgoMax }
+  const scenarios = [
+    // 22 full happy-path exits
+    ...Array.from({ length: 22 }, () => ({ type: 'full_exit', daysAgoMin: 3, daysAgoMax: 90 })),
+    // 7 cancelled before arrival
+    ...Array.from({ length: 7 }, () => ({ type: 'cancelled_early', daysAgoMin: 2, daysAgoMax: 90 })),
+    // 3 cancelled after transfer to custody
+    ...Array.from({ length: 3 }, () => ({ type: 'cancelled_after_transfer', daysAgoMin: 2, daysAgoMax: 80 })),
+    // 4 hospital direct exits
+    ...Array.from({ length: 4 }, () => ({ type: 'hospital_exit', daysAgoMin: 5, daysAgoMax: 85 })),
+    // 3 failed intake → released → exited
+    ...Array.from({ length: 3 }, () => ({ type: 'failed_intake', daysAgoMin: 5, daysAgoMax: 75 })),
+    // 2 medical release (auto-exits)
+    ...Array.from({ length: 2 }, () => ({ type: 'medical_release', daysAgoMin: 7, daysAgoMax: 60 })),
+    // 1 jail exit
+    { type: 'jail_exit', daysAgoMin: 10, daysAgoMax: 70 },
+    // 2 expired holds
+    ...Array.from({ length: 2 }, () => ({ type: 'expired', daysAgoMin: 2, daysAgoMax: 60 })),
+    // 1 death in custody
+    { type: 'death', daysAgoMin: 14, daysAgoMax: 90 },
+    // 5 in-progress (recent)
+    { type: 'in_progress_detained', daysAgoMin: 0, daysAgoMax: 0 },
+    { type: 'in_progress_onsite', daysAgoMin: 0, daysAgoMax: 0 },
+    { type: 'in_progress_awaiting', daysAgoMin: 0, daysAgoMax: 0 },
+    { type: 'in_progress_ready', daysAgoMin: 0, daysAgoMax: 0 },
+    { type: 'in_progress_chair', daysAgoMin: 0, daysAgoMax: 0 },
+  ];
+
+  let holdsAdded = 0;
+  let inTransitAdded = 0;
+  let occupiedAdded = 0;
+
+  for (let idx = 0; idx < scenarios.length; idx++) {
+    const { type, daysAgoMin, daysAgoMax } = scenarios[idx];
+
+    // Base time: when incident was created
+    let base;
+    if (daysAgoMin === 0) {
+      // In-progress: created within last 1-4 hours
+      base = addHrs(new Date(), -(1 + idx * 0.5));
+    } else {
+      base = randomPastTime(daysAgoMin, daysAgoMax);
+    }
+
+    // Shared timing deltas (realistic durations)
+    const arrivedDelta = randInt(5, 25);       // mins: creation → arrived
+    const transferDelta = randInt(5, 25);      // mins: arrived → transfer
+    const safetyCheckDelta = randInt(5, 20);   // mins: transfer → safety check
+    const admitDelta = randInt(5, 30);         // mins: safety check → admit
+    const intakeDelta = randInt(15, 60);       // mins: admit → intake complete
+    const inCustodyDuration = randInt(60, 480); // mins: intake → release
+    const exitDelta = randInt(15, 45);         // mins: release → exit
+
+    const tArrived = addMins(base, arrivedDelta);
+    const tTransfer = addMins(tArrived, transferDelta);
+    const tSafetyCheck = addMins(tTransfer, safetyCheckDelta);
+    const tAdmit = addMins(tSafetyCheck, admitDelta);
+    const tIntake = addMins(tAdmit, intakeDelta);
+    const tRelease = addMins(tIntake, inCustodyDuration);
+    const tExit = addMins(tRelease, exitDelta);
+
+    // Pick optional deflection detail
+    const detail = deflectionDetails.length > 0 && Math.random() > 0.5
+      ? { connect: { id: pick(deflectionDetails).id } }
+      : undefined;
+
+    // ── Create subject (most scenarios) ──
+    let subject = null;
+    if (type !== 'expired') {
+      subject = await prisma.subject.create({ data: makeSubject() });
+    }
+
+    // ── Sentinel gets special cadNumber on first scenario ──
+    const isSentinel = idx === 0;
+
+    // ── Build per-type incident + deflection ──
+
+    if (type === 'full_exit') {
+      const incident = await prisma.incident.create({
+        data: {
+          ...makeIncidentData(facility.id, fieldUser, base, tArrived, tExit, tExit, idx),
+          ...(isSentinel ? { cadNumber: 'HIST-SENTINEL' } : {}),
+        },
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          status: 'COMPLETED',
+          completedAt: tExit,
+          admittedAt: tAdmit,
+          admittedById: careUser.id,
+          releasedAt: tRelease,
+          releasedById: custodyUser.id,
+          releaseReasonId: releaseReasonSobered.id,
+          ...exitData(careUser, pick(commonExitDests)?.id ?? 'street', pick(housingStatuses)?.id ?? 'unknown', tExit),
+          ...(detail ? { deflectionDetails: detail } : {}),
+        },
+      });
+    }
+
+    else if (type === 'cancelled_early') {
+      const tCancel = addMins(base, randInt(5, 60));
+      const cancelReason = pick(cancelReasons);
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, null, null, tCancel, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          subjectStatus: 'DETAINED',
+          status: 'CANCELLED',
+          cancelReasonId: cancelReason.id,
+          cancelledAt: tCancel,
+          cancelledById: fieldUser.id,
+        },
+      });
+    }
+
+    else if (type === 'cancelled_after_transfer') {
+      const tCancel = addMins(tTransfer, randInt(10, 90));
+      const cancelReason = pick(cancelReasons);
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, null, tCancel, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'AWAITING_INTAKE',
+          status: 'CANCELLED',
+          cancelReasonId: cancelReason.id,
+          cancelledAt: tCancel,
+          cancelledById: custodyUser.id,
+          completedAt: tCancel,
+        },
+      });
+    }
+
+    else if (type === 'hospital_exit') {
+      const refusal = refusalReasonMedical ?? refusalReasonAggressive;
+      const tHospital = addMins(tSafetyCheck, randInt(5, 30));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tHospital, tHospital, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          status: 'COMPLETED',
+          refusalReasonId: refusal?.id ?? null,
+          exitedAt: tHospital,
+          exitedById: custodyUser.id,
+          completedAt: tHospital,
+        },
+      });
+    }
+
+    else if (type === 'failed_intake') {
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tExit, tExit, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          status: 'COMPLETED',
+          admittedAt: tAdmit,
+          admittedById: careUser.id,
+          rejectedAt: tIntake,
+          rejectedById: careUser.id,
+          releasedAt: tRelease,
+          releasedById: custodyUser.id,
+          releaseReasonId: releaseReasonSobered.id,
+          ...exitData(careUser, pick(commonExitDests)?.id ?? 'street', pick(housingStatuses)?.id ?? 'unknown', tExit),
+        },
+      });
+    }
+
+    else if (type === 'medical_release') {
+      // Medical release auto-exits immediately (no explicit exit step needed)
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tRelease, tRelease, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          status: 'COMPLETED',
+          admittedAt: tAdmit,
+          admittedById: careUser.id,
+          releasedAt: tRelease,
+          releasedById: custodyUser.id,
+          releaseReasonId: releaseReasonMedical?.id ?? releaseReasonSobered.id,
+          exitedAt: tRelease,
+          exitedById: custodyUser.id,
+          exitDestinationId: exitDestHospital?.id ?? null,
+          completedAt: tRelease,
+        },
+      });
+    }
+
+    else if (type === 'jail_exit') {
+      const refusal = refusalReasonAggressive ?? refusalReasonMedical;
+      const tJail = addMins(tTransfer, randInt(15, 60));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tJail, tJail, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          status: 'COMPLETED',
+          refusalReasonId: refusal?.id ?? null,
+          exitedAt: tJail,
+          exitedById: custodyUser.id,
+          completedAt: tJail,
+        },
+      });
+    }
+
+    else if (type === 'expired') {
+      // Hold created but no follow-up; expired after 1 hour
+      const tExpiry = addHrs(base, 1);
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, null, null, null, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: null,
+          expiresAt: tExpiry,
+          subjectStatus: 'DETAINED',
+          status: 'EXPIRED',
+        },
+      });
+    }
+
+    else if (type === 'death') {
+      const tDeath = addMins(tIntake, randInt(30, 180));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tDeath, tDeath, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'DEATH_IN_CUSTODY',
+          status: 'COMPLETED',
+          admittedAt: tAdmit,
+          admittedById: careUser.id,
+          completedAt: tDeath,
+        },
+      });
+    }
+
+    // ── In-progress scenarios ──
+
+    else if (type === 'in_progress_detained') {
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, null, null, null, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          subjectStatus: 'DETAINED',
+          status: 'ACTIVE',
+        },
+      });
+      holdsAdded++;
+      inTransitAdded++;
+    }
+
+    else if (type === 'in_progress_onsite') {
+      const tOnsite = addMins(base, randInt(10, 20));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          subjectStatus: 'ONSITE_AWAITING_TRANSFER',
+          status: 'ACTIVE',
+        },
+      });
+      holdsAdded++;
+      inTransitAdded++;
+    }
+
+    else if (type === 'in_progress_awaiting') {
+      const tOnsite = addMins(base, randInt(5, 15));
+      const tTrans = addMins(tOnsite, randInt(5, 15));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTrans),
+          subjectStatus: 'AWAITING_INTAKE',
+        },
+      });
+      holdsAdded++;
+    }
+
+    else if (type === 'in_progress_ready') {
+      const tOnsite = addMins(base, randInt(5, 15));
+      const tTrans = addMins(tOnsite, randInt(5, 15));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTrans),
+          subjectStatus: 'READY_FOR_INTAKE',
+        },
+      });
+      holdsAdded++;
+    }
+
+    else if (type === 'in_progress_chair') {
+      const tOnsite = addMins(base, randInt(5, 15));
+      const tTrans = addMins(tOnsite, randInt(5, 15));
+      const tAdm = addMins(tTrans, randInt(10, 35));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
+      });
+      await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTrans),
+          subjectStatus: 'IN_CHAIR',
+          admittedAt: tAdm,
+          admittedById: careUser.id,
+        },
+      });
+      occupiedAdded++;
+    }
+
+    console.log(`  [${idx + 1}/50] ${type}`);
+  }
+
+  // ── Update bedType capacity to reflect active in-progress holds ──
+  if (holdsAdded > 0 || occupiedAdded > 0 || inTransitAdded > 0) {
+    await prisma.bedType.update({
+      where: { id: bedType.id },
+      data: {
+        holds: { increment: holdsAdded },
+        inTransit: { increment: inTransitAdded },
+        occupied: { increment: occupiedAdded },
+        available: { decrement: holdsAdded + occupiedAdded },
+      },
+    });
+  }
+
+  console.log(`Done! Seeded 50 historical scenarios (holds +${holdsAdded}, inTransit +${inTransitAdded}, occupied +${occupiedAdded}).`);
+}

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -361,6 +361,7 @@ export default async function main (prisma) {
   let holdsAdded = 0;
   let inTransitAdded = 0;
   let occupiedAdded = 0;
+  let inProgressIdx = 0;
 
   for (let idx = 0; idx < scenarios.length; idx++) {
     const { type, daysAgoMin, daysAgoMax } = scenarios[idx];
@@ -370,7 +371,8 @@ export default async function main (prisma) {
     const isInProgress = type.startsWith('in_progress_');
     if (isInProgress) {
       // In-progress: created within last 1-4 hours, spaced to avoid overlap
-      base = addHrs(new Date(), -(1 + idx * 0.5));
+      base = addHrs(new Date(), -(1 + inProgressIdx * 0.5));
+      inProgressIdx++;
     } else {
       base = randomPastTime(daysAgoMin, daysAgoMax);
     }

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -955,7 +955,7 @@ export default async function main (prisma) {
         admittedAt: tAdmit,
         admittedById: careUser.id,
         exitedAt: tExit,
-        exitedById: careUser.id,
+        exitedById: isJailExit ? custodyUser.id : careUser.id,
         ...(isJailExit
           ? {
               refusalReasonId: refusalReason?.id ?? null,

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -1,16 +1,31 @@
-// Generates 50 synthetic scenarios (45 historical + 5 in-progress) for dashboard testing.
+// Generates synthetic scenarios (historical + in-progress) for dashboard testing.
 // Idempotent: skips if sentinel cadNumber already exists.
+// Deterministic: uses a seeded PRNG so all developers see the same data.
+
+// ─── Seeded PRNG (mulberry32) ─────────────────────────────────────────────────
+
+function mulberry32 (seed) {
+  return function () {
+    seed |= 0;
+    seed = seed + 0x6d2b79f5 | 0;
+    let t = Math.imul(seed ^ seed >>> 15, 1 | seed);
+    t = t + Math.imul(t ^ t >>> 7, 61 | t) ^ t;
+    return ((t ^ t >>> 14) >>> 0) / 4294967296;
+  };
+}
+
+// Module-level RNG seeded to a fixed value for full determinism
+const rng = mulberry32(0xdeadbeef);
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function addMins (date, m) { return new Date(date.getTime() + m * 60_000); }
 function addHrs (date, h) { return new Date(date.getTime() + h * 3_600_000); }
-function addDays (date, d) { return new Date(date.getTime() + d * 86_400_000); }
-function randInt (min, max) { return Math.floor(Math.random() * (max - min + 1)) + min; }
-function pick (arr) { return arr[Math.floor(Math.random() * arr.length)]; }
+function randInt (min, max) { return Math.floor(rng() * (max - min + 1)) + min; }
+function pick (arr) { return arr[Math.floor(rng() * arr.length)]; }
 function weightedPick (items) {
   const total = items.reduce((s, i) => s + i.w, 0);
-  let r = Math.random() * total;
+  let r = rng() * total;
   for (const item of items) { r -= item.w; if (r <= 0) return item.v; }
   return items.at(-1).v;
 }
@@ -42,17 +57,20 @@ const LAST_NAMES = [
 ];
 
 const SF_ADDRESSES = [
-  { addressLine1: '850 Bryant St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
-  { addressLine1: '6th St & Howard St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
-  { addressLine1: '7th St & Market St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
-  { addressLine1: 'Civic Center Plaza', city: 'San Francisco', state: 'CA', postalCode: '94102' },
-  { addressLine1: 'UN Plaza', city: 'San Francisco', state: 'CA', postalCode: '94102' },
-  { addressLine1: '16th St & Mission St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
-  { addressLine1: '100 Larkin St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
-  { addressLine1: 'Market St & 5th St', city: 'San Francisco', state: 'CA', postalCode: '94103' },
-  { addressLine1: '200 McAllister St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
-  { addressLine1: 'Turk St & Hyde St', city: 'San Francisco', state: 'CA', postalCode: '94102' },
+  { addressLine1: '850 Bryant St', city: 'San Francisco', state: 'CA', postalCode: '94103', latitude: 37.775840, longitude: -122.403370 },
+  { addressLine1: '6th St & Howard St', city: 'San Francisco', state: 'CA', postalCode: '94103', latitude: 37.778140, longitude: -122.407360 },
+  { addressLine1: '7th St & Market St', city: 'San Francisco', state: 'CA', postalCode: '94102', latitude: 37.779820, longitude: -122.411800 },
+  { addressLine1: 'Civic Center Plaza', city: 'San Francisco', state: 'CA', postalCode: '94102', latitude: 37.779280, longitude: -122.418540 },
+  { addressLine1: 'UN Plaza', city: 'San Francisco', state: 'CA', postalCode: '94102', latitude: 37.779950, longitude: -122.414070 },
+  { addressLine1: '16th St & Mission St', city: 'San Francisco', state: 'CA', postalCode: '94103', latitude: 37.764650, longitude: -122.419740 },
+  { addressLine1: '100 Larkin St', city: 'San Francisco', state: 'CA', postalCode: '94102', latitude: 37.779060, longitude: -122.415770 },
+  { addressLine1: 'Market St & 5th St', city: 'San Francisco', state: 'CA', postalCode: '94103', latitude: 37.783680, longitude: -122.407520 },
+  { addressLine1: '200 McAllister St', city: 'San Francisco', state: 'CA', postalCode: '94102', latitude: 37.780170, longitude: -122.416910 },
+  { addressLine1: 'Turk St & Hyde St', city: 'San Francisco', state: 'CA', postalCode: '94102', latitude: 37.782590, longitude: -122.416080 },
 ];
+
+// Counter for SF# local IDs — deterministically incremented per subject created
+let localIdCounter = 10001;
 
 const BEHAVIORS = [
   'Cooperative', 'Cooperative', 'Cooperative',
@@ -77,6 +95,7 @@ function makeSubject () {
       { v: 'WHITE', w: 30 }, { v: 'BLACK', w: 25 }, { v: 'HISPANIC', w: 25 },
       { v: 'ASIAN', w: 10 }, { v: 'OTHER', w: 7 }, { v: 'UNKNOWN', w: 3 },
     ]),
+    localId: `SF-${localIdCounter++}`,
   };
 }
 
@@ -85,6 +104,8 @@ function makeIncidentData (facilityId, fieldUser, baseTime, arrivedAt, leftAt, c
   return {
     facilityId,
     ...addr,
+    latitude: addr.latitude,
+    longitude: addr.longitude,
     arrestedAt: addMins(baseTime, -randInt(1, 20)),
     encounteredVia: weightedPick([{ v: 'ON_VIEW', w: 60 }, { v: 'DISPATCHED', w: 40 }]),
     cadNumber: `26-${String(10000 + idx).slice(1)}`,
@@ -102,21 +123,23 @@ function makeIncidentData (facilityId, fieldUser, baseTime, arrivedAt, leftAt, c
 }
 
 function makeDeflectionBase (facilityId, bedTypeId, fieldUser, baseTime) {
-  const hasDrug = Math.random() > 0.4;
+  const hasDrug = rng() > 0.4;
   return {
     facilityId,
     bedTypeId,
     createdById: fieldUser.id,
-    narcoticsSubstance: Math.random() > 0.5,
-    narcoticsParaphernalia: Math.random() > 0.7,
+    narcoticsSubstance: rng() > 0.5,
+    narcoticsParaphernalia: rng() > 0.7,
     drugUseEvidence: hasDrug,
-    drugType: hasDrug ? weightedPick([
-      { v: 'CNS_DEPRESSANTS', w: 40 }, { v: 'CNS_STIMULANTS', w: 30 },
-      { v: 'NARCOTIC_ANALGESICS', w: 20 }, { v: 'HALLUCINOGENS', w: 5 },
-      { v: 'CANNABIS', w: 5 },
-    ]) : null,
+    drugType: hasDrug
+      ? weightedPick([
+        { v: 'CNS_DEPRESSANTS', w: 40 }, { v: 'CNS_STIMULANTS', w: 30 },
+        { v: 'NARCOTIC_ANALGESICS', w: 20 }, { v: 'HALLUCINOGENS', w: 5 },
+        { v: 'CANNABIS', w: 5 },
+      ])
+      : null,
     behavior: pick(BEHAVIORS),
-    behaviorAdditions: Math.random() > 0.7 ? 'Difficulty maintaining balance' : null,
+    behaviorAdditions: rng() > 0.7 ? 'Difficulty maintaining balance' : null,
     property: weightedPick([
       { v: 'NONE', w: 40 }, { v: 'SMALL', w: 35 },
       { v: 'MEDIUM', w: 20 }, { v: 'LARGE', w: 5 },
@@ -135,7 +158,7 @@ function transferData (custodyUser, sfsoUnit, t) {
     transferredAt: t,
     transferredById: custodyUser.id,
     transferredByBadgeNumber: String(5000 + randInt(0, 3999)),
-    transferredByProp115Certified: Math.random() > 0.1,
+    transferredByProp115Certified: rng() > 0.1,
     transferredByOrganizationId: custodyUser.organizationId,
     transferredByUnitId: sfsoUnit?.id ?? null,
     transferredByTitleId: 'deputy',
@@ -189,6 +212,26 @@ async function createIncidentOfficer (prisma, {
   });
 }
 
+// Creates DeflectionUpdate audit rows for each state transition in a scenario.
+// Each entry in `steps` is { subjectStatus?, status?, releaseReasonId?, refusalReasonId?,
+//   exitDestinationId?, exitHousingStatusId?, exitConnectedToCare?, exitSFResident?,
+//   cancelReasonId?, updatedAt, updatedById }
+async function createDeflectionUpdates (prisma, deflectionId, steps) {
+  for (const step of steps) {
+    const data = { deflectionId, updatedAt: step.updatedAt, updatedById: step.updatedById };
+    if (step.subjectStatus != null) data.subjectStatus = step.subjectStatus;
+    if (step.status != null) data.status = step.status;
+    if (step.releaseReasonId != null) data.releaseReasonId = step.releaseReasonId;
+    if (step.refusalReasonId != null) data.refusalReasonId = step.refusalReasonId;
+    if (step.exitDestinationId != null) data.exitDestinationId = step.exitDestinationId;
+    if (step.exitHousingStatusId != null) data.exitHousingStatusId = step.exitHousingStatusId;
+    if (step.exitConnectedToCare != null) data.exitConnectedToCare = step.exitConnectedToCare;
+    if (step.exitSFResident != null) data.exitSFResident = step.exitSFResident;
+    if (step.cancelReasonId != null) data.cancelReasonId = step.cancelReasonId;
+    await prisma.deflectionUpdate.create({ data });
+  }
+}
+
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
 export default async function main (prisma) {
@@ -232,8 +275,11 @@ export default async function main (prisma) {
   const cancelReasons = await prisma.deflectionCancelReason.findMany();
   const releaseReasonSobered = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'sobered' } });
   const releaseReasonMedical = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'medical_issue' } });
+  const releaseReasonOther = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'other' } });
   const releaseReasonDeathCustody = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'death_in_custody' } });
+  const releaseReasonDeathFacility = await prisma.deflectionReleaseReason.findUnique({ where: { id: 'death_in_facility' } });
   const refusalReasonMedical = await prisma.deflectionRefusalReason.findUnique({ where: { id: 'medical_issue' } });
+  const refusalReasonAggressive = await prisma.deflectionRefusalReason.findUnique({ where: { id: 'aggressive_behavior' } });
 
   const exitDestinations = await prisma.deflectionExitDestination.findMany();
   const exitHousingStatuses = await prisma.deflectionExitHousingStatus.findMany();
@@ -244,13 +290,35 @@ export default async function main (prisma) {
   const exitDestServices = exitDestinations.find(d => d.id === 'services_non_hospital');
   const exitDestHospital = exitDestinations.find(d => d.id === 'hospital');
   const exitDestDeclined = exitDestinations.find(d => d.id === 'declined_consent');
+  const exitDestJail = exitDestinations.find(d => d.id === 'jail');
+  const exitDestOther = exitDestinations.find(d => d.id === 'other');
 
-  const commonExitDests = [exitDestStreet, exitDestHome, exitDestServices, exitDestDeclined].filter(Boolean);
+  const housingStatusPermanent = exitHousingStatuses.find(s => s.id === 'permanent');
+  const housingStatusSheltered = exitHousingStatuses.find(s => s.id === 'sheltered');
+  const housingStatusTemporary = exitHousingStatuses.find(s => s.id === 'temporary');
+  const housingStatusUnknown = exitHousingStatuses.find(s => s.id === 'unknown');
+  const housingStatusDeclined = exitHousingStatuses.find(s => s.id === 'declined_consent');
+
+  // All full-spectrum exit dests and housing statuses for varied coverage
+  const allExitDests = [
+    exitDestStreet, exitDestHome, exitDestServices, exitDestDeclined, exitDestOther,
+  ].filter(Boolean);
+  const allHousingStatuses = [
+    housingStatusPermanent, housingStatusSheltered, housingStatusTemporary,
+    housingStatusUnknown, housingStatusDeclined,
+  ].filter(Boolean);
   const housingStatuses = exitHousingStatuses;
+  const commonExitDests = [exitDestStreet, exitDestHome, exitDestServices, exitDestDeclined].filter(Boolean);
 
   if (!releaseReasonSobered || cancelReasons.length === 0) {
     console.warn('Missing reference data; skipping historical data seed.');
     return;
+  }
+
+  // ── Create repeat-encounter subjects (5 subjects who appear multiple times) ──
+  const repeatSubjects = [];
+  for (let i = 0; i < 5; i++) {
+    repeatSubjects.push(await prisma.subject.create({ data: makeSubject() }));
   }
 
   // ── Build scenario list ──
@@ -270,12 +338,18 @@ export default async function main (prisma) {
     ...Array.from({ length: 3 }, () => ({ type: 'failed_intake', daysAgoMin: 5, daysAgoMax: 75 })),
     // 2 medical release (auto-exits)
     ...Array.from({ length: 2 }, () => ({ type: 'medical_release', daysAgoMin: 7, daysAgoMax: 60 })),
-    // 1 jail exit
+    // 1 jail exit (aggressive_behavior refusal)
     { type: 'jail_exit', daysAgoMin: 10, daysAgoMax: 70 },
+    // 1 jail exit with medical_issue refusal
+    { type: 'jail_exit_medical', daysAgoMin: 8, daysAgoMax: 65 },
     // 2 expired holds
     ...Array.from({ length: 2 }, () => ({ type: 'expired', daysAgoMin: 2, daysAgoMax: 60 })),
     // 1 death in custody
-    { type: 'death', daysAgoMin: 14, daysAgoMax: 90 },
+    { type: 'death_in_custody', daysAgoMin: 14, daysAgoMax: 90 },
+    // 1 death in facility (released → record-death)
+    { type: 'death_in_facility', daysAgoMin: 14, daysAgoMax: 90 },
+    // 60 recent exits spread across last 7 days (exitedAt + releasedAt filled)
+    ...Array.from({ length: 60 }, (_, i) => ({ type: 'recent_exit', daysAgoMin: 0, daysAgoMax: 7, recentIdx: i })),
     // 5 in-progress (recent)
     { type: 'in_progress_detained', daysAgoMin: 0, daysAgoMax: 0 },
     { type: 'in_progress_onsite', daysAgoMin: 0, daysAgoMax: 0 },
@@ -293,8 +367,9 @@ export default async function main (prisma) {
 
     // Base time: when incident was created
     let base;
-    if (daysAgoMin === 0) {
-      // In-progress: created within last 1-4 hours
+    const isInProgress = type.startsWith('in_progress_');
+    if (isInProgress) {
+      // In-progress: created within last 1-4 hours, spaced to avoid overlap
       base = addHrs(new Date(), -(1 + idx * 0.5));
     } else {
       base = randomPastTime(daysAgoMin, daysAgoMax);
@@ -318,14 +393,15 @@ export default async function main (prisma) {
     const tExit = addMins(tRelease, exitDelta);
 
     // Pick optional deflection detail
-    const detail = deflectionDetails.length > 0 && Math.random() > 0.5
+    const detail = deflectionDetails.length > 0 && rng() > 0.5
       ? { connect: { id: pick(deflectionDetails).id } }
       : undefined;
 
-    // ── Create subject (most scenarios) ──
+    // ── Create subject (most scenarios); ~30% of historical scenarios reuse a repeat subject ──
     let subject = null;
     if (type !== 'expired') {
-      subject = await prisma.subject.create({ data: makeSubject() });
+      const useRepeat = rng() < 0.3 && repeatSubjects.length > 0;
+      subject = useRepeat ? pick(repeatSubjects) : await prisma.subject.create({ data: makeSubject() });
     }
 
     // ── Sentinel gets special cadNumber on first scenario ──
@@ -334,6 +410,9 @@ export default async function main (prisma) {
     // ── Build per-type incident + deflection ──
 
     if (type === 'full_exit') {
+      const exitDest = pick(allExitDests) ?? exitDestStreet;
+      const housingStatus = pick(allHousingStatuses) ?? housingStatusUnknown;
+      const exitFields = exitData(careUser, exitDest?.id ?? 'street', housingStatus?.id ?? 'unknown', tExit);
       const incident = await prisma.incident.create({
         data: {
           ...makeIncidentData(facility.id, fieldUser, base, tArrived, tExit, tExit, idx),
@@ -348,7 +427,7 @@ export default async function main (prisma) {
         arrivedAt: tArrived,
         leftAt: tExit,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -360,13 +439,31 @@ export default async function main (prisma) {
           releasedAt: tRelease,
           releasedById: custodyUser.id,
           releaseReasonId: releaseReasonSobered.id,
-          ...exitData(careUser, pick(commonExitDests)?.id ?? 'street', pick(housingStatuses)?.id ?? 'unknown', tExit),
+          ...exitFields,
           ...(detail ? { deflectionDetails: detail } : {}),
         },
       });
-    }
-
-    else if (type === 'handoff_full_exit') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+        { subjectStatus: 'RELEASED', releaseReasonId: releaseReasonSobered.id, updatedAt: tRelease, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'EXITED',
+          exitDestinationId: exitDest?.id,
+          exitHousingStatusId: housingStatus?.id,
+          exitConnectedToCare: exitFields.exitConnectedToCare,
+          exitSFResident: exitFields.exitSFResident,
+          updatedAt: tExit,
+          updatedById: careUser.id
+        },
+      ]);
+    } else if (type === 'handoff_full_exit') {
+      const exitDest = pick(allExitDests) ?? exitDestStreet;
+      const housingStatus = pick(allHousingStatuses) ?? housingStatusUnknown;
+      const exitFields = exitData(careUser, exitDest?.id ?? 'street', housingStatus?.id ?? 'unknown', tExit);
       const tHandoff = addMins(base, randInt(10, Math.max(11, arrivedDelta - 1)));
       const incident = await prisma.incident.create({
         data: {
@@ -390,7 +487,7 @@ export default async function main (prisma) {
         handoffReceivedAt: tHandoff,
         handoffReceivedFromId: fieldUser.id,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -403,10 +500,27 @@ export default async function main (prisma) {
           releasedAt: tRelease,
           releasedById: custodyUser.id,
           releaseReasonId: releaseReasonSobered.id,
-          ...exitData(careUser, pick(commonExitDests)?.id ?? 'street', pick(housingStatuses)?.id ?? 'unknown', tExit),
+          ...exitFields,
           ...(detail ? { deflectionDetails: detail } : {}),
         },
       });
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser2.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+        { subjectStatus: 'RELEASED', releaseReasonId: releaseReasonSobered.id, updatedAt: tRelease, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'EXITED',
+          exitDestinationId: exitDest?.id,
+          exitHousingStatusId: housingStatus?.id,
+          exitConnectedToCare: exitFields.exitConnectedToCare,
+          exitSFResident: exitFields.exitSFResident,
+          updatedAt: tExit,
+          updatedById: careUser.id
+        },
+      ]);
       await prisma.incident.update({
         where: { id: incident.id },
         data: {
@@ -415,9 +529,7 @@ export default async function main (prisma) {
           completedAt: tExit,
         },
       });
-    }
-
-    else if (type === 'cancelled_early') {
+    } else if (type === 'cancelled_early') {
       const tCancel = addMins(base, randInt(5, 60));
       const cancelReason = pick(cancelReasons);
       const incident = await prisma.incident.create({
@@ -429,7 +541,7 @@ export default async function main (prisma) {
         officer: fieldUser,
         role: 'ARRESTING',
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -441,9 +553,10 @@ export default async function main (prisma) {
           cancelledById: fieldUser.id,
         },
       });
-    }
-
-    else if (type === 'cancelled_after_transfer') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { status: 'CANCELLED', cancelReasonId: cancelReason.id, updatedAt: tCancel, updatedById: fieldUser.id },
+      ]);
+    } else if (type === 'cancelled_after_transfer') {
       const tCancel = addMins(tTransfer, randInt(10, 90));
       const cancelReason = pick(cancelReasons);
       const incident = await prisma.incident.create({
@@ -456,7 +569,7 @@ export default async function main (prisma) {
         role: 'ARRESTING',
         arrivedAt: tArrived,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -469,9 +582,12 @@ export default async function main (prisma) {
           cancelledById: custodyUser.id,
         },
       });
-    }
-
-    else if (type === 'hospital_exit') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { status: 'CANCELLED', cancelReasonId: cancelReason.id, updatedAt: tCancel, updatedById: custodyUser.id },
+      ]);
+    } else if (type === 'hospital_exit') {
       const tHospital = addMins(tSafetyCheck, randInt(5, 30));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tHospital, tHospital, idx),
@@ -484,7 +600,7 @@ export default async function main (prisma) {
         arrivedAt: tArrived,
         leftAt: tHospital,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -499,9 +615,22 @@ export default async function main (prisma) {
           exitDestinationId: exitDestHospital?.id ?? null,
         },
       });
-    }
-
-    else if (type === 'failed_intake') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'EXITED',
+          releaseReasonId: releaseReasonMedical?.id,
+          exitDestinationId: exitDestHospital?.id,
+          updatedAt: tHospital,
+          updatedById: custodyUser.id
+        },
+      ]);
+    } else if (type === 'failed_intake') {
+      const exitDest = pick(commonExitDests) ?? exitDestStreet;
+      const housingStatus = pick(housingStatuses) ?? housingStatusUnknown;
+      const exitFields = exitData(careUser, exitDest?.id ?? 'street', housingStatus?.id ?? 'unknown', tExit);
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tExit, tExit, idx),
       });
@@ -513,7 +642,7 @@ export default async function main (prisma) {
         arrivedAt: tArrived,
         leftAt: tExit,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -527,12 +656,27 @@ export default async function main (prisma) {
           releasedAt: tRelease,
           releasedById: custodyUser.id,
           releaseReasonId: releaseReasonSobered.id,
-          ...exitData(careUser, pick(commonExitDests)?.id ?? 'street', pick(housingStatuses)?.id ?? 'unknown', tExit),
+          ...exitFields,
         },
       });
-    }
-
-    else if (type === 'medical_release') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'FAILED_INTAKE', updatedAt: tIntake, updatedById: careUser.id },
+        { subjectStatus: 'RELEASED', releaseReasonId: releaseReasonSobered.id, updatedAt: tRelease, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'EXITED',
+          exitDestinationId: exitDest?.id,
+          exitHousingStatusId: housingStatus?.id,
+          exitConnectedToCare: exitFields.exitConnectedToCare,
+          exitSFResident: exitFields.exitSFResident,
+          updatedAt: tExit,
+          updatedById: careUser.id
+        },
+      ]);
+    } else if (type === 'medical_release') {
       // Medical release auto-exits immediately (no explicit exit step needed)
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tRelease, tRelease, idx),
@@ -545,7 +689,7 @@ export default async function main (prisma) {
         arrivedAt: tArrived,
         leftAt: tRelease,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -562,9 +706,22 @@ export default async function main (prisma) {
           exitDestinationId: exitDestHospital?.id ?? null,
         },
       });
-    }
-
-    else if (type === 'jail_exit') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+        {
+          subjectStatus: 'EXITED',
+          releaseReasonId: releaseReasonMedical?.id,
+          exitDestinationId: exitDestHospital?.id,
+          updatedAt: tRelease,
+          updatedById: custodyUser.id
+        },
+      ]);
+    } else if (type === 'jail_exit') {
+      // Aggressive behavior refusal reason → jail
       const tJail = addMins(tTransfer, randInt(15, 60));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tJail, tJail, idx),
@@ -577,7 +734,45 @@ export default async function main (prisma) {
         arrivedAt: tArrived,
         leftAt: tJail,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'EXITED',
+          refusalReasonId: refusalReasonAggressive?.id ?? null,
+          exitedAt: tJail,
+          exitedById: custodyUser.id,
+          exitDestinationId: exitDestJail?.id ?? 'jail',
+        },
+      });
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'EXITED',
+          refusalReasonId: refusalReasonAggressive?.id,
+          exitDestinationId: exitDestJail?.id,
+          updatedAt: tJail,
+          updatedById: custodyUser.id
+        },
+      ]);
+    } else if (type === 'jail_exit_medical') {
+      // Medical issue refusal reason → jail
+      const tJail = addMins(tTransfer, randInt(15, 60));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tJail, tJail, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tJail,
+      });
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -587,12 +782,21 @@ export default async function main (prisma) {
           refusalReasonId: refusalReasonMedical?.id ?? null,
           exitedAt: tJail,
           exitedById: custodyUser.id,
-          exitDestinationId: 'jail',
+          exitDestinationId: exitDestJail?.id ?? 'jail',
         },
       });
-    }
-
-    else if (type === 'expired') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'EXITED',
+          refusalReasonId: refusalReasonMedical?.id,
+          exitDestinationId: exitDestJail?.id,
+          updatedAt: tJail,
+          updatedById: custodyUser.id
+        },
+      ]);
+    } else if (type === 'expired') {
       // Hold created but no follow-up; expired after 1 hour
       const tExpiry = addHrs(base, 1);
       const incident = await prisma.incident.create({
@@ -604,7 +808,7 @@ export default async function main (prisma) {
         officer: fieldUser,
         role: 'ARRESTING',
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -614,9 +818,10 @@ export default async function main (prisma) {
           status: 'EXPIRED',
         },
       });
-    }
-
-    else if (type === 'death') {
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { status: 'EXPIRED', updatedAt: tExpiry, updatedById: fieldUser.id },
+      ]);
+    } else if (type === 'death_in_custody') {
       const tDeath = addMins(tIntake, randInt(30, 180));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tArrived, tDeath, tDeath, idx),
@@ -629,7 +834,7 @@ export default async function main (prisma) {
         arrivedAt: tArrived,
         leftAt: tDeath,
       });
-      await prisma.deflection.create({
+      const deflection = await prisma.deflection.create({
         data: {
           ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
           incidentId: incident.id,
@@ -641,11 +846,164 @@ export default async function main (prisma) {
           releaseReasonId: releaseReasonDeathCustody?.id ?? 'death_in_custody',
         },
       });
-    }
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+        {
+          subjectStatus: 'DEATH_IN_CUSTODY',
+          releaseReasonId: releaseReasonDeathCustody?.id,
+          updatedAt: tDeath,
+          updatedById: custodyUser.id
+        },
+      ]);
+    } else if (type === 'death_in_facility') {
+      // Subject released (sobered), then dies after release
+      const tDeath = addMins(tRelease, randInt(15, 90));
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tDeath, tDeath, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tDeath,
+      });
+      const deflection = await prisma.deflection.create({
+        data: {
+          ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+          incidentId: incident.id,
+          subjectId: subject.id,
+          ...transferData(custodyUser, sfsoUnit, tTransfer),
+          subjectStatus: 'DEATH_IN_FACILITY',
+          admittedAt: tAdmit,
+          admittedById: careUser.id,
+          releasedAt: tRelease,
+          releasedById: custodyUser.id,
+          releaseReasonId: releaseReasonDeathFacility?.id ?? 'death_in_facility',
+        },
+      });
+      await createDeflectionUpdates(prisma, deflection.id, [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+        { subjectStatus: 'RELEASED', releaseReasonId: releaseReasonSobered.id, updatedAt: tRelease, updatedById: custodyUser.id },
+        {
+          subjectStatus: 'DEATH_IN_FACILITY',
+          releaseReasonId: releaseReasonDeathFacility?.id,
+          updatedAt: tDeath,
+          updatedById: custodyUser.id
+        },
+      ]);
+    } else if (type === 'recent_exit') {
+      // 60 recent exits across last 7 days, cycling through all requested field combos
+      const { recentIdx } = scenarios[idx];
 
-    // ── In-progress scenarios ──
+      // Cycle through exit destinations: declined_consent, home, hospital, jail, other, services_non_hospital, street
+      const recentExitDestPool = [
+        exitDestDeclined, exitDestHome, exitDestHospital, exitDestJail,
+        exitDestOther, exitDestServices, exitDestStreet,
+      ].filter(Boolean);
+      const recentHousingPool = allHousingStatuses;
+      const recentExitDest = recentExitDestPool[recentIdx % recentExitDestPool.length];
+      const recentHousing = recentHousingPool[recentIdx % recentHousingPool.length];
 
-    else if (type === 'in_progress_detained') {
+      // Cycle through refusal reasons for some (aggressive_behavior, medical_issue, none)
+      const isJailExit = recentExitDest?.id === 'jail';
+      const refusalReason = isJailExit
+        ? (recentIdx % 2 === 0 ? refusalReasonAggressive : refusalReasonMedical)
+        : null;
+
+      // Vary release reason: sobered (~60%), medical_issue (~25%), other (~15%)
+      const releaseReasonCycle = [
+        releaseReasonSobered, releaseReasonSobered, releaseReasonSobered,
+        releaseReasonMedical, releaseReasonMedical,
+        releaseReasonOther,
+      ];
+      const recentReleaseReason = isJailExit
+        ? null
+        : (releaseReasonCycle[recentIdx % releaseReasonCycle.length] ?? releaseReasonSobered);
+
+      const exitFields = isJailExit ? null : exitData(careUser, recentExitDest?.id ?? 'street', recentHousing?.id ?? 'unknown', tExit);
+
+      const incident = await prisma.incident.create({
+        data: makeIncidentData(facility.id, fieldUser, base, tArrived, tExit, tExit, idx),
+      });
+      await createIncidentOfficer(prisma, {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        officer: fieldUser,
+        role: 'ARRESTING',
+        arrivedAt: tArrived,
+        leftAt: tExit,
+      });
+
+      const deflectionPayload = {
+        ...makeDeflectionBase(facility.id, bedType.id, fieldUser, base),
+        incidentId: incident.id,
+        subjectId: subject.id,
+        ...transferData(custodyUser, sfsoUnit, tTransfer),
+        subjectStatus: 'EXITED',
+        admittedAt: tAdmit,
+        admittedById: careUser.id,
+        exitedAt: tExit,
+        exitedById: careUser.id,
+        ...(isJailExit
+          ? {
+              refusalReasonId: refusalReason?.id ?? null,
+              exitDestinationId: recentExitDest?.id ?? 'jail',
+            }
+          : {
+              releasedAt: tRelease,
+              releasedById: custodyUser.id,
+              releaseReasonId: recentReleaseReason?.id,
+              ...exitFields,
+            }),
+      };
+
+      const deflection = await prisma.deflection.create({ data: deflectionPayload });
+
+      const updateSteps = [
+        { subjectStatus: 'ONSITE_AWAITING_TRANSFER', updatedAt: tArrived, updatedById: fieldUser.id },
+        { subjectStatus: 'AWAITING_INTAKE', updatedAt: tTransfer, updatedById: custodyUser.id },
+        { subjectStatus: 'READY_FOR_INTAKE', updatedAt: tSafetyCheck, updatedById: custodyUser.id },
+        { subjectStatus: 'ADMITTED', updatedAt: tAdmit, updatedById: careUser.id },
+        { subjectStatus: 'IN_CHAIR', updatedAt: tIntake, updatedById: careUser.id },
+      ];
+      if (isJailExit) {
+        updateSteps.push({
+          subjectStatus: 'EXITED',
+          refusalReasonId: refusalReason?.id,
+          exitDestinationId: recentExitDest?.id,
+          updatedAt: tExit,
+          updatedById: custodyUser.id
+        });
+      } else {
+        updateSteps.push({
+          subjectStatus: 'RELEASED',
+          releaseReasonId: recentReleaseReason?.id,
+          updatedAt: tRelease,
+          updatedById: custodyUser.id
+        });
+        updateSteps.push({
+          subjectStatus: 'EXITED',
+          exitDestinationId: recentExitDest?.id,
+          exitHousingStatusId: recentHousing?.id,
+          exitConnectedToCare: exitFields?.exitConnectedToCare,
+          exitSFResident: exitFields?.exitSFResident,
+          updatedAt: tExit,
+          updatedById: careUser.id
+        });
+      }
+      await createDeflectionUpdates(prisma, deflection.id, updateSteps);
+    } else if (type === 'in_progress_detained') {
+      // ── In-progress scenarios ──
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, null, null, null, idx),
       });
@@ -666,9 +1024,7 @@ export default async function main (prisma) {
       });
       holdsAdded++;
       inTransitAdded++;
-    }
-
-    else if (type === 'in_progress_onsite') {
+    } else if (type === 'in_progress_onsite') {
       const tOnsite = addMins(base, randInt(10, 20));
       const incident = await prisma.incident.create({
         data: makeIncidentData(facility.id, fieldUser, base, tOnsite, null, null, idx),
@@ -691,9 +1047,7 @@ export default async function main (prisma) {
       });
       holdsAdded++;
       inTransitAdded++;
-    }
-
-    else if (type === 'in_progress_awaiting') {
+    } else if (type === 'in_progress_awaiting') {
       const tOnsite = addMins(base, randInt(5, 15));
       const tTrans = addMins(tOnsite, randInt(5, 15));
       const incident = await prisma.incident.create({
@@ -716,9 +1070,7 @@ export default async function main (prisma) {
         },
       });
       holdsAdded++;
-    }
-
-    else if (type === 'in_progress_ready') {
+    } else if (type === 'in_progress_ready') {
       const tOnsite = addMins(base, randInt(5, 15));
       const tTrans = addMins(tOnsite, randInt(5, 15));
       const incident = await prisma.incident.create({
@@ -741,9 +1093,7 @@ export default async function main (prisma) {
         },
       });
       holdsAdded++;
-    }
-
-    else if (type === 'in_progress_chair') {
+    } else if (type === 'in_progress_chair') {
       const tOnsite = addMins(base, randInt(5, 15));
       const tTrans = addMins(tOnsite, randInt(5, 15));
       const tAdm = addMins(tTrans, randInt(10, 35));
@@ -771,7 +1121,7 @@ export default async function main (prisma) {
       occupiedAdded++;
     }
 
-    console.log(`  [${idx + 1}/50] ${type}`);
+    console.log(`  [${idx + 1}/${scenarios.length}] ${type}`);
   }
 
   // ── Update bedType capacity to reflect active in-progress holds ──
@@ -787,5 +1137,5 @@ export default async function main (prisma) {
     });
   }
 
-  console.log(`Done! Seeded 50 historical scenarios (holds +${holdsAdded}, inTransit +${inTransitAdded}, occupied +${occupiedAdded}).`);
+  console.log(`Done! Seeded ${scenarios.length} historical scenarios (holds +${holdsAdded}, inTransit +${inTransitAdded}, occupied +${occupiedAdded}).`);
 }


### PR DESCRIPTION
Note that I haven't tested this, as I don't have a good enough sense of how the incidents are supposed to flow through the system.  The scenarios are randomized from a stable seed, so everyone should get the same seeded records.

## Summary

- **[SYNTHETIC_DATA_GUIDELINES.md](cci:7://file:///C:/Projects/c4sf/CareConnect/care-connect/docs/SYNTHETIC_DATA_GUIDELINES.md:0:0-0:0)** — Documents the full state machines, field definitions, business rules, and temporal constraints for incidents, deflections, and related entities. Intended as a reference for generating synthetic test data and for building analytics on top of the system.

- **[server/prisma/seeds/historicalData.js](cci:7://file:///C:/Projects/c4sf/CareConnect/care-connect/server/prisma/seeds/historicalData.js:0:0-0:0)** — Generates 112 realistic scenarios against the RESET (LESC) facility, wired into the main [seed.js](cci:7://file:///C:/Projects/c4sf/CareConnect/care-connect/server/prisma/seed.js:0:0-0:0). Idempotent via a sentinel `cadNumber`. Fully deterministic via a seeded PRNG ([mulberry32](cci:1://file:///C:/Projects/c4sf/CareConnect/care-connect/server/prisma/seeds/historicalData.js:6:0-14:1)) so all developers see identical data.

## Seed scenario breakdown

| Type | Count | End state |
|---|---|---|
| Full happy path (sobered) | 22 | `EXITED` |
| Cancelled before arrival | 7 | `CANCELLED` |
| Cancelled after transfer | 3 | `CANCELLED` (from `AWAITING_INTAKE`) |
| Hospital exit | 4 | `EXITED` via hospital |
| Failed intake → released | 3 | `EXITED` via `FAILED_INTAKE` path |
| Medical release | 2 | `EXITED` (auto-exit on medical release) |
| Jail exit — aggressive behavior | 1 | `EXITED` via jail (`aggressive_behavior` refusal) |
| Jail exit — medical issue | 1 | `EXITED` via jail (`medical_issue` refusal) |
| Expired | 2 | `EXPIRED` |
| Death in custody | 1 | `DEATH_IN_CUSTODY` |
| Death in facility | 1 | `DEATH_IN_FACILITY` |
| Recent exits (last 7 days) | 60 | `EXITED` with `exitedAt` + `releasedAt` populated |
| **In-progress (active)** | **5** | One each at `DETAINED`, `ONSITE_AWAITING_TRANSFER`, `AWAITING_INTAKE`, `READY_FOR_INTAKE`, `IN_CHAIR` |

Past incidents are spread across 2–90 days ago at realistic hours. Recent exits are distributed across the last 7 days. Active in-progress incidents are within the last few hours. Bed type capacity counters (`holds`, `inTransit`, `occupied`, `available`) are updated atomically at the end to reflect only the active deflections.

## Additional data coverage

- **`DeflectionUpdate` audit trail** — Every scenario emits a full sequence of `DeflectionUpdate` rows for each state transition, including `IN_CHAIR` records (enabling admission counts for SFSO reporting).
- **Refusal reasons** — `aggressive_behavior` and `medical_issue` both represented.
- **Release reasons** — `sobered`, `medical_issue`, `other`, `death_in_custody`, `death_in_facility` all represented.
- **Exit destinations** — `declined_consent`, `home`, `hospital`, `jail`, `other`, `services_non_hospital`, `street` all represented.
- **Exit housing statuses** — `declined_consent`, `permanent`, `sheltered`, `temporary`, `unknown` all represented.
- **Repeat encounters** — 5 subjects are reused across ~30% of scenarios to simulate repeat arrivals/admissions.
- **Subject `localId`** — Every subject is assigned a deterministic `SF-#####` identifier.
- **Incident coordinates** — Every incident is assigned realistic `latitude`/`longitude` from a pool of SF locations.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sfbrigade/care-connect/pull/557" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
