### PR TITLE
Updated hold reasons on frontend and backend (#590)

### DIFF
--- a/client/src/lesc/components/Hold.stories.jsx
+++ b/client/src/lesc/components/Hold.stories.jsx
@@ -190,7 +190,7 @@ export const CancelledWithSomeDetails = {
       ...WithSomeSubjectDetails.args.deflection,
       status: 'CANCELLED',
       cancelledAt: new Date().toISOString(),
-      cancelReasonId: 'facility_emergency',
+      cancelReasonId: 'staffing_shortage',
     },
   }
 };

--- a/server/prisma/migrations/20260413173000_rename_facility_emergency_cancel_reason/migration.sql
+++ b/server/prisma/migrations/20260413173000_rename_facility_emergency_cancel_reason/migration.sql
@@ -1,0 +1,5 @@
+UPDATE "DeflectionCancelReason"
+SET
+  "id" = 'staffing_shortage',
+  "name" = 'Staffing shortage'
+WHERE "id" = 'facility_emergency';

--- a/server/prisma/seeds/deflectionCancelReasons.js
+++ b/server/prisma/seeds/deflectionCancelReasons.js
@@ -35,8 +35,8 @@ export default async function main (prisma) {
       updatedById: adminUser.id,
     },
     {
-      id: 'facility_emergency',
-      name: 'Facility Emergency',
+      id: 'staffing_shortage',
+      name: 'Staffing shortage',
       createdById: adminUser.id,
       updatedById: adminUser.id,
     },

--- a/server/test/fixtures/db/deflectionCancelReasons.yml
+++ b/server/test/fixtures/db/deflectionCancelReasons.yml
@@ -21,8 +21,8 @@ items:
     name: 'Release on Scene'
     createdBy: '@user1'
     updatedBy: '@user1'
-  facility_emergency:
-    id: 'facility_emergency'
-    name: 'Facility Emergency'
+  staffing_shortage:
+    id: 'staffing_shortage'
+    name: 'Staffing shortage'
     createdBy: '@user1'
     updatedBy: '@user1'

--- a/server/test/routes/api/deflections/cancel-reasons.test.js
+++ b/server/test/routes/api/deflections/cancel-reasons.test.js
@@ -27,7 +27,7 @@ test('/api/deflections/cancel-reasons', async (t) => {
       assert.ok(ids.includes('jail'));
       assert.ok(ids.includes('hospital'));
       assert.ok(ids.includes('release_on_scene'));
-      assert.ok(ids.includes('facility_emergency'));
+      assert.ok(ids.includes('staffing_shortage'));
 
       // Check sorting by name
       const names = reasons.map(r => r.name);


### PR DESCRIPTION
## Summary

Renames the SFPD hold cancellation reason from `facility_emergency` / "Facility Emergency" to `staffing_shortage` / "Staffing shortage".

## Changes

- Updated seeded deflection cancel reason data to use:
  - `id: staffing_shortage`
  - `name: Staffing shortage`
- Updated test fixtures to match the new id and label
- Updated the cancel-reasons API test to expect `staffing_shortage`
- Updated story data that referenced the old cancel reason id
- Added a Prisma migration to rename the existing database record from `facility_emergency` to `staffing_shortage` and update the display name

## Notes

- This is a full internal rename, not just a UI label change, so backend analytics and raw data will also reflect `staffing_shortage`. Contemplated just doing the label change, but this will likely confuse data analysts if we do not make the full change.
- Existing foreign key references should update automatically because the relation is defined with `ON UPDATE CASCADE`

Closes #590 