### PR TITLE
Adds supervising sergeant star to 647f (#556)

### DIFF
--- a/server/lib/forms/jsx/Form647f.jsx
+++ b/server/lib/forms/jsx/Form647f.jsx
@@ -43,6 +43,18 @@ export const metadata = {
             unit: true,
           },
         },
+        incidentOfficers: {
+          include: {
+            officer: {
+              include: {
+                organization: true,
+                unit: true,
+              },
+            },
+            organization: true,
+            unit: true,
+          },
+        },
       },
     },
     facility: true,
@@ -71,6 +83,7 @@ export const metadata = {
     arrestLocation: z.string(),
     officerUnit: z.string(),
     officerBadge: z.string(),
+    supervisorBadgeNumber: z.string(),
     agency: z.string(),
     charge: z.string(),
     justification: z.string(),
@@ -83,7 +96,8 @@ export const metadata = {
   transformData (deflection) {
     const subject = deflection.subject;
     const incident = deflection.incident;
-    const officer = incident?.createdBy || deflection.createdBy;
+    const arrestingOfficerRecord = incident?.incidentOfficers?.find(record => record.role === 'ARRESTING');
+    const officer = arrestingOfficerRecord?.officer || incident?.createdBy || deflection.createdBy;
 
     const subjectAddress = [subject?.addressLine1, subject?.city, subject?.state]
       .filter(Boolean)
@@ -96,9 +110,9 @@ export const metadata = {
     const officerName = officer
       ? `${officer.firstName} ${officer.lastName}`
       : '';
-    const officerBadge = incident?.createdByBadgeNumber || officer?.badgeNumber || '';
-    const officerUnit = incident?.createdByUnit?.name || officer?.unit?.name || '';
-    const agency = officer?.organization?.name || '';
+    const officerBadge = arrestingOfficerRecord?.badgeNumber || incident?.createdByBadgeNumber || officer?.badgeNumber || '';
+    const officerUnit = arrestingOfficerRecord?.unit?.name || incident?.createdByUnit?.name || officer?.unit?.name || '';
+    const agency = arrestingOfficerRecord?.organization?.name || officer?.organization?.name || '';
 
     const facility = deflection.facility;
     const facilityAddress = [facility?.addressLine1, facility?.city, facility?.state, facility?.postalCode]
@@ -122,6 +136,7 @@ export const metadata = {
       arrestLocation,
       officerUnit,
       officerBadge,
+      supervisorBadgeNumber: incident?.supervisorBadgeNumber || '',
       agency,
       charge: '647(f) RWS',
       justification: deflection.behavior || '',
@@ -150,6 +165,7 @@ export default function Form647f ({ data = {} }) {
     arrestLocation = '',
     officerUnit = '',
     officerBadge = '',
+    supervisorBadgeNumber = '',
     agency = '',
     charge = '',
     justification = '',
@@ -196,6 +212,7 @@ export default function Form647f ({ data = {} }) {
             <Row label='Location Arrested' value={arrestLocation} required />
             <Row label='Unit' value={officerUnit} required />
             <Row label='Badge Number / Star Number' value={officerBadge} required />
+            <Row label="Supervising Sergeant's Star Number" value={supervisorBadgeNumber} required />
             <Row label='Agency' value={agency} required />
             <Row label='Charge' value={charge || '647(f) RWS'} required />
 

--- a/server/test/routes/api/forms.test.js
+++ b/server/test/routes/api/forms.test.js
@@ -68,6 +68,63 @@ test('/api/forms', async (t) => {
         .get(`/api/forms/647f/data/${unreleasedDeflection.id}`);
       assert.strictEqual(response.statusCode, StatusCodes.UNAUTHORIZED);
     });
+
+    await t.test('prefers the arresting officer badge number from IncidentOfficer records', async () => {
+      const deflection = await app.prisma.deflection.findFirst({
+        where: { releasedAt: null },
+        include: { incident: true },
+      });
+      assert.ok(deflection?.incident, 'fixture: an unreleased deflection with incident must exist');
+
+      await app.prisma.incident.update({
+        where: { id: deflection.incident.id },
+        data: {
+          createdByBadgeNumber: null,
+        },
+      });
+
+      await app.prisma.incidentOfficer.create({
+        data: {
+          incidentId: deflection.incident.id,
+          facilityId: deflection.facilityId,
+          officerId: deflection.incident.createdById,
+          role: 'ARRESTING',
+          badgeNumber: '4321',
+          organizationId: 'sfpd',
+        },
+      });
+
+      const response = await app.inject()
+        .get(`/api/forms/647f/data/${deflection.id}`)
+        .headers(userHeaders);
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+
+      const data = JSON.parse(response.body);
+      assert.strictEqual(data.officerBadge, '4321');
+    });
+
+    await t.test('includes the supervising sergeant star number from the incident', async () => {
+      const deflection = await app.prisma.deflection.findFirst({
+        where: { releasedAt: null },
+        include: { incident: true },
+      });
+      assert.ok(deflection?.incident, 'fixture: an unreleased deflection with incident must exist');
+
+      await app.prisma.incident.update({
+        where: { id: deflection.incident.id },
+        data: {
+          supervisorBadgeNumber: '9876',
+        },
+      });
+
+      const response = await app.inject()
+        .get(`/api/forms/647f/data/${deflection.id}`)
+        .headers(userHeaders);
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+
+      const data = JSON.parse(response.body);
+      assert.strictEqual(data.supervisorBadgeNumber, '9876');
+    });
   });
 
   await t.test('GET /cert/data/:deflectionId', async (t) => {


### PR DESCRIPTION
### Summary
This updates the 647(f) form to include the Supervising Sergeant's Star Number under the `Arrest Information` section.

### Changes
- Added `supervisorBadgeNumber` to the 647(f) form data schema
- Mapped the value from the incident record into the 647(f) form payload
- Rendered `Supervising Sergeant's Star Number` in the Arrest Information section of the 647(f) output
- Added a regression test to verify the 647(f) data endpoint returns the supervising sergeant star number

### Testing
- Added route-level test coverage for `/api/forms/647f/data/:deflectionId`

### Notes
- The incident form already collected this value; this PR just wires it into the 647(f) form output.

Closes #556 