### PR TITLE
Update 'not in custody' to 'legally released'

### DIFF
--- a/client/src/lesc/components/care/Care.jsx
+++ b/client/src/lesc/components/care/Care.jsx
@@ -182,7 +182,7 @@ function Care () {
             onChange={setTab}
             data={[
               { label: 'In custody', value: 'in-custody' },
-              { label: 'Not in custody', value: 'not-in-custody' },
+              { label: 'Legally released', value: 'not-in-custody' },
             ]}
           />
           <FacilityStatusBanner />

--- a/client/src/lesc/components/care/careFlow.test.js
+++ b/client/src/lesc/components/care/careFlow.test.js
@@ -101,7 +101,7 @@ describe('Care flow unit tests', () => {
       highlightTarget: '901',
       navigateTo: '/care?tab=not-in-custody',
       toastTitle: 'Exit recorded',
-      toastBody: 'Person now appears in Exited facility under Not in custody (last 24 hours).',
+      toastBody: 'Person now appears in Exited facility under Legally released (last 24 hours).',
     });
   });
 

--- a/client/src/lesc/components/care/careFlowUtils.js
+++ b/client/src/lesc/components/care/careFlowUtils.js
@@ -54,7 +54,7 @@ export function getCareExitSuccessPayload (deflectionId) {
     highlightTarget: String(deflectionId),
     navigateTo: '/care?tab=not-in-custody',
     toastTitle: 'Exit recorded',
-    toastBody: 'Person now appears in Exited facility under Not in custody (last 24 hours).',
+    toastBody: 'Person now appears in Exited facility under Legally released (last 24 hours).',
   };
 }
 

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -267,7 +267,7 @@ function Custody () {
             onChange={setTab}
             data={[
               { label: 'In Custody', value: 'in-custody' },
-              { label: 'Not in custody', value: 'released' },
+              { label: 'Legally released', value: 'released' },
             ]}
           />
           <FacilityStatusBanner />

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -266,7 +266,7 @@ function Custody () {
             value={tab}
             onChange={setTab}
             data={[
-              { label: 'In Custody', value: 'in-custody' },
+              { label: 'In custody', value: 'in-custody' },
               { label: 'Legally released', value: 'released' },
             ]}
           />

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -136,7 +136,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
       queryClient.invalidateQueries({ queryKey: ['deflections', facility.id] });
       queryClient.invalidateQueries({ queryKey: ['deflections', String(deflection.id)] });
       queryClient.invalidateQueries({ queryKey: ['deflections'] });
-      showToast('Exit recorded', 'success', 4000, 'Person moved to "Transferred to jail" under Not in custody.');
+      showToast('Exit recorded', 'success', 4000, 'Person moved to "Transferred to jail" under "Legally released".');
       navigate('/custody?tab=released');
     },
     onError: () => {

--- a/client/src/lesc/components/custody/ExitToJailModal.jsx
+++ b/client/src/lesc/components/custody/ExitToJailModal.jsx
@@ -41,7 +41,7 @@ function ExitToJailModal ({
             <br />
             &bull; This person will move to &quot;Transferred to jail&quot; for 24 hours.
             <br />
-            &bull; They will be removed from in-custody lists and only appear under Not in custody.
+            &bull; They will be removed from in-custody lists and only appear under 'Legally released'.
             <br />
             &bull; Their property record will be marked as returned.
           </Text>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -87,7 +87,7 @@ function LegalReleaseQuestions () {
       queryClient.invalidateQueries({ queryKey: ['deflections', String(id)] });
       queryClient.invalidateQueries({ queryKey: ['deflections'] });
       if (isExitRelease) {
-        showToast('Exit recorded', 'success', 4000, 'Person now appears in Exited facility under Not in custody (last 24 hours).');
+        showToast('Exit recorded', 'success', 4000, 'Person now appears in Exited facility under Legally released (last 24 hours).');
         navigate(backTo);
         return;
       }


### PR DESCRIPTION
Addresses #611. 

This PR changes:

- The text label in the segmented control seen by CARE and SFSO users ("Legally released" rather than "Not in custody")
- Changes related user-facing text in a few toast notifications
- Updates `In Custody` to `In custody` (this was inconsistent across the CARE and SFSO views; this PR makes it consistent)

This PR **doesn't** change the underlying tab names used for navigation. (So the page still recognizes `custody?tab=not-in-custody` rather than `custody?tab=legally-released`. But we changed the user-facing copy in the UI.

<img width="533" height="371" alt="image" src="https://github.com/user-attachments/assets/49fff456-e345-4824-94d1-0a34d82e2941" />

<img width="583" height="471" alt="image" src="https://github.com/user-attachments/assets/88587bb7-4320-4e4f-989a-daaffe0fdbd0" />
