### PR TITLE
Replaced drug use language in 647f (#615)

### DIFF
--- a/client/src/utils/deflectionNarrative.js
+++ b/client/src/utils/deflectionNarrative.js
@@ -51,7 +51,7 @@ export function buildDeflectionNarrative ({ incident, observedBehaviorNames, dru
   ];
 
   if (drugUseEvidence === true) {
-    lines.push(drugType ? `Officer observed that drugs were recently used: ${formatDrugType(drugType)}.` : DRUG_USE_DETAILS_MISSING);
+    lines.push(drugType ? `Officer suspected person used intoxicants: ${formatDrugType(drugType)}.` : DRUG_USE_DETAILS_MISSING);
   }
 
   lines.push('Officer concluded that a 647(f) RWS arrest and transport of the individual to RESET was appropriate.');

--- a/client/src/utils/deflectionNarrative.test.js
+++ b/client/src/utils/deflectionNarrative.test.js
@@ -48,7 +48,7 @@ describe('deflectionNarrative', () => {
     expect(narrative).toBe([
       'Officer encountered this individual at 1455 Market St on 2/12/2026 at 11:53 PM.',
       'Officer observed the following behaviors: fumbling for ID or belongings.',
-      'Officer observed that drugs were recently used: CNS Depressants.',
+      'Officer suspected person used intoxicants: CNS Depressants.',
       'Officer concluded that a 647(f) RWS arrest and transport of the individual to RESET was appropriate.',
       'Person volunteered to be taken to RESET.',
     ].join('\n'));


### PR DESCRIPTION
## Summary

Updates the auto-generated 647(f) deflection narrative language (and in test) to replace:

`Officer observed that drugs were recently used:`

with:

`Officer suspects person used intoxicants:`

That is all.

Closes #615 