### PR TITLE
Allows manual SFPD unit entry and profile editing (#603)

### DIFF
--- a/client/src/UnitSelector.jsx
+++ b/client/src/UnitSelector.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Box, Button, Container, Stack, Title, Autocomplete, Loader } from '@mantine/core';
+import { Box, Button, Container, Stack, Title, Autocomplete, Loader, Text } from '@mantine/core';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router';
 
@@ -37,36 +37,42 @@ function UnitSelector () {
     value: unit.id,
     label: unit.name,
   }));
+  const canConfirm = unitName.trim().length >= 3;
 
   function handleOptionSubmit (value) {
     setUnitName(value);
-    const selectedUnit = units.find((unit) => unit.name === value);
-    if (selectedUnit) {
-      setUnitId(selectedUnit.id);
-    }
+    const normalizedValue = value.trim().toLowerCase();
+    const selectedUnit = units.find((unit) => unit.name.trim().toLowerCase() === normalizedValue);
+    setUnitId(selectedUnit?.id ?? null);
   }
 
   function onConfirm () {
-    onSubmitMutation.mutate({ unitId });
+    onSubmitMutation.mutate({
+      unitId,
+      unitName: unitName.trim(),
+    });
   }
 
   return (
     <Container>
       <Stack gap='xl' mah='calc(100vh - var(--app-shell-header-offset) - var(--app-shell-padding) - 1.25rem)'>
         <Title flex='0 0' order={2}>What unit are you assigned to today?</Title>
-        <Autocomplete
-          label='Unit'
-          placeholder='Start typing a unit name'
-          data={autocompleteData}
-          value={unitName}
-          onChange={handleOptionSubmit}
-          clearable
-          disabled={isLoading}
-          rightSection={isLoading ? <Loader size='sm' /> : null}
-          nothingfound='No units found'
-        />
+        <Stack gap='xs'>
+          <Text size='sm' c='dimmed'>If your unit number does not appear in list, just type and confirm</Text>
+          <Autocomplete
+            label='Unit'
+            placeholder='Type unit name'
+            data={autocompleteData}
+            value={unitName}
+            onChange={handleOptionSubmit}
+            clearable
+            disabled={isLoading}
+            rightSection={isLoading ? <Loader size='sm' /> : null}
+            nothingfound='No units found'
+          />
+        </Stack>
         <Box flex='0 0'>
-          <Button disabled={!unitId} fullWidth mt='3rem' onClick={onConfirm}>Confirm unit</Button>
+          <Button disabled={!canConfirm} loading={onSubmitMutation.isPending} fullWidth mt='3rem' onClick={onConfirm}>Confirm unit</Button>
         </Box>
       </Stack>
     </Container>

--- a/client/src/UserProfile/EditUserProfilePage.jsx
+++ b/client/src/UserProfile/EditUserProfilePage.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { Anchor, Button, Checkbox, Container, Fieldset, Group, Select, Stack, Text, TextInput, Title } from '@mantine/core';
+import { useEffect, useState } from 'react';
+import { Anchor, Autocomplete, Button, Checkbox, Container, Fieldset, Group, Loader, Select, Stack, Text, TextInput, Title } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { useForm } from '@mantine/form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -18,6 +18,8 @@ function EditUserProfilePage () {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { showToast } = useToast();
+  const [unitName, setUnitName] = useState('');
+  const [unitId, setUnitId] = useState('');
 
   const form = useForm({
     mode: 'uncontrolled',
@@ -53,11 +55,40 @@ function EditUserProfilePage () {
         ...data,
         password: '',
       });
+      setUnitName(data.unit?.name || '');
+      setUnitId(data.unitId || '');
     }
   }, [data]);
 
+  const autocompleteData = units?.map((unit) => ({
+    value: unit.id,
+    label: unit.name,
+  })) || [];
+
+  function handleUnitChange (value) {
+    setUnitName(value);
+    const normalizedValue = value.trim().toLowerCase();
+    const selectedUnit = units?.find((unit) => unit.name.trim().toLowerCase() === normalizedValue);
+    const nextUnitId = selectedUnit?.id || '';
+    setUnitId(nextUnitId);
+    form.setFieldValue('unitId', nextUnitId);
+  }
+
   const onSubmitMutation = useMutation({
-    mutationFn: (values) => Api.users.update(userId, values),
+    mutationFn: (values) => {
+      const payload = {
+        badgeNumber: values.badgeNumber,
+        unitId,
+        unitName: unitName.trim(),
+      };
+
+      if (values.organizationId === 'sfso') {
+        payload.titleId = values.titleId;
+        payload.prop115Certified = values.prop115Certified;
+      }
+
+      return Api.users.update(userId, payload);
+    },
     onSuccess: (response) => {
       queryClient.setQueryData(['users', userId], response.data);
       if (userId === user?.id) {
@@ -101,11 +132,15 @@ function EditUserProfilePage () {
                   />
                 )}
                 {(form.getValues().organizationId === 'sfpd' || form.getValues().organizationId === 'sfso') && (
-                  <Select
-                    {...form.getInputProps('unitId')}
-                    key={form.key('unitId')}
+                  <Autocomplete
                     label='Unit'
-                    data={units?.map((unit) => ({ value: unit.id, label: unit.name })) || []}
+                    placeholder='Type unit name'
+                    data={autocompleteData}
+                    value={unitName}
+                    onChange={handleUnitChange}
+                    disabled={!form.getValues().organizationId}
+                    rightSection={units === undefined && form.getValues().organizationId ? <Loader size='sm' /> : null}
+                    nothingfound='No units found'
                   />
                 )}
                 {form.getValues().organizationId === 'sfso' && (

--- a/server/lib/slugifyUnitId.js
+++ b/server/lib/slugifyUnitId.js
@@ -1,0 +1,8 @@
+export default function slugifyUnitId (value) {
+  return (value || '')
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -51,6 +51,7 @@ const UserResponseSchema = UserAttributesSchema.extend({
 });
 
 const UserUpdateSchema = UserAttributesSchema.extend({
+  unitName: z.string().trim().min(1).optional(),
   password: UserPasswordSchema.or(z.literal('')),
   picture: z.string().nullable(),
   isAdmin: z.boolean(),

--- a/server/prisma/seeds/units.js
+++ b/server/prisma/seeds/units.js
@@ -1,6 +1,9 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+import slugifyUnitId from '#lib/slugifyUnitId.js';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -19,7 +22,7 @@ async function seedUnitsForOrganization (prisma, adminUser, csvPath, organizatio
   let unitsSeeded = 0;
 
   for (const unitName of unitIds) {
-    const uniqueId = slugify(unitName);
+    const uniqueId = slugifyUnitId(unitName);
     await prisma.unit.upsert({
       where: {
         unitId: {
@@ -63,12 +66,4 @@ export default async function main (prisma) {
   const sfsoCount = await seedUnitsForOrganization(prisma, adminUser, sfsoPath, 'sfso');
 
   console.log(`Done seeding units! (SFPD: ${sfpdCount}, SFSO: ${sfsoCount})`);
-}
-function slugify (value) {
-  return (value || '')
-    .toString()
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
 }

--- a/server/routes/api/users/patch.js
+++ b/server/routes/api/users/patch.js
@@ -4,16 +4,8 @@ import _ from 'lodash';
 import crypto from 'node:crypto';
 import { z } from 'zod';
 
+import slugifyUnitId from '#lib/slugifyUnitId.js';
 import User from '#models/user.js';
-
-function slugify (value) {
-  return (value || '')
-    .toString()
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '');
-}
 
 async function resolveUnitId (tx, { organizationId, userId, unitId, unitName }) {
   const trimmedUnitName = unitName?.trim();
@@ -36,7 +28,7 @@ async function resolveUnitId (tx, { organizationId, userId, unitId, unitName }) 
     return existingUnit.id;
   }
 
-  const baseId = slugify(trimmedUnitName) || crypto.randomUUID();
+  const baseId = slugifyUnitId(trimmedUnitName) || crypto.randomUUID();
   let nextUnitId = baseId;
   let suffix = 2;
 

--- a/server/routes/api/users/patch.js
+++ b/server/routes/api/users/patch.js
@@ -1,9 +1,68 @@
 import { errorCodes } from 'fastify';
 import { StatusCodes } from 'http-status-codes';
 import _ from 'lodash';
+import crypto from 'node:crypto';
 import { z } from 'zod';
 
 import User from '#models/user.js';
+
+function slugify (value) {
+  return (value || '')
+    .toString()
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+async function resolveUnitId (tx, { organizationId, userId, unitId, unitName }) {
+  const trimmedUnitName = unitName?.trim();
+
+  if (!trimmedUnitName || unitId) {
+    return unitId;
+  }
+
+  const existingUnit = await tx.unit.findFirst({
+    where: {
+      organizationId,
+      name: {
+        equals: trimmedUnitName,
+        mode: 'insensitive',
+      },
+    },
+  });
+
+  if (existingUnit) {
+    return existingUnit.id;
+  }
+
+  const baseId = slugify(trimmedUnitName) || crypto.randomUUID();
+  let nextUnitId = baseId;
+  let suffix = 2;
+
+  while (await tx.unit.findUnique({
+    where: {
+      unitId: {
+        id: nextUnitId,
+        organizationId,
+      },
+    },
+  })) {
+    nextUnitId = `${baseId}_${suffix}`;
+    suffix++;
+  }
+
+  const createdUnit = await tx.unit.create({
+    data: {
+      id: nextUnitId,
+      name: trimmedUnitName,
+      organizationId,
+      createdById: userId,
+    },
+  });
+
+  return createdUnit.id;
+}
 
 export default async function (fastify, opts) {
   fastify.patch('/:id',
@@ -77,7 +136,7 @@ export default async function (fastify, opts) {
       }
       const user = new User(data);
       // Convert empty strings to null for nullable fields
-      const updateData = _.omit(request.body, ['password', 'picture']);
+      const updateData = _.omit(request.body, ['password', 'picture', 'unitName']);
       if (updateData.badgeNumber === '') updateData.badgeNumber = null;
       if (updateData.titleId === '') updateData.titleId = null;
       if (updateData.unitId === '') updateData.unitId = null;
@@ -101,6 +160,16 @@ export default async function (fastify, opts) {
       // update picture
       const pictureHandler = user.setAsset('picture', picture);
       await fastify.prisma.$transaction(async (tx) => {
+        if (request.body.unitName && data.organizationId) {
+          data.unitId = await resolveUnitId(tx, {
+            organizationId: data.organizationId,
+            userId: request.user.id,
+            unitId: data.unitId,
+            unitName: request.body.unitName,
+          });
+          user.changes.add('unitId');
+        }
+
         data = await tx.user.update({
           where: { id },
           include: {

--- a/server/test/routes/api/users.test.js
+++ b/server/test/routes/api/users.test.js
@@ -320,6 +320,53 @@ test('/api/users', async (t) => {
       data = await prisma.user.findUnique({ where: { id: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5' } });
       assert.deepStrictEqual(data.unitId, null);
     });
+
+    await t.test('creates and assigns a manually entered unit when one does not exist', async (t) => {
+      const response = await app.inject().patch('/api/users/dab5dff3-360d-4dbb-98dd-1990dfb5c4c5').payload({
+        unitName: 'Car 42'
+      }).headers(userHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.unitId, 'car_42');
+      assert.deepStrictEqual(data.unit.name, 'Car 42');
+
+      const unit = await prisma.unit.findUnique({
+        where: {
+          unitId: {
+            id: 'car_42',
+            organizationId: 'sfpd',
+          },
+        },
+      });
+      assert.ok(unit);
+      assert.deepStrictEqual(unit.name, 'Car 42');
+
+      const user = await prisma.user.findUnique({ where: { id: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5' } });
+      assert.deepStrictEqual(user.unitId, 'car_42');
+    });
+
+    await t.test('reuses an existing unit when a matching name is entered manually', async (t) => {
+      const response = await app.inject().patch('/api/users/dab5dff3-360d-4dbb-98dd-1990dfb5c4c5').payload({
+        unitName: 'option 1'
+      }).headers(userHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.unitId, 'option-1');
+      assert.deepStrictEqual(data.unit.name, 'Option 1');
+
+      const matchingUnits = await prisma.unit.findMany({
+        where: {
+          organizationId: 'sfpd',
+          name: {
+            equals: 'Option 1',
+            mode: 'insensitive',
+          },
+        },
+      });
+      assert.deepStrictEqual(matchingUnits.length, 1);
+    });
   });
 
   await t.test('PATCH /:id (org admin)', async (t) => {


### PR DESCRIPTION
## Summary

Updated SFPD/SFSO unit entry so officers can type and save units that are not already in the system.

### Login unit selection behavior changes

- Added helper subtitle above first-login unit entry:
  - `If unit number does not appear in list, just type and confirm`
- Changed first-login unit placeholder to:
  - `Type unit name`
- Enabled `Confirm unit` once at least 3 characters are entered
- Updated first-login unit submission to:
  - match existing units case-insensitively
  - create a new backend `Unit` record when no match exists
  - save the resolved `unitId` onto the user

### Profile edit behavior changes

- Updated profile unit editing to match first-login behavior
- Replaced the unit dropdown with typed autocomplete
- Allowed users to save a manually entered unit even if it is not already in the known unit list
- Limited profile PATCH payloads to editable fields only, fixing a `403 Forbidden` issue caused by sending extra protected fields

### Backend

- Extended user update schema to accept `unitName`
- Added backend resolution logic to:
  - reuse an existing unit in the same organization when names match
  - create a new organization-scoped unit when needed
  - persist that unit association on the user

### Tests / verification

- Added backend coverage for:
  - creating and assigning a manually entered unit
  - reusing an existing unit on manual entry
- Lint passed for the changed client/server files
- Full server route test execution could not be completed locally in this environment because the test suite requires a working container runtime for `testcontainers`

### Notes

- Ideally, SFPD would give us a complete list of units. They have not done so, and may not even have a complete list of units that can be updated often enough. While allowing manual entry is not ideal and could lead to mistaken or incorrect units in the dataset, it may be the best we can do for now under the circumstances.
- Note that this applies to the SFSO as well, in case we run into the same problem, but they appear to have smaller numbers of units so less likely to come up.

Closes #603  