### PR TITLE
[Minor] Consistently put double-quotes around subject status in UI copy

### DIFF
--- a/client/src/lesc/components/care/careFlow.test.js
+++ b/client/src/lesc/components/care/careFlow.test.js
@@ -101,7 +101,7 @@ describe('Care flow unit tests', () => {
       highlightTarget: '901',
       navigateTo: '/care?tab=not-in-custody',
       toastTitle: 'Exit recorded',
-      toastBody: 'Person now appears in "Exited facility" under "Legally released" (last 24 hours).',
+      toastBody: 'Person now appears in "Exited facility" under "Legally released" (for 24 hours).',
     });
   });
 

--- a/client/src/lesc/components/care/careFlow.test.js
+++ b/client/src/lesc/components/care/careFlow.test.js
@@ -101,7 +101,7 @@ describe('Care flow unit tests', () => {
       highlightTarget: '901',
       navigateTo: '/care?tab=not-in-custody',
       toastTitle: 'Exit recorded',
-      toastBody: 'Person now appears in Exited facility under Legally released (last 24 hours).',
+      toastBody: 'Person now appears in "Exited facility" under "Legally released" (last 24 hours).',
     });
   });
 

--- a/client/src/lesc/components/care/careFlowUtils.js
+++ b/client/src/lesc/components/care/careFlowUtils.js
@@ -54,7 +54,7 @@ export function getCareExitSuccessPayload (deflectionId) {
     highlightTarget: String(deflectionId),
     navigateTo: '/care?tab=not-in-custody',
     toastTitle: 'Exit recorded',
-    toastBody: 'Person now appears in "Exited facility" under "Legally released" (last 24 hours).',
+    toastBody: 'Person now appears in "Exited facility" under "Legally released" (for 24 hours).',
   };
 }
 

--- a/client/src/lesc/components/care/careFlowUtils.js
+++ b/client/src/lesc/components/care/careFlowUtils.js
@@ -54,7 +54,7 @@ export function getCareExitSuccessPayload (deflectionId) {
     highlightTarget: String(deflectionId),
     navigateTo: '/care?tab=not-in-custody',
     toastTitle: 'Exit recorded',
-    toastBody: 'Person now appears in Exited facility under Legally released (last 24 hours).',
+    toastBody: 'Person now appears in "Exited facility" under "Legally released" (last 24 hours).',
   };
 }
 

--- a/client/src/lesc/components/custody/ExitToJailModal.jsx
+++ b/client/src/lesc/components/custody/ExitToJailModal.jsx
@@ -41,7 +41,7 @@ function ExitToJailModal ({
             <br />
             &bull; This person will move to &quot;Transferred to jail&quot; for 24 hours.
             <br />
-            &bull; They will be removed from in-custody lists and only appear under 'Legally released'.
+            &bull; They will be removed from in-custody lists and only appear under &quot;Legally released&quot;.
             <br />
             &bull; Their property record will be marked as returned.
           </Text>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -87,7 +87,7 @@ function LegalReleaseQuestions () {
       queryClient.invalidateQueries({ queryKey: ['deflections', String(id)] });
       queryClient.invalidateQueries({ queryKey: ['deflections'] });
       if (isExitRelease) {
-        showToast('Exit recorded', 'success', 4000, 'Person now appears in Exited facility under Legally released (last 24 hours).');
+        showToast('Exit recorded', 'success', 4000, 'Person now appears in "Exited facility" under "Legally released" (last 24 hours).');
         navigate(backTo);
         return;
       }

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -87,7 +87,7 @@ function LegalReleaseQuestions () {
       queryClient.invalidateQueries({ queryKey: ['deflections', String(id)] });
       queryClient.invalidateQueries({ queryKey: ['deflections'] });
       if (isExitRelease) {
-        showToast('Exit recorded', 'success', 4000, 'Person now appears in "Exited facility" under "Legally released" (last 24 hours).');
+        showToast('Exit recorded', 'success', 4000, 'Person now appears in "Exited facility" under "Legally released" (for 24 hours).');
         navigate(backTo);
         return;
       }


### PR DESCRIPTION
Resolves #643 

This was *not* intended to be a big global pass finding every instance of this problem across the application. This is a quick PR meant to remediate the inconsistency that I introduced in a couple places in #635. References to the status `Legally released` are now consistently double-quoted whenever presented to the user in written prose messages (e.g. toasts, paragraph text in a modal, etc).

