### PR TITLE
Generates and files 647f when hold released for medical reason (#597)

### DIFF
--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -285,7 +285,7 @@ const Api = {
       return instance.patch(`/api/incidents/${id}/extend`).catch(handleError);
     },
     cancel (id, { cancelReasonId } = {}) {
-      return instance.delete(`/api/incidents/${id}${cancelReasonId ? `?cancelReasonId=${cancelReasonId}` : ''}`).catch(handleError);
+      return instance.delete(`/api/incidents/${id}${cancelReasonId ? `?cancelReasonId=${cancelReasonId}` : ''}`);
     },
   },
   deflections: {

--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -103,6 +103,14 @@ function Deflection () {
       showToast('Hold cancelled', 'success', 4000, `You cancelled the hold for ${name}.`);
       navigate('/holds');
     },
+    onError: (error) => {
+      const message = error?.response?.data?.error;
+      if (error?.response?.status === 422 && message) {
+        showToast(message, 'error');
+        return;
+      }
+      showToast('We couldn’t cancel the hold', 'error', 4000, 'Something went wrong. Try again later.');
+    },
   });
 
   const cancelIncidentMutation = useMutation({
@@ -130,6 +138,11 @@ function Deflection () {
 
       if (isNetworkError) {
         showToast('Connection failure', 'warning', 4000, 'Failed to cancel incident. Check your connection and try again.');
+        return;
+      }
+
+      if (error?.response?.status === 422 && error?.response?.data?.error) {
+        showToast(error.response.data.error, 'error');
         return;
       }
 

--- a/client/src/lesc/components/Holds.jsx
+++ b/client/src/lesc/components/Holds.jsx
@@ -340,6 +340,14 @@ function Holds () {
       onCloseCancelModal();
       showToast('Hold cancelled', 'success', 4000, 'You cancelled the hold.');
     },
+    onError: (error) => {
+      const message = error?.response?.data?.error;
+      if (error?.response?.status === 422 && message) {
+        showToast(message, 'error');
+        return;
+      }
+      showToast('We couldn’t cancel the hold', 'error', 4000, 'Something went wrong. Try again later.');
+    },
   });
 
   const cancelIncidentMutation = useMutation({
@@ -370,6 +378,11 @@ function Holds () {
 
       if (isNetworkError) {
         showToast('Connection failure', 'warning', 4000, 'Failed to cancel incident. Check your connection and try again.');
+        return;
+      }
+
+      if (error?.response?.status === 422 && error?.response?.data?.error) {
+        showToast(error.response.data.error, 'error');
         return;
       }
 

--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -200,6 +200,11 @@ function IncidentForm () {
         return;
       }
 
+      if (error?.response?.status === 422 && error?.response?.data?.error) {
+        showToast(error.response.data.error, 'error');
+        return;
+      }
+
       showToast('We couldn’t cancel the incident', 'error', 4000, 'Something went wrong. Try again later.');
     },
   });

--- a/server/lib/forms/647f/Form647f.jsx
+++ b/server/lib/forms/647f/Form647f.jsx
@@ -48,6 +48,7 @@ export default function Form647f ({ data = {} }) {
     agency = '',
     charge = '',
     justification = '',
+    hospitalCancellationReleaseNarrative = '',
     substanceFound = false,
     paraphernaliaFound = false,
     deflectionId = '',
@@ -59,7 +60,7 @@ export default function Form647f ({ data = {} }) {
   const paraphernaliaNot = paraphernaliaFound ? '' : 'not ';
   const narcoticsStatement = `SFPD Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
 
-  const narrative = [justification, narcoticsStatement]
+  const narrative = [justification, narcoticsStatement, hospitalCancellationReleaseNarrative]
     .filter(Boolean)
     .join('\n\n');
 

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -1,4 +1,5 @@
 import { metadata } from './metadata.js';
+import { getHospitalCancellationReleaseNarrative, HOSPITAL_CANCEL_REASON_ID } from '#lib/hospitalCancellation647f.js';
 
 export function transformData (deflection) {
   const subject = deflection.subject;
@@ -47,6 +48,9 @@ export function transformData (deflection) {
     agency,
     charge: '647(f) RWS',
     justification: deflection.behavior || '',
+    hospitalCancellationReleaseNarrative: deflection.cancelReasonId === HOSPITAL_CANCEL_REASON_ID
+      ? getHospitalCancellationReleaseNarrative(deflection.cancelledAt)
+      : '',
     substanceFound: deflection.narcoticsSubstance === true,
     paraphernaliaFound: deflection.narcoticsParaphernalia === true,
     facilityName: facility?.name || '',

--- a/server/lib/hospitalCancellation647f.js
+++ b/server/lib/hospitalCancellation647f.js
@@ -1,0 +1,76 @@
+import { DateTime } from 'luxon';
+
+export const HOSPITAL_CANCEL_REASON_ID = 'hospital';
+export const HOSPITAL_CANCELLATION_INCOMPLETE_DETAILS_ERROR = 'SFPD policy requires person details to be completed before a medical-related cancelation';
+export const HOSPITAL_CANCELLATION_ELIGIBLE_SUBJECT_STATUSES = new Set([
+  'DETAINED',
+  'ONSITE_AWAITING_TRANSFER',
+  'AWAITING_INTAKE',
+  'FAILED_INTAKE',
+  'READY_FOR_INTAKE',
+  'ADMITTED',
+  'IN_CHAIR',
+]);
+
+function hasMinimumAlphanumericChars (value, minimum) {
+  const alphanumericCount = String(value ?? '').match(/[0-9a-z]/gi)?.length ?? 0;
+  return alphanumericCount >= minimum;
+}
+
+export function hasCompleteHospitalCancellationDetails (deflection) {
+  const subject = deflection?.subject;
+  const incident = deflection?.incident;
+
+  const subjectComplete = Boolean(
+    subject?.firstName &&
+    subject?.lastName &&
+    subject?.dateOfBirth &&
+    subject?.sex &&
+    subject?.race
+  );
+
+  const incidentComplete = Boolean(
+    incident?.addressLine1 &&
+    incident?.city &&
+    incident?.state &&
+    incident?.arrestedAt &&
+    incident?.encounteredVia &&
+    hasMinimumAlphanumericChars(incident?.cadNumber, 2) &&
+    hasMinimumAlphanumericChars(incident?.caseNumber, 2) &&
+    String(incident?.supervisorBadgeNumber ?? '').length >= 1 &&
+    String(incident?.supervisorBadgeNumber ?? '').length <= 4
+  );
+
+  const deflectionComplete = Boolean(
+    typeof deflection?.narcoticsSubstance === 'boolean' &&
+    typeof deflection?.narcoticsParaphernalia === 'boolean' &&
+    typeof deflection?.drugUseEvidence === 'boolean' &&
+    (
+      deflection?.drugUseEvidence === false ||
+      Boolean(deflection?.drugType)
+    ) &&
+    String(deflection?.behavior ?? '').trim().length >= 2 &&
+    String(deflection?.behaviorNarrative ?? '').trim().length >= 2 &&
+    Boolean(deflection?.property)
+  );
+
+  return subjectComplete && incidentComplete && deflectionComplete;
+}
+
+export function isHospitalCancellation647fEligible (deflection) {
+  return (
+    deflection?.status === 'ACTIVE' &&
+    HOSPITAL_CANCELLATION_ELIGIBLE_SUBJECT_STATUSES.has(deflection?.subjectStatus)
+  );
+}
+
+export function getHospitalCancellationReleaseNarrative (cancelledAt) {
+  if (!cancelledAt) return '';
+
+  const releasedAt = DateTime.fromJSDate(cancelledAt instanceof Date ? cancelledAt : new Date(cancelledAt), { zone: 'America/Los_Angeles' });
+  const releasedAtText = releasedAt.isValid
+    ? releasedAt.toFormat("HH:mm 'on' MM/dd/yyyy")
+    : String(cancelledAt);
+
+  return `The person was released at ${releasedAtText} due to a medical need and was transported to hospital.`;
+}

--- a/server/routes/api/deflections/cancel.js
+++ b/server/routes/api/deflections/cancel.js
@@ -6,6 +6,13 @@ import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { sendHoldCancelledEmails } from '#lib/holdNotifications.js';
 import { canModifyDeflection } from '#lib/incidentPermissions.js';
+import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
+import {
+  hasCompleteHospitalCancellationDetails,
+  HOSPITAL_CANCELLATION_INCOMPLETE_DETAILS_ERROR,
+  HOSPITAL_CANCEL_REASON_ID,
+  isHospitalCancellation647fEligible,
+} from '#lib/hospitalCancellation647f.js';
 
 export default async function (fastify, opts) {
   fastify.delete('/:id',
@@ -23,6 +30,9 @@ export default async function (fastify, opts) {
           [StatusCodes.OK]: Deflection.ResponseSchema,
           [StatusCodes.NOT_FOUND]: z.null(),
           [StatusCodes.GONE]: z.null(),
+          [StatusCodes.UNPROCESSABLE_ENTITY]: z.object({
+            error: z.string(),
+          }),
         },
       },
     },
@@ -40,6 +50,26 @@ export default async function (fastify, opts) {
 
       if (!canModifyDeflection(deflection, request.user)) {
         return reply.code(StatusCodes.FORBIDDEN).send();
+      }
+
+      if (cancelReasonId === HOSPITAL_CANCEL_REASON_ID) {
+        const detailedDeflection = await fastify.prisma.deflection.findUnique({
+          where: { id },
+          include: {
+            subject: true,
+            incident: true,
+          },
+        });
+
+        if (
+          detailedDeflection?.subjectId &&
+          isHospitalCancellation647fEligible(detailedDeflection) &&
+          !hasCompleteHospitalCancellationDetails(detailedDeflection)
+        ) {
+          return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({
+            error: HOSPITAL_CANCELLATION_INCOMPLETE_DETAILS_ERROR,
+          });
+        }
       }
 
       // create the update record for the cancellation
@@ -129,6 +159,19 @@ export default async function (fastify, opts) {
       });
 
       deflection.propertyPhotos = deflection.propertyPhotos.map(photo => new PropertyPhoto(photo));
+
+      if (
+        deflection.status === Deflection.HoldStatus.CANCELLED &&
+        deflection.cancelReasonId === HOSPITAL_CANCEL_REASON_ID &&
+        isHospitalCancellation647fEligible({ ...deflection, status: Deflection.HoldStatus.ACTIVE })
+      ) {
+        await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
+          deflectionId: deflection.id,
+          userId: request.user.id,
+          formIds: ['647f'],
+          emailTemplate: 'transfer-form',
+        });
+      }
 
       // Send email if cancelled by someone other than the creator
       if (deflection.status === Deflection.HoldStatus.CANCELLED && deflection.createdById !== request.user.id) {

--- a/server/routes/api/incidents/cancel.js
+++ b/server/routes/api/incidents/cancel.js
@@ -1,5 +1,12 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
+import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
+import {
+  hasCompleteHospitalCancellationDetails,
+  HOSPITAL_CANCELLATION_INCOMPLETE_DETAILS_ERROR,
+  HOSPITAL_CANCEL_REASON_ID,
+  isHospitalCancellation647fEligible,
+} from '#lib/hospitalCancellation647f.js';
 
 export default async function (fastify, opts) {
   fastify.delete('/:id',
@@ -55,15 +62,41 @@ export default async function (fastify, opts) {
       }
 
       try {
+        const hospitalCancellationDeflectionIds = [];
+
         await fastify.prisma.$transaction(async (tx) => {
           const deflections = await tx.deflection.findMany({
             where: { incidentId: id },
+            include: {
+              subject: true,
+              incident: true,
+            },
           });
+          const activeDeflections = deflections.filter((deflection) => deflection.status === 'ACTIVE');
+          const hospitalEligibleDeflections = activeDeflections.filter(isHospitalCancellation647fEligible);
 
           const hasHoldsWithDetails = deflections.some((deflection) => Boolean(deflection.subjectId));
 
           if (hasHoldsWithDetails && !cancelReasonId) {
             throw new Error('CANCEL_REASON_REQUIRED');
+          }
+
+          if (cancelReasonId === HOSPITAL_CANCEL_REASON_ID) {
+            const incompleteHospitalCancellation = hospitalEligibleDeflections.some((deflection) =>
+              deflection.subjectId && !hasCompleteHospitalCancellationDetails(deflection)
+            );
+
+            if (incompleteHospitalCancellation) {
+              throw new Error('HOSPITAL_CANCELLATION_DETAILS_INCOMPLETE');
+            }
+          }
+
+          if (cancelReasonId === HOSPITAL_CANCEL_REASON_ID) {
+            hospitalCancellationDeflectionIds.push(
+              ...hospitalEligibleDeflections
+                .filter((deflection) => Boolean(deflection.subjectId))
+                .map((deflection) => deflection.id)
+            );
           }
 
           const bedTypeIds = [...new Set(deflections.map((deflection) => deflection.bedTypeId))];
@@ -164,10 +197,27 @@ export default async function (fastify, opts) {
             },
           });
         });
+
+        if (cancelReasonId === HOSPITAL_CANCEL_REASON_ID) {
+          await Promise.all(hospitalCancellationDeflectionIds.map((deflectionId) =>
+            fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
+              deflectionId,
+              userId: request.user.id,
+              formIds: ['647f'],
+              emailTemplate: 'transfer-form',
+            })
+          ));
+        }
       } catch (error) {
         if (error.message === 'CANCEL_REASON_REQUIRED') {
           return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({
             error: 'A cancellation reason is required when the incident contains holds with subject details.',
+          });
+        }
+
+        if (error.message === 'HOSPITAL_CANCELLATION_DETAILS_INCOMPLETE') {
+          return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({
+            error: HOSPITAL_CANCELLATION_INCOMPLETE_DETAILS_ERROR,
           });
         }
 

--- a/server/test/lib/forms/647f.test.js
+++ b/server/test/lib/forms/647f.test.js
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { transformData } from '#lib/forms/647f/generate.js';
+
+test('647f hospital cancellation appends the release narrative', () => {
+  const data = transformData({
+    id: 42,
+    behavior: 'Subject was unable to care for themself.',
+    narcoticsSubstance: false,
+    narcoticsParaphernalia: true,
+    cancelReasonId: 'hospital',
+    cancelledAt: new Date('2025-04-15T17:35:00.000Z'),
+    subject: {
+      firstName: 'Test',
+      lastName: 'Client',
+      middleInitial: 'T',
+      race: 'WHITE',
+      sex: 'MALE',
+      dateOfBirth: new Date('2000-01-01T00:00:00.000Z'),
+    },
+    incident: {
+      cadNumber: 'CAD-123',
+      arrestedAt: new Date('2025-04-15T16:00:00.000Z'),
+      supervisorBadgeNumber: '1234',
+    },
+    facility: {
+      name: 'LES Center',
+      addressLine1: '123 Main St',
+      city: 'San Francisco',
+      state: 'CA',
+      postalCode: '94102',
+    },
+  });
+
+  assert.equal(
+    data.hospitalCancellationReleaseNarrative,
+    'The person was released at 10:35 on 04/15/2025 due to a medical need and was transported to hospital.'
+  );
+});

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -936,6 +936,56 @@ test('/api/deflections', async (t) => {
   });
 
   await t.test('DELETE /:id', async (t) => {
+    await t.test('blocks hospital cancellation when hold details are incomplete', async () => {
+      const response = await app.inject().delete('/api/deflections/4?cancelReasonId=hospital').headers(userHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.UNPROCESSABLE_ENTITY);
+
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.error, 'SFPD policy requires person details to be completed before a medical-related cancelation');
+
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
+    });
+
+    await t.test('queues 647f generation when a completed hold is cancelled for hospital', async () => {
+      await prisma.incident.update({
+        where: { id: 1 },
+        data: {
+          addressLine1: '100 Main St',
+          city: 'San Francisco',
+          state: 'CA',
+          supervisorBadgeNumber: '1234',
+        },
+      });
+      await prisma.deflection.update({
+        where: { id: 4 },
+        data: {
+          narcoticsSubstance: false,
+          narcoticsParaphernalia: false,
+          drugUseEvidence: false,
+          drugType: null,
+          behavior: 'Subject was unable to care for self.',
+          behaviorNarrative: 'Additional narrative.',
+          property: 'NONE',
+        },
+      });
+
+      const response = await app.inject().delete('/api/deflections/4?cancelReasonId=hospital').headers(userHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.status, 'CANCELLED');
+      assert.deepStrictEqual(data.cancelReasonId, 'hospital');
+
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
+        deflectionId: 4,
+        userId: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5',
+        formIds: ['647f'],
+        emailTemplate: 'transfer-form',
+      });
+    });
+
     await t.test('cancels the deflection', async () => {
       await prisma.deflection.expire();
 

--- a/server/test/routes/api/incidents.test.js
+++ b/server/test/routes/api/incidents.test.js
@@ -334,6 +334,61 @@ test('/api/incidents', async (t) => {
       assert.ok(incidentStillExists);
     });
 
+    await t.test('blocks hospital cancellation when a detailed hold is incomplete', async () => {
+      const deleteResponse = await app.inject().delete('/api/incidents/1?cancelReasonId=hospital').headers(userHeaders);
+      assert.deepStrictEqual(deleteResponse.statusCode, StatusCodes.UNPROCESSABLE_ENTITY);
+
+      const data = JSON.parse(deleteResponse.body);
+      assert.deepStrictEqual(data.error, 'SFPD policy requires person details to be completed before a medical-related cancelation');
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
+    });
+
+    await t.test('queues 647f generation for completed detailed holds on hospital incident cancellation', async () => {
+      await prisma.incident.update({
+        where: { id: 1 },
+        data: {
+          addressLine1: '100 Main St',
+          city: 'San Francisco',
+          state: 'CA',
+          supervisorBadgeNumber: '1234',
+        },
+      });
+      await prisma.deflection.updateMany({
+        where: {
+          id: { in: [4, 5, 6] },
+        },
+        data: {
+          narcoticsSubstance: false,
+          narcoticsParaphernalia: false,
+          drugUseEvidence: false,
+          drugType: null,
+          behavior: 'Subject was unable to care for self.',
+          behaviorNarrative: 'Additional narrative.',
+          property: 'NONE',
+        },
+      });
+
+      const deleteResponse = await app.inject().delete('/api/incidents/1?cancelReasonId=hospital').headers(userHeaders);
+      assert.deepStrictEqual(deleteResponse.statusCode, StatusCodes.NO_CONTENT);
+
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 3);
+      assert.deepStrictEqual(
+        app.backgroundJobs._sent.map((job) => job.name),
+        ['generate-forms', 'generate-forms', 'generate-forms']
+      );
+      const sentJobs = [...app.backgroundJobs._sent]
+        .map((job) => job.data)
+        .sort((a, b) => a.deflectionId - b.deflectionId);
+      assert.deepStrictEqual(
+        sentJobs,
+        [
+          { deflectionId: 4, userId: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5', formIds: ['647f'], emailTemplate: 'transfer-form' },
+          { deflectionId: 5, userId: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5', formIds: ['647f'], emailTemplate: 'transfer-form' },
+          { deflectionId: 6, userId: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5', formIds: ['647f'], emailTemplate: 'transfer-form' },
+        ]
+      );
+    });
+
     await t.test('cancels an incident with non-empty holds with a cancel reason', async () => {
       const bedTypeId = '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76';
       const createResponse = await app.inject().post(`/api/incidents?bedTypeId=${bedTypeId}`).payload({


### PR DESCRIPTION
## Summary

Implements 647f generation on hold/incident cancelation for SFPD users only when "Hospital" is cited as the cancelation reason. This is to accommodate a SFPD feature request.

## Details

- Added logic to generate and file a `647f` when a hold is canceled by arresting user with the `Hospital` reason.
- Reused the existing background form-generation flow.
- Appended a hospital-release sentence to the bottom of the 647f narrative:
  - `The person was released at [time/date] due to a medical need and was transported to hospital.`
- Enforced a new server-side policy check:
  - if cancel reason is `Hospital` and required person/incident/deflection details are incomplete, cancellation is blocked (this is per SFPD policy)
  - returns a policy-specific error message instead of allowing cancelation
- Updated client cancel flows to surface the policy toast instead of a generic connection failure.

## Validation / Scope Rules

Hospital-related 647f generation and completeness enforcement now apply only to eligible active deflections in pre-release / in-facility statuses:

- `DETAINED`
- `ONSITE_AWAITING_TRANSFER`
- `AWAITING_INTAKE`
- `FAILED_INTAKE`
- `READY_FOR_INTAKE`
- `ADMITTED`
- `IN_CHAIR`

This avoids incorrectly applying the hospital-cancel rule to already released historical deflections on the same incident.

## User-Facing Behavior

If a user selects `Hospital` as the cancel reason before required details are complete, the UI now shows:

`SFPD policy requires person details to be completed before a medical-related cancelation`

This applies to:
- canceling an individual hold
- canceling an incident
- hold cancel flows that route through incident cancellation

Closes #597 
