### PR TITLE
Adds sending to supervisor label to 849b review screen (#616)

### DIFF
--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -130,7 +130,7 @@ function LegalReleaseQuestions () {
         <Stack gap='xl'>
           <Stack gap={0}>
             <Text size='xl' c='dimmed'>Confirm legal release</Text>
-            <Title order={3}>Review the 849(b) and choose a release reason.</Title>
+            <Title order={3}>Review the 849(b) before continuing.</Title>
           </Stack>
 
           <Stack gap='xs'>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -9,7 +9,7 @@ import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useToast } from '@/components/ToastContext';
 import useEnsureReleaseNarrative from '../../../hooks/useEnsureReleaseNarrative';
-import { IconArrowLeft } from '@tabler/icons-react';
+import { IconAlertCircle, IconArrowLeft } from '@tabler/icons-react';
 import { getPrefilledLegalReleaseState } from './legalReleasePresets';
 
 const RELEASE_TOAST_KEY = 'custodyReleaseToast';
@@ -130,7 +130,7 @@ function LegalReleaseQuestions () {
         <Stack gap='xl'>
           <Stack gap={0}>
             <Text size='xl' c='dimmed'>Confirm legal release</Text>
-            <Title order={3}>Review the 849(b) and choose a release reason. After you confirm, it&apos;s sent to SFSO supervisors and can&apos;t be changed.</Title>
+            <Title order={3}>Review the 849(b) and choose a release reason.</Title>
           </Stack>
 
           <Stack gap='xs'>
@@ -216,6 +216,15 @@ function LegalReleaseQuestions () {
               </>
             )}
           </Stack>
+
+          <Group gap='sm' align='flex-start' wrap='nowrap'>
+            <Box pt={2} c='indigo.6'>
+              <IconAlertCircle size={24} />
+            </Box>
+            <Text size='md'>
+              When you confirm release, the 849(b) will be sent to SFSO supervisors
+            </Text>
+          </Group>
 
           <Group>
             <Button variant='destructive' onClick={() => navigate(backTo)}>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -222,7 +222,7 @@ function LegalReleaseQuestions () {
               <IconAlertCircle size={24} />
             </Box>
             <Text size='md'>
-              When you confirm release, the 849(b) will be sent to SFSO supervisors
+              When you confirm release, the 849(b) will be sent to SFSO supervisors.
             </Text>
           </Group>
 

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.view.test.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.view.test.jsx
@@ -99,7 +99,7 @@ describe('LegalReleaseQuestions', () => {
   it('shows the SFSO supervisor notice above the release actions', async () => {
     renderPage();
 
-    expect(await screen.findByText('When you confirm release, the 849(b) will be sent to SFSO .')).toBeInTheDocument();
+    expect(await screen.findByText(/When you confirm release, the 849\(b\) will be sent to SFSO supervisors\./i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Confirm release' })).toBeDisabled();
   });

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.view.test.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.view.test.jsx
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MantineProvider } from '@mantine/core';
+import { MemoryRouter } from 'react-router';
+
+import LegalReleaseQuestions from './LegalReleaseQuestions';
+
+const {
+  mockNavigate,
+  mockGetDeflection,
+  mockShowToast,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockGetDeflection: vi.fn(),
+  mockShowToast: vi.fn(),
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: '123' }),
+    useSearchParams: () => [new URLSearchParams()],
+  };
+});
+
+vi.mock('@/Api', () => ({
+  default: {
+    deflections: {
+      get: mockGetDeflection,
+      update: vi.fn(),
+      release: vi.fn(),
+    },
+    incidents: {
+      get: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/components/Header', () => ({
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/IconButtonLink', () => ({
+  default: () => <button type='button'>Back</button>,
+}));
+
+vi.mock('@/components/ToastContext', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+  }),
+}));
+
+vi.mock('@unhead/react', () => ({
+  Head: ({ children }) => <>{children}</>,
+}));
+
+vi.mock('../../../hooks/useEnsureReleaseNarrative', () => ({
+  default: () => 'Generated narrative text.',
+}));
+
+function renderPage () {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <LegalReleaseQuestions />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetDeflection.mockResolvedValue({
+    data: {
+      id: 123,
+      incidentId: null,
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('LegalReleaseQuestions', () => {
+  it('shows the SFSO supervisor notice above the release actions', async () => {
+    renderPage();
+
+    expect(await screen.findByText('When you confirm release, the 849(b) will be sent to SFSO .')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm release' })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- update the SFSO legal release screen to match the Figma spec by moving the 849(b) supervisor warning into its own inline notice above the cancel/confirm buttons
- add the alert-circle icon
- simplify the header copy so the warning text appears only once

Closes #616 