### PR TITLE
Adds 3 sec polling for facility and bed type data (#588)

### DIFF
--- a/client/src/components/FacilityStatusBanner.jsx
+++ b/client/src/components/FacilityStatusBanner.jsx
@@ -5,6 +5,7 @@ import { IconAlertCircle, IconX } from '@tabler/icons-react';
 
 import Api from '@/Api';
 import { useFacilityContext } from '@/FacilityContext';
+import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 
 function getBannerConfig (facilityName) {
   return {
@@ -29,7 +30,7 @@ function FacilityStatusBanner () {
     queryKey: ['facilities', facility?.id],
     queryFn: () => Api.facilities.get(facility.id).then(r => r.data),
     enabled: !!facility?.id,
-    refetchOnWindowFocus: true,
+    ...facilityLiveQueryOptions,
   });
 
   const currentFacility = freshFacility || facility;

--- a/client/src/hooks/facilityLiveQueryOptions.js
+++ b/client/src/hooks/facilityLiveQueryOptions.js
@@ -1,0 +1,8 @@
+export const FACILITY_LIVE_REFETCH_INTERVAL_MS = 3000;
+
+export const facilityLiveQueryOptions = {
+  refetchInterval: FACILITY_LIVE_REFETCH_INTERVAL_MS,
+  refetchOnWindowFocus: true,
+  refetchOnReconnect: true,
+  refetchOnMount: 'always',
+};

--- a/client/src/lesc/components/Holds.jsx
+++ b/client/src/lesc/components/Holds.jsx
@@ -12,6 +12,7 @@ import { useAuthContext } from '@/AuthContext';
 import ActionFooter from '@/components/ActionFooter';
 import { useToast } from '@/components/ToastContext';
 import { useFacilityContext } from '@/FacilityContext';
+import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import useSessionState from '@/hooks/useSessionState';
 import { formatTime } from '@/utils/format';
 
@@ -53,12 +54,16 @@ function Holds () {
   const [holdsHighlighted, setHoldsHighlighted] = useState(false);
   const [scanHandoffModalOpened, setScanHandoffModalOpened] = useState(false);
 
+  const { data: freshFacility } = useQuery({
+    queryKey: ['facilities', facility.id],
+    queryFn: () => Api.facilities.get(facility.id).then(response => response.data),
+    ...facilityLiveQueryOptions,
+  });
+
   const { data: bedTypes } = useQuery({
     queryKey: ['facilities', facility.id, 'bed-types'],
     queryFn: () => Api.facilities.bedTypes.index(facility.id).then(response => response.data),
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
-    refetchOnMount: 'always',
+    ...facilityLiveQueryOptions,
   });
 
   const { data: incident, dataUpdatedAt: incidentUpdatedAt } = useQuery({
@@ -448,10 +453,12 @@ function Holds () {
     }
   }
 
+  const currentFacility = freshFacility ?? facility;
   const showActionFooter = true;
-  const primaryBedType = (bedTypes ?? facility.bedTypes)?.[0];
-  const isClosed = facility.status === 'CLOSED';
-  const isFull = ((bedTypes ?? facility.bedTypes)?.reduce((sum, bedType) => sum + bedType.available, 0) ?? 0) === 0;
+  const currentBedTypes = bedTypes ?? currentFacility.bedTypes;
+  const primaryBedType = currentBedTypes?.[0];
+  const isClosed = currentFacility.status === 'CLOSED';
+  const isFull = (currentBedTypes?.reduce((sum, bedType) => sum + bedType.available, 0) ?? 0) === 0;
   const myOfficerRecord = incident?.incidentOfficers?.[0];
   const myArrivedAt = myOfficerRecord ? myOfficerRecord.arrivedAt : incident?.arrivedAt;
   const myLeftAt = myOfficerRecord ? myOfficerRecord.leftAt : incident?.leftAt;
@@ -478,8 +485,8 @@ function Holds () {
       <Container>
         <Stack gap='xl'>
           <Facility
-            facility={facility}
-            bedTypes={bedTypes ?? facility.bedTypes}
+            facility={currentFacility}
+            bedTypes={currentBedTypes}
             arrivedAt={myArrivedAt}
             leftAt={myLeftAt}
             hasActiveHold={(deflections?.length ?? 0) > 0}

--- a/client/src/lesc/components/ManageCapacity/ManageCapacity.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageCapacity.jsx
@@ -6,6 +6,7 @@ import { Head } from '@unhead/react';
 
 import Api from '@/Api';
 import { useFacilityContext } from '@/FacilityContext';
+import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import IconButtonLink from '@/components/IconButtonLink';
 
 import AdjustAvailability from './AdjustAvailability';
@@ -19,13 +20,13 @@ function ManageCapacity () {
   const { data: freshFacility } = useQuery({
     queryKey: ['facilities', facility.id],
     queryFn: () => Api.facilities.get(facility.id).then(response => response.data),
-    refetchOnMount: 'always',
+    ...facilityLiveQueryOptions,
   });
 
   const { data: bedTypes } = useQuery({
     queryKey: ['facilities', facility.id, 'bed-types'],
     queryFn: () => Api.facilities.bedTypes.index(facility.id).then(response => response.data),
-    refetchOnMount: 'always',
+    ...facilityLiveQueryOptions,
   });
 
   const currentFacility = freshFacility || facility;

--- a/client/src/lesc/components/care/Care.jsx
+++ b/client/src/lesc/components/care/Care.jsx
@@ -13,6 +13,7 @@ import ScanTransferCodeIcon from '@/components/ScanTransferCodeIcon';
 import { useFacilityContext } from '@/FacilityContext';
 import { useToast } from '@/components/ToastContext';
 import useSessionState from '@/hooks/useSessionState';
+import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import { formatTime } from '@/utils/format';
 
 import ChairAvailabilityCard from '../ChairAvailabilityCard';
@@ -94,9 +95,7 @@ function Care () {
   const { data: bedTypes } = useQuery({
     queryKey: ['facilities', facility.id, 'bed-types'],
     queryFn: () => Api.facilities.bedTypes.index(facility.id).then(response => response.data),
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
-    refetchOnMount: 'always',
+    ...facilityLiveQueryOptions,
   });
 
   useEffect(() => {

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -11,6 +11,7 @@ import ScanTransferCodeIcon from '@/components/ScanTransferCodeIcon';
 import { useFacilityContext } from '@/FacilityContext';
 import { useToast } from '@/components/ToastContext';
 import useSessionState from '@/hooks/useSessionState';
+import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import { formatTime } from '@/utils/format';
 
 import ChairAvailabilityCard from '../ChairAvailabilityCard';
@@ -114,9 +115,7 @@ function Custody () {
   const { data: bedTypes } = useQuery({
     queryKey: ['facilities', facility.id, 'bed-types'],
     queryFn: () => Api.facilities.bedTypes.index(facility.id).then(response => response.data),
-    refetchOnWindowFocus: true,
-    refetchOnReconnect: true,
-    refetchOnMount: 'always',
+    ...facilityLiveQueryOptions,
   });
 
   function handleScanSuccess () {


### PR DESCRIPTION
## Summary

Fixes stale facility operational state across devices by polling facility status and bed-type data on the same 3-second interval already used for deflections.

## Problem

When a facility admin changed chair availability or updated the facility to closed/open-not-accepting, other users did not see the update until a manual refresh. The backend update succeeded, but the client kept using stale cached facility data because those queries only refetched on mount, focus, or reconnect.

## Root Cause

Deflection queries already poll every 3 seconds, but facility status and bed-type queries did not. Some screens also continued reading `facility.status` from the static facility context, which could stay stale for the full session.

## Changes

- Add shared live-query options for facility operational data with a 3-second refetch interval.
- Apply live polling to:
  - facility status banner queries
  - chair availability / bed-type queries in Care
  - chair availability / bed-type queries in Custody
  - facility status + bed-type queries in Manage Capacity
  - facility status + bed-type queries in Holds
- Update Holds to use the freshly fetched facility record when evaluating closed/open state and rendering facility details.

Closes #588 