### PR TITLE
Adds 849b review nudges (#605)

### DIFF
--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
-import { Anchor, Box, Button, Chip, Container, Group, Input, Stack, Text, Textarea, Title } from '@mantine/core';
+import { Box, Button, Chip, Container, Group, Input, Stack, Text, Textarea, Title } from '@mantine/core';
 import { Head } from '@unhead/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -9,7 +9,7 @@ import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useToast } from '@/components/ToastContext';
 import useEnsureReleaseNarrative from '../../../hooks/useEnsureReleaseNarrative';
-import { IconArrowLeft } from '@tabler/icons-react';
+import { IconAlertCircle, IconArrowBackUp, IconArrowLeft, IconCheck } from '@tabler/icons-react';
 import { getPrefilledLegalReleaseState } from './legalReleasePresets';
 
 const RELEASE_TOAST_KEY = 'custodyReleaseToast';
@@ -27,6 +27,7 @@ function LegalReleaseQuestions () {
 
   const [releaseReasonId, setReleaseReasonId] = useState(prefilledState.releaseReasonId);
   const [isEditingNarrative, setIsEditingNarrative] = useState(false);
+  const [hasReviewedNarrative, setHasReviewedNarrative] = useState(false);
   const [narrativeDraft, setNarrativeDraft] = useState('');
   const [otherReason, setOtherReason] = useState('');
   const [otherDestination, setOtherDestination] = useState('');
@@ -130,118 +131,165 @@ function LegalReleaseQuestions () {
         <Stack gap='xl'>
           <Stack gap={0}>
             <Text size='xl' c='dimmed'>Confirm legal release</Text>
-            <Title order={3}>Review the 849(b) and choose a release reason. After you confirm, it&apos;s sent to SFSO supervisors and can&apos;t be changed.</Title>
+            <Title order={3}>Review the 849(b) before continuing.</Title>
           </Stack>
 
-          <Stack gap='xs'>
-            <Text size='md' fz='md' c='dimmed'>849(b) narrative</Text>
-            {!isEditingNarrative && <Text size='md' fz='md' style={{ whiteSpace: 'pre-wrap' }}>{narrativeText}</Text>}
-            {isEditingNarrative && (
-              <Textarea
-                value={narrativeDraft}
-                onChange={(event) => setNarrativeDraft(event.currentTarget.value)}
-                minRows={6}
-                autosize
-              />
-            )}
-            {!isEditingNarrative && (
-              <Anchor onClick={() => setIsEditingNarrative(true)}>
-                Edit narrative
-              </Anchor>
-            )}
-            {isEditingNarrative && (
+          <Box bg='gray.1' p='md' radius='md'>
+            <Stack gap='md'>
+              <Stack gap={0}>
+                <Text size='md' fz='md' c='dimmed'>849(b) narrative</Text>
+                {!isEditingNarrative && <Text size='md' fz='md' style={{ whiteSpace: 'pre-wrap' }}>{narrativeText}</Text>}
+                {isEditingNarrative && (
+                  <Textarea
+                    value={narrativeDraft}
+                    onChange={(event) => setNarrativeDraft(event.currentTarget.value)}
+                    minRows={6}
+                    autosize
+                  />
+                )}
+              </Stack>
+
+              {!isEditingNarrative && (
+                !hasReviewedNarrative
+                  ? (
+                    <Stack gap='xs' align='flex-start'>
+                      <Button radius='xl' onClick={() => setHasReviewedNarrative(true)}>
+                        Mark as reviewed
+                      </Button>
+                      <Button variant='subtle' color='indigo' radius='xl' onClick={() => setIsEditingNarrative(true)}>
+                        Edit narrative
+                      </Button>
+                    </Stack>
+                    )
+                  : (
+                    <Group gap='xs'>
+                      <Button
+                        variant='secondary'
+                        radius='xl'
+                        leftSection={<IconCheck size={20} />}
+                        disabled
+                      >
+                        Reviewed
+                      </Button>
+                      <Button
+                        variant='subtle'
+                        color='indigo'
+                        radius='xl'
+                        leftSection={<IconArrowBackUp size={20} />}
+                        onClick={() => setHasReviewedNarrative(false)}
+                      >
+                        Undo review
+                      </Button>
+                    </Group>
+                    )
+              )}
+
+              {isEditingNarrative && (
+                <Group>
+                  <Button
+                    variant='secondary'
+                    onClick={() => {
+                      setNarrativeDraft(narrativeText);
+                      setIsEditingNarrative(false);
+                    }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button onClick={() => saveNarrativeMutation.mutate()} loading={saveNarrativeMutation.isPending}>
+                    Save narrative
+                  </Button>
+                </Group>
+              )}
+            </Stack>
+          </Box>
+
+          {hasReviewedNarrative && (
+            <>
+              <Stack gap='xl'>
+                <Title order={3}>Choose a release reason.</Title>
+                <Input.Wrapper label='Release reason' required>
+                  <Box mt='md'>
+                    <Chip.Group value={releaseReasonId} onChange={setReleaseReasonId}>
+                      <Stack gap='sm' align='flex-start'>
+                        <Chip value='sobered'>Can care for themselves</Chip>
+                        <Chip value='medical_issue'>Medical issue</Chip>
+                        <Chip value='other'>Other (please specify)</Chip>
+                      </Stack>
+                    </Chip.Group>
+                  </Box>
+                </Input.Wrapper>
+                {isMedicalRelease && (
+                  <>
+                    <Text size='md' c='dimmed'>
+                      This &lsquo;Medical issue&rsquo; release will also mark the person as exited from RESET
+                    </Text>
+                    <Input.Wrapper label='Exit destination' required>
+                      <Chip.Group value={exitDestinationId} onChange={setExitDestinationId}>
+                        <Group gap='sm'>
+                          <Chip value='hospital'>Hospital</Chip>
+                          <Chip value='other'>Other</Chip>
+                        </Group>
+                      </Chip.Group>
+                    </Input.Wrapper>
+                  </>
+                )}
+                {isOtherRelease && (
+                  <>
+                    <Textarea
+                      label='Other release reason'
+                      required
+                      value={otherReason}
+                      onChange={(event) => setOtherReason(event.currentTarget.value)}
+                      minRows={1}
+                      placeholder='For example: Facility emergency'
+                    />
+                    <Textarea
+                      label='Other release destination'
+                      required
+                      value={otherDestination}
+                      onChange={(event) => setOtherDestination(event.currentTarget.value)}
+                      minRows={1}
+                      placeholder='For example: Alternate care site'
+                    />
+                    <Text size='md' c='dimmed'>
+                      For &ldquo;Other&rdquo;, add a reason and destination. This release will also mark the person as exited from RESET.
+                    </Text>
+                  </>
+                )}
+              </Stack>
+
+              <Group gap='md' wrap='nowrap' align='flex-start'>
+                <IconAlertCircle size={24} color='var(--mantine-color-indigo-6)' stroke={1.75} />
+                <Text size='md'>When you confirm release, the 849(b) will be sent to SFSO supervisors.</Text>
+              </Group>
+
               <Group>
-                <Button
-                  variant='secondary'
-                  onClick={() => {
-                    setNarrativeDraft(narrativeText);
-                    setIsEditingNarrative(false);
-                  }}
-                >
+                <Button variant='destructive' onClick={() => navigate(backTo)}>
                   Cancel
                 </Button>
-                <Button onClick={() => saveNarrativeMutation.mutate()} loading={saveNarrativeMutation.isPending}>
-                  Save narrative
+                <Button
+                  onClick={() => {
+                    if (isEditingNarrative) {
+                      saveNarrativeMutation.mutate(undefined, {
+                        onSuccess: () => releaseMutation.mutate(),
+                      });
+                      return;
+                    }
+                    releaseMutation.mutate();
+                  }}
+                  loading={releaseMutation.isPending || saveNarrativeMutation.isPending}
+                  disabled={
+                    !releaseReasonId ||
+                    (releaseReasonId === 'medical_issue' && !exitDestinationId) ||
+                    (releaseReasonId === 'other' && (!otherReason.trim() || !otherDestination.trim())) ||
+                    (releaseReasonId !== 'sobered' && releaseReasonId !== 'medical_issue' && releaseReasonId !== 'other')
+                  }
+                >
+                  {isExitRelease ? 'Confirm release and exit' : 'Confirm release'}
                 </Button>
               </Group>
-            )}
-          </Stack>
-
-          <Stack gap='xl'>
-            <Input.Wrapper label='Release reason' required>
-              <Chip.Group value={releaseReasonId} onChange={setReleaseReasonId}>
-                <Group gap='sm'>
-                  <Chip value='sobered'>Can care for themselves</Chip>
-                  <Chip value='medical_issue'>Medical issue</Chip>
-                  <Chip value='other'>Other (please specify)</Chip>
-                </Group>
-              </Chip.Group>
-            </Input.Wrapper>
-            {isMedicalRelease && (
-              <>
-                <Text size='md' c='dimmed'>
-                  This &lsquo;Medical issue&rsquo; release will also mark the person as exited from RESET
-                </Text>
-                <Input.Wrapper label='Exit destination' required>
-                  <Chip.Group value={exitDestinationId} onChange={setExitDestinationId}>
-                    <Group gap='sm'>
-                      <Chip value='hospital'>Hospital</Chip>
-                      <Chip value='other'>Other</Chip>
-                    </Group>
-                  </Chip.Group>
-                </Input.Wrapper>
-              </>
-            )}
-            {isOtherRelease && (
-              <>
-                <Textarea
-                  label='Other release reason'
-                  required
-                  value={otherReason}
-                  onChange={(event) => setOtherReason(event.currentTarget.value)}
-                  minRows={1}
-                  placeholder='For example: Facility emergency'
-                />
-                <Textarea
-                  label='Other release destination'
-                  required
-                  value={otherDestination}
-                  onChange={(event) => setOtherDestination(event.currentTarget.value)}
-                  minRows={1}
-                  placeholder='For example: Alternate care site'
-                />
-                <Text size='md' c='dimmed'>
-                  For &ldquo;Other&rdquo;, add a reason and destination. This release will also mark the person as exited from RESET.
-                </Text>
-              </>
-            )}
-          </Stack>
-
-          <Group>
-            <Button variant='destructive' onClick={() => navigate(backTo)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
-                if (isEditingNarrative) {
-                  saveNarrativeMutation.mutate(undefined, {
-                    onSuccess: () => releaseMutation.mutate(),
-                  });
-                  return;
-                }
-                releaseMutation.mutate();
-              }}
-              loading={releaseMutation.isPending || saveNarrativeMutation.isPending}
-              disabled={
-                !releaseReasonId ||
-                (releaseReasonId === 'medical_issue' && !exitDestinationId) ||
-                (releaseReasonId === 'other' && (!otherReason.trim() || !otherDestination.trim())) ||
-                (releaseReasonId !== 'sobered' && releaseReasonId !== 'medical_issue' && releaseReasonId !== 'other')
-              }
-            >
-              {isExitRelease ? 'Confirm release and exit' : 'Confirm release'}
-            </Button>
-          </Group>
+            </>
+          )}
           <Box h={8} />
         </Stack>
       </Container>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
-import { Box, Button, Chip, Container, Group, Input, Stack, Text, Textarea, Title } from '@mantine/core';
+import { Box, Card, Button, Chip, Container, Group, Input, Stack, Text, Textarea, Title } from '@mantine/core';
 import { Head } from '@unhead/react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -134,7 +134,7 @@ function LegalReleaseQuestions () {
             <Title order={3}>Review the 849(b) before continuing.</Title>
           </Stack>
 
-          <Box bg='gray.1' p='md' radius='md'>
+          <Card bg='gray.1' p='md' radius='md'>
             <Stack gap='md'>
               <Stack gap={0}>
                 <Text size='md' fz='md' c='dimmed'>849(b) narrative</Text>
@@ -201,7 +201,7 @@ function LegalReleaseQuestions () {
                 </Group>
               )}
             </Stack>
-          </Box>
+          </Card>
 
           {hasReviewedNarrative && (
             <>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import LegalReleaseQuestions from './LegalReleaseQuestions';
+
+const {
+  mockNavigate,
+  mockShowToast,
+  mockDeflectionGet,
+  mockDeflectionRelease,
+  mockDeflectionUpdate,
+  mockIncidentGet,
+} = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockShowToast: vi.fn(),
+  mockDeflectionGet: vi.fn(),
+  mockDeflectionRelease: vi.fn(),
+  mockDeflectionUpdate: vi.fn(),
+  mockIncidentGet: vi.fn(),
+}));
+
+vi.mock('@/Api', () => ({
+  default: {
+    deflections: {
+      get: mockDeflectionGet,
+      release: mockDeflectionRelease,
+      update: mockDeflectionUpdate,
+    },
+    incidents: {
+      get: mockIncidentGet,
+    },
+  },
+}));
+
+vi.mock('react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useParams: () => ({ id: '123' }),
+  useSearchParams: () => [new URLSearchParams()],
+}));
+
+vi.mock('@unhead/react', () => ({
+  Head: ({ children }) => <>{children}</>,
+}));
+
+vi.mock('@/components/Header', () => ({
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/IconButtonLink', () => ({
+  default: () => <button type='button'>Back</button>,
+}));
+
+vi.mock('@/components/ToastContext', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+  }),
+}));
+
+vi.mock('../../../hooks/useEnsureReleaseNarrative', () => ({
+  default: () => 'Narrative text for the 849(b).',
+}));
+
+function renderPage () {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <LegalReleaseQuestions />
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}
+
+describe('LegalReleaseQuestions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockDeflectionGet.mockResolvedValue({
+      data: {
+        id: '123',
+        incidentId: 'incident-1',
+      },
+    });
+    mockIncidentGet.mockResolvedValue({
+      data: {
+        id: 'incident-1',
+      },
+    });
+    mockDeflectionRelease.mockResolvedValue({ data: {} });
+    mockDeflectionUpdate.mockResolvedValue({ data: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('hides the release reason and final actions until the narrative is reviewed', async () => {
+    renderPage();
+
+    expect(await screen.findByText('Narrative text for the 849(b).')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mark as reviewed' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit narrative' })).toBeInTheDocument();
+    expect(screen.queryByText('Release reason')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Confirm release' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
+  });
+
+  it('shows the release reason section after review and restores the initial state on undo', async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+
+    expect(screen.getByRole('button', { name: 'Reviewed' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Undo review' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit narrative' })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Choose a release reason.' })).toBeInTheDocument();
+    expect(screen.getByText('Release reason')).toBeInTheDocument();
+    expect(screen.getByText('When you confirm release, the 849(b) will be sent to SFSO supervisors.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm release' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo review' }));
+
+    expect(screen.getByRole('button', { name: 'Mark as reviewed' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit narrative' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Undo review' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Release reason')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Confirm release' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- updates the Confirm legal release screen to gate release reasons behind an explicit 849(b) narrative review step
- restyles the narrative section to match the Figma flow, including reviewed and undo-review states
- adds targeted screen tests for the reviewed/unreviewed UI behavior

(See [Figma designs](https://www.figma.com/design/Q8kS4FJXh1TbbM8eDR7Z6Y/CareConnect?node-id=7952-72860&m=dev) for changes reference)

## Detail
- groups the 849(b) narrative inside a gray card
- shows `Mark as reviewed` first, with `Edit narrative` stacked below it
- hides the release reason section and final action buttons until the narrative is marked reviewed
- after review, swaps the actions to `Reviewed` and `Undo review`, hide `Edit narrative`, and reveal:
  - `Choose a release reason.`
  - the existing release reason options
  - the SFSO supervisor info message with the matching alert icon treatment
  - the cancel / confirm actions
- stack release reason chips vertically and adjust spacing to match design intent (Figma says padding-sm and spacing-sm, but this always looks too tight in reality; adjusted to -md)

Closes #605 