### PR TITLE
View substance use, edit PII, for care users (#458, #124, #670)

### DIFF
--- a/client/src/lesc/components/care/CareSubjectForm.jsx
+++ b/client/src/lesc/components/care/CareSubjectForm.jsx
@@ -1,0 +1,202 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router';
+import { Head } from '@unhead/react';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { Button, Container, Fieldset, Group, Stack, Text, TextInput, Title } from '@mantine/core';
+import { useForm } from '@mantine/form';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { DateTime } from 'luxon';
+import { useTranslation } from 'react-i18next';
+
+import Api from '@/Api';
+import ChipInput from '@/components/ChipInput';
+import Header from '@/components/Header';
+import IconButtonLink from '@/components/IconButtonLink';
+import { useToast } from '@/components/ToastContext';
+import { formatInputDob } from '@/utils/format';
+
+const initialValues = {
+  firstName: '',
+  lastName: '',
+  middleInitial: '',
+  dateOfBirth: '',
+  sex: '',
+  race: '',
+  driverLicense: '',
+};
+
+function normalizeText (value) {
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+}
+
+function validateCareSubject (values, dobInput) {
+  const errors = {};
+  const parsedDob = DateTime.fromFormat(dobInput.trim(), 'MM/dd/yyyy', { zone: 'local' });
+
+  if (!values.firstName?.trim()) errors.firstName = 'This field is required';
+  if (!values.lastName?.trim()) errors.lastName = 'This field is required';
+  if (!dobInput.trim() || !parsedDob.isValid) errors.dateOfBirth = 'Enter a valid date';
+  if (!values.sex) errors.sex = 'Select one';
+  if (!values.race) errors.race = 'Select one';
+
+  return errors;
+}
+
+function CareSubjectForm () {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const { t } = useTranslation();
+  const [dobInput, setDobInput] = useState('');
+
+  const form = useForm({
+    mode: 'controlled',
+    initialValues,
+    validate: (values) => validateCareSubject(values, dobInput),
+  });
+
+  const { data: deflection, isLoading } = useQuery({
+    queryKey: ['deflections', id],
+    queryFn: () => Api.deflections.get(id).then(response => response.data),
+  });
+
+  useEffect(() => {
+    if (isLoading || form.initialized) return;
+
+    const subject = deflection?.subject ?? {};
+    const dateOfBirth = subject.dateOfBirth
+      ? DateTime.fromISO(subject.dateOfBirth, { setZone: true }).toFormat('MM/dd/yyyy')
+      : '';
+
+    setDobInput(dateOfBirth);
+    form.initialize({
+      ...initialValues,
+      firstName: subject.firstName ?? '',
+      lastName: subject.lastName ?? '',
+      middleInitial: subject.middleInitial ?? '',
+      dateOfBirth,
+      sex: subject.sex ?? '',
+      race: subject.race ?? '',
+      driverLicense: subject.driverLicense ?? '',
+    });
+  }, [deflection, form, form.initialized, isLoading]);
+
+  const updateSubjectMutation = useMutation({
+    mutationFn: (values) => {
+      const parsedDob = DateTime.fromFormat(dobInput.trim(), 'MM/dd/yyyy', { zone: 'local' });
+      return Api.deflections.subject(id, {
+        firstName: normalizeText(values.firstName),
+        lastName: normalizeText(values.lastName),
+        middleInitial: normalizeText(values.middleInitial),
+        dateOfBirth: parsedDob.isValid ? parsedDob.toISO() : null,
+        sex: values.sex || null,
+        race: values.race || null,
+        driverLicense: normalizeText(values.driverLicense),
+        narcoticsSubstance: deflection?.narcoticsSubstance ?? null,
+        narcoticsParaphernalia: deflection?.narcoticsParaphernalia ?? null,
+        drugUseEvidence: deflection?.drugUseEvidence ?? null,
+        drugType: deflection?.drugUseEvidence === true ? deflection?.drugType ?? null : null,
+      });
+    },
+    onSuccess: (response) => {
+      queryClient.setQueryData(['deflections', id], response.data);
+      queryClient.setQueryData(['deflections', Number(id)], response.data);
+      queryClient.invalidateQueries({ queryKey: ['deflections'] });
+      showToast('Details updated', 'success', 4000, 'Changes were saved successfully.');
+      navigate(`/care/${id}`);
+    },
+    onError: () => {
+      showToast('Details not updated', 'error', 4000, 'Changes were not saved. Please try again.');
+      navigate(`/care/${id}`);
+    },
+  });
+
+  return (
+    <>
+      <Head>
+        <title>Edit Care Details</title>
+      </Head>
+      <Header>
+        <IconButtonLink icon={IconArrowLeft} to={`/care/${id}`} />
+      </Header>
+      <Container>
+        <Stack gap='xl'>
+          <Stack gap={0}>
+            <Text c='dimmed' size='xl'>Edit details</Text>
+            <Title order={3}>Update client identity details.</Title>
+          </Stack>
+          <form onSubmit={form.onSubmit((values) => updateSubjectMutation.mutate(values))}>
+            <Fieldset disabled={isLoading || updateSubjectMutation.isPending} variant='unstyled'>
+              <Stack gap='xl'>
+                <TextInput
+                  key={form.key('firstName')}
+                  label={<>First name<span>*</span></>}
+                  placeholder='Enter first name'
+                  {...form.getInputProps('firstName')}
+                />
+                <TextInput
+                  key={form.key('lastName')}
+                  label={<>Last name<span>*</span></>}
+                  placeholder='Enter last name'
+                  {...form.getInputProps('lastName')}
+                />
+                <TextInput
+                  key={form.key('middleInitial')}
+                  label='Middle initial (optional)'
+                  placeholder='Optional'
+                  {...form.getInputProps('middleInitial')}
+                />
+                <TextInput
+                  label={<>Date of birth<span>*</span></>}
+                  type='text'
+                  inputMode='numeric'
+                  maxLength={10}
+                  placeholder='MM/DD/YYYY'
+                  {...form.getInputProps('dateOfBirth')}
+                  value={dobInput}
+                  onChange={(event) => {
+                    const formatted = formatInputDob(event.currentTarget.value);
+                    setDobInput(formatted);
+                    form.setFieldValue('dateOfBirth', formatted);
+                  }}
+                />
+                <ChipInput
+                  label={<>Sex<span>*</span></>}
+                  options={['MALE', 'FEMALE', 'OTHER', 'UNKNOWN'].map((sex) => ({
+                    value: sex,
+                    label: t(`sex.${sex}`),
+                  }))}
+                  {...form.getInputProps('sex')}
+                  key={form.key('sex')}
+                />
+                <ChipInput
+                  label={<>Race<span>*</span></>}
+                  options={['WHITE', 'BLACK', 'HISPANIC', 'ASIAN', 'OTHER', 'UNKNOWN'].map((race) => ({
+                    value: race,
+                    label: t(`race.${race}`),
+                  }))}
+                  {...form.getInputProps('race')}
+                  key={form.key('race')}
+                />
+                <TextInput
+                  key={form.key('driverLicense')}
+                  label="Driver's license number (optional)"
+                  placeholder='Optional'
+                  {...form.getInputProps('driverLicense')}
+                />
+                <Group>
+                  <Button variant='destructive' onClick={() => navigate(`/care/${id}`)}>Cancel</Button>
+                  <Button type='submit' loading={updateSubjectMutation.isPending}>Save changes</Button>
+                </Group>
+              </Stack>
+            </Fieldset>
+          </form>
+        </Stack>
+      </Container>
+    </>
+  );
+}
+
+export default CareSubjectForm;

--- a/client/src/lesc/components/care/CareSubjectForm.test.jsx
+++ b/client/src/lesc/components/care/CareSubjectForm.test.jsx
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import CareSubjectForm from './CareSubjectForm';
+
+const { mockGet, mockSubject, mockNavigate, mockShowToast } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSubject: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockShowToast: vi.fn(),
+}));
+
+vi.mock('@/Api', () => ({
+  default: {
+    deflections: {
+      get: mockGet,
+      subject: mockSubject,
+    },
+  },
+}));
+
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: () => ({ id: '123' }),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key) => key,
+  }),
+}));
+
+vi.mock('@/components/ToastContext', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+  }),
+}));
+
+vi.mock('@/components/Header', () => ({
+  default: ({ children }) => <div>{children}</div>,
+}));
+
+vi.mock('@/components/IconButtonLink', () => ({
+  default: () => <a href='/care/123'>back</a>,
+}));
+
+vi.mock('@unhead/react', () => ({
+  Head: ({ children }) => <>{children}</>,
+}));
+
+function buildDeflection (overrides = {}) {
+  return {
+    id: 123,
+    narcoticsSubstance: true,
+    narcoticsParaphernalia: false,
+    drugUseEvidence: true,
+    drugType: 'ALCOHOL',
+    subject: {
+      firstName: 'Marcus',
+      lastName: 'Hill',
+      middleInitial: 'J',
+      dateOfBirth: '1990-01-01T00:00:00.000Z',
+      sex: 'MALE',
+      race: 'WHITE',
+      driverLicense: 'D3478215',
+    },
+    ...overrides,
+  };
+}
+
+function renderForm () {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <CareSubjectForm />
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGet.mockResolvedValue({ data: buildDeflection() });
+  mockSubject.mockResolvedValue({ data: buildDeflection({ subject: { ...buildDeflection().subject, firstName: 'Mara' } }) });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('CareSubjectForm', () => {
+  it('saves care-editable personal details while preserving substance fields', async () => {
+    renderForm();
+
+    const firstName = await screen.findByDisplayValue('Marcus');
+    fireEvent.change(firstName, { target: { value: 'Mara' } });
+    fireEvent.change(screen.getByDisplayValue('D3478215'), { target: { value: 'D000111' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(mockSubject).toHaveBeenCalledWith('123', expect.objectContaining({
+        firstName: 'Mara',
+        lastName: 'Hill',
+        middleInitial: 'J',
+        sex: 'MALE',
+        race: 'WHITE',
+        driverLicense: 'D000111',
+        narcoticsSubstance: true,
+        narcoticsParaphernalia: false,
+        drugUseEvidence: true,
+        drugType: 'ALCOHOL',
+      }));
+    });
+    expect(mockShowToast).toHaveBeenCalledWith(
+      'Details updated',
+      'success',
+      4000,
+      'Changes were saved successfully.'
+    );
+    expect(mockNavigate).toHaveBeenCalledWith('/care/123');
+  });
+
+  it('returns to care details and shows a failure toast when save fails', async () => {
+    mockSubject.mockRejectedValueOnce(new Error('Save failed'));
+    renderForm();
+
+    await screen.findByDisplayValue('Marcus');
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Details not updated',
+        'error',
+        4000,
+        'Changes were not saved. Please try again.'
+      );
+    });
+    expect(mockNavigate).toHaveBeenCalledWith('/care/123');
+  });
+});

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -70,6 +70,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   const careStatusChip = getCareStatusChip({ deflection, careFooterState });
   const releaseTimingChip = releaseTiming(deflection);
   const propertyReturnStatusText = getPropertyReturnStatusText(deflection);
+  const hasDrugUseEvidence = deflection?.drugUseEvidence !== null && deflection?.drugUseEvidence !== undefined;
 
   function navigateToHospitalReleaseFlow () {
     navigate(`/custody/${deflection.id}/legal-release?from=detail&releaseReasonId=medical_issue&exitDestinationId=hospital`);
@@ -174,7 +175,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   });
 
   const name = [deflection?.subject?.firstName, deflection?.subject?.middleInitial, deflection?.subject?.lastName].filter(Boolean).join(' ') || 'Unknown person';
-  const careDisplayName = [deflection?.subject?.firstName, deflection?.subject?.lastName].filter(Boolean).join(' ') || 'Unknown person';
+  const careDisplayName = [deflection?.subject?.firstName, deflection?.subject?.middleInitial, deflection?.subject?.lastName].filter(Boolean).join(' ') || 'Unknown person';
   const address = formatAddress(deflection?.subject ?? {});
   const [releaseNarrative, setReleaseNarrative] = useState('');
   const [isEditingReleaseNarrative, setIsEditingReleaseNarrative] = useState(false);
@@ -301,7 +302,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
             )}
             {deflection?.subject?.sex && (
               <Box>
-                <Text c='dimmed'>{isCareView ? 'Gender' : 'Sex'}</Text>
+                <Text c='dimmed'>Sex</Text>
                 <Text>{t(`sex.${deflection.subject.sex}`)}</Text>
               </Box>
             )}
@@ -311,7 +312,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                 <Text>{t(`race.${deflection.subject.race}`)}</Text>
               </Box>
             )}
-            {!isCareView && deflection?.subject?.driverLicense && (
+            {deflection?.subject?.driverLicense && (
               <Box>
                 <Text c='dimmed'>Driver's license number</Text>
                 <Text>{deflection.subject.driverLicense}</Text>
@@ -328,7 +329,30 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                 <Button variant='secondary' size='md' onClick={() => navigate(`/custody/${deflection?.id}/subject`)}>Edit</Button>
               </Group>
             )}
+            {isCareView && (
+              <Group mt='md'>
+                <Button variant='secondary' size='md' onClick={() => navigate(`/care/${deflection?.id}/subject`)}>Edit</Button>
+              </Group>
+            )}
           </Stack>
+          {isCareView && hasDrugUseEvidence && (
+            <>
+              <Divider />
+              <Stack gap='sm'>
+                <Title order={3}>Substance-related details</Title>
+                <Box>
+                  <Text c='dimmed'>Signs of substance use</Text>
+                  <Text>{deflection.drugUseEvidence ? 'Yes' : 'No'}</Text>
+                </Box>
+                {deflection.drugUseEvidence === true && deflection?.drugType && (
+                  <Box>
+                    <Text c='dimmed'>Substance used (suspected)</Text>
+                    <Text>{t(`drugType.${deflection.drugType}`)}</Text>
+                  </Box>
+                )}
+              </Stack>
+            </>
+          )}
           {!isCareView && (
             <>
               <Accordion
@@ -340,31 +364,31 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                 <Divider />
                 <Accordion.Item value='substance'>
                   <Accordion.Control>
-                    <Title order={3}>Substance details</Title>
+                    <Title order={3}>Substance-related details</Title>
                   </Accordion.Control>
                   <Accordion.Panel>
                     <Stack gap='sm'>
                       {deflection?.narcoticsSubstance !== null && deflection?.narcoticsSubstance !== undefined && (
                         <Box>
                           <Text c='dimmed'>Controlled substance found</Text>
-                          <Text c={deflection.narcoticsSubstance ? 'red.6' : 'teal.6'}>{deflection.narcoticsSubstance ? 'Yes' : 'No'}</Text>
+                          <Text>{deflection.narcoticsSubstance ? 'Yes' : 'No'}</Text>
                         </Box>
                       )}
                       {deflection?.narcoticsParaphernalia !== null && deflection?.narcoticsParaphernalia !== undefined && (
                         <Box>
                           <Text c='dimmed'>Paraphernalia found</Text>
-                          <Text c={deflection.narcoticsParaphernalia ? 'red.6' : 'teal.6'}>{deflection.narcoticsParaphernalia ? 'Yes' : 'No'}</Text>
+                          <Text>{deflection.narcoticsParaphernalia ? 'Yes' : 'No'}</Text>
                         </Box>
                       )}
-                      {deflection?.drugUseEvidence !== null && deflection?.drugUseEvidence !== undefined && (
+                      {hasDrugUseEvidence && (
                         <Box>
                           <Text c='dimmed'>Signs of substance use</Text>
-                          <Text c={deflection.drugUseEvidence ? 'red.6' : 'teal.6'}>{deflection.drugUseEvidence ? 'Yes' : 'No'}</Text>
+                          <Text>{deflection.drugUseEvidence ? 'Yes' : 'No'}</Text>
                         </Box>
                       )}
                       {deflection?.drugUseEvidence === true && deflection?.drugType && (
                         <Box>
-                          <Text c='dimmed'>Substance used</Text>
+                          <Text c='dimmed'>Substance used (suspected)</Text>
                           <Text>{t(`drugType.${deflection.drugType}`)}</Text>
                         </Box>
                       )}

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -187,13 +187,14 @@ describe('CustodyDetailContent', () => {
     CustodyDetailContent = (await import('./CustodyDetailContent')).default;
     AuthContextProvider = (await import('../../../AuthContextProvider')).default;
 
-    render = (deflectionOverride = {}) => {
+    render = (deflectionOverride = {}, propsOverride = {}) => {
       const content = h(CustodyDetailContent, {
         deflection: {
           ...deflection,
           ...deflectionOverride,
         },
-        backTo: '/custody'
+        backTo: propsOverride.viewerMode === 'care' ? '/care' : '/custody',
+        ...propsOverride,
       });
       const provider = h(AuthContextProvider, null, content);
       return renderToStaticMarkup(provider);
@@ -211,6 +212,8 @@ describe('CustodyDetailContent', () => {
     propertyPhotos: [],
     narcoticsSubstance: false,
     narcoticsParaphernalia: false,
+    drugUseEvidence: false,
+    drugType: null,
     subject: {
       firstName: 'Test',
       lastName: 'Person',
@@ -240,6 +243,7 @@ describe('CustodyDetailContent', () => {
     expect(html).toContain('Intake staff can scan this code to start full intake.');
     expect(html).toContain('Legal release');
     expect(html).toContain('Behavioral observations');
+    expect(html).toContain('Substance-related details');
     expect(html).toContain('Property details');
     expect(html).toContain('Incident details');
     expect(html).toContain('CASE-456');
@@ -268,5 +272,31 @@ describe('CustodyDetailContent', () => {
 
     expect(html).not.toContain('Exit to hospital');
     expect(html).not.toContain('Record exit to hospital');
+  });
+
+  it('shows drug use status and selected drug type in care personal details', () => {
+    const html = render(
+      { subjectStatus: 'ADMITTED', drugUseEvidence: true, drugType: 'ALCOHOL' },
+      { viewerMode: 'care' }
+    );
+
+    expect(html).toContain('Edit');
+    expect(html).toContain('Substance-related details');
+    expect(html).toContain('Signs of substance use');
+    expect(html).toContain('Yes');
+    expect(html).toContain('Substance used (suspected)');
+    expect(html).toContain('drugType.ALCOHOL');
+  });
+
+  it('shows no drug use status without a drug type in care personal details', () => {
+    const html = render(
+      { subjectStatus: 'ADMITTED', drugUseEvidence: false, drugType: null },
+      { viewerMode: 'care' }
+    );
+
+    expect(html).toContain('Substance-related details');
+    expect(html).toContain('Signs of substance use');
+    expect(html).toContain('No');
+    expect(html).not.toContain('Substance used (suspected)');
   });
 });

--- a/client/src/lesc/routes/LESCRoutes.jsx
+++ b/client/src/lesc/routes/LESCRoutes.jsx
@@ -5,6 +5,7 @@ import { getDefaultPathForUser } from '@/AppRedirectsConfig';
 import Holds from '../components/Holds';
 import Care from '../components/care/Care';
 import CareExitDetails from '../components/care/CareExitDetails';
+import CareSubjectForm from '../components/care/CareSubjectForm';
 import Custody from '../components/custody/Custody';
 import CustodyDetail from '../components/custody/CustodyDetail';
 import LegalReleaseQuestions from '../components/custody/LegalReleaseQuestions';
@@ -39,6 +40,7 @@ function LESCRoutes () {
       <Route path='custody/:id' element={<CustodyDetail />} />
       <Route path='custody' element={<Custody />} />
       <Route path='care/:id' element={<CustodyDetail viewerMode='care' />} />
+      <Route path='care/:id/subject' element={<CareSubjectForm />} />
       <Route path='care/:id/exit' element={<CareExitDetails />} />
       <Route path='care' element={<Care />} />
       <Route path='manage-capacity' element={<ManageCapacity />} />

--- a/server/lib/deflectionVisibility.js
+++ b/server/lib/deflectionVisibility.js
@@ -1,9 +1,11 @@
 const CARE_ALLOWED_SUBJECT_FIELDS = new Set([
   'firstName',
   'lastName',
+  'middleInitial',
   'dateOfBirth',
   'sex',
   'race',
+  'driverLicense',
   // These are model-required metadata fields; keep them stable for existing response contracts.
   'id',
   'createdAt',

--- a/server/routes/api/deflections/subject.js
+++ b/server/routes/api/deflections/subject.js
@@ -8,6 +8,16 @@ import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { canModifyDeflection } from '#lib/incidentPermissions.js';
 import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
 
+const CARE_EDITABLE_SUBJECT_FIELDS = [
+  'firstName',
+  'lastName',
+  'middleInitial',
+  'dateOfBirth',
+  'sex',
+  'race',
+  'driverLicense',
+];
+
 export default async function (fastify, opts) {
   fastify.put('/:id/subject',
     {
@@ -39,22 +49,39 @@ export default async function (fastify, opts) {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      if (!canModifyDeflection(deflection, request.user)) {
+      const canModifyFullDeflection = canModifyDeflection(deflection, request.user);
+      const isCareSubjectEdit = request.user.isCare && !canModifyFullDeflection;
+
+      if (!canModifyFullDeflection && !isCareSubjectEdit) {
         return reply.code(StatusCodes.FORBIDDEN).send();
       }
 
-      const subjectData = { ...data };
-      delete subjectData.narcoticsSubstance;
-      delete subjectData.narcoticsParaphernalia;
-      delete subjectData.drugUseEvidence;
-      delete subjectData.drugType;
+      const subjectData = isCareSubjectEdit
+        ? Object.fromEntries(CARE_EDITABLE_SUBJECT_FIELDS
+          .filter(field => Object.hasOwn(data, field))
+          .map(field => [field, data[field]]))
+        : { ...data };
 
-      const deflectionData = {
-        narcoticsSubstance: data.narcoticsSubstance ?? null,
-        narcoticsParaphernalia: data.narcoticsParaphernalia ?? null,
-        drugUseEvidence: data.drugUseEvidence ?? null,
-        drugType: data.drugUseEvidence === true ? data.drugType ?? null : null,
-      };
+      if (!isCareSubjectEdit) {
+        delete subjectData.narcoticsSubstance;
+        delete subjectData.narcoticsParaphernalia;
+        delete subjectData.drugUseEvidence;
+        delete subjectData.drugType;
+      }
+
+      const deflectionData = isCareSubjectEdit
+        ? {
+            narcoticsSubstance: deflection.narcoticsSubstance,
+            narcoticsParaphernalia: deflection.narcoticsParaphernalia,
+            drugUseEvidence: deflection.drugUseEvidence,
+            drugType: deflection.drugUseEvidence === true ? deflection.drugType ?? null : null,
+          }
+        : {
+            narcoticsSubstance: data.narcoticsSubstance ?? null,
+            narcoticsParaphernalia: data.narcoticsParaphernalia ?? null,
+            drugUseEvidence: data.drugUseEvidence ?? null,
+            drugType: data.drugUseEvidence === true ? data.drugType ?? null : null,
+          };
 
       await fastify.prisma.$transaction(async (tx) => {
         if (!deflection.subjectId) {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -6,8 +6,6 @@ import { authenticate, build } from '#test/helper.js';
 
 function assertCareSubjectRedaction (subject) {
   assert.ok(subject);
-  assert.strictEqual(subject.middleInitial, null);
-  assert.strictEqual(subject.driverLicense, null);
   assert.strictEqual(subject.addressLine1, null);
   assert.strictEqual(subject.addressLine2, null);
   assert.strictEqual(subject.city, null);
@@ -113,9 +111,11 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(data.length, 1);
       assert.deepStrictEqual(data[0].subject.firstName, 'Test');
       assert.deepStrictEqual(data[0].subject.lastName, 'Client3');
+      assert.deepStrictEqual(data[0].subject.middleInitial, 'T');
       assert.ok(data[0].subject.dateOfBirth);
       assert.deepStrictEqual(data[0].subject.sex, 'FEMALE');
       assert.deepStrictEqual(data[0].subject.race, 'HISPANIC');
+      assert.deepStrictEqual(data[0].subject.driverLicense, 'DL789');
       assertCareSubjectRedaction(data[0].subject);
     });
 
@@ -148,8 +148,10 @@ test('/api/deflections', async (t) => {
       const data = JSON.parse(response.body);
       assert.deepStrictEqual(data.subject.firstName, 'Test');
       assert.deepStrictEqual(data.subject.lastName, 'Client');
+      assert.deepStrictEqual(data.subject.middleInitial, 'T');
       assert.deepStrictEqual(data.subject.sex, 'MALE');
       assert.deepStrictEqual(data.subject.race, 'WHITE');
+      assert.deepStrictEqual(data.subject.driverLicense, 'DL123');
       assertCareSubjectRedaction(data.subject);
     });
 
@@ -932,6 +934,75 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(deflection.narcoticsParaphernalia, true);
       assert.deepStrictEqual(deflection.drugUseEvidence, false);
       assert.deepStrictEqual(deflection.drugType, null);
+    });
+
+    await t.test('allows care users to update only care-editable personal details', async () => {
+      await prisma.deflection.update({
+        where: { id: 4 },
+        data: {
+          narcoticsSubstance: true,
+          narcoticsParaphernalia: true,
+          drugUseEvidence: true,
+          drugType: 'ALCOHOL',
+        },
+      });
+
+      const existingSubject = await prisma.subject.findUnique({
+        where: { id: 'a95b66ee-f5f3-4e59-87d8-b56afdfd7ab5' },
+      });
+
+      const response = await app.inject().put('/api/deflections/4/subject').payload({
+        firstName: 'Care',
+        lastName: 'Edited',
+        middleInitial: 'Q',
+        dateOfBirth: '1991-06-15',
+        sex: 'OTHER',
+        race: 'OTHER',
+        driverLicense: 'DL-CARE',
+        addressLine1: 'Should Not Change',
+        localId: 'SHOULD-NOT-CHANGE',
+        narcoticsSubstance: false,
+        narcoticsParaphernalia: false,
+        drugUseEvidence: false,
+        drugType: 'HEROIN',
+      }).headers(careUserHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.subject.firstName, 'Care');
+      assert.deepStrictEqual(data.subject.lastName, 'Edited');
+      assert.deepStrictEqual(data.subject.middleInitial, 'Q');
+      assert.deepStrictEqual(data.subject.dateOfBirth, '1991-06-15T00:00:00.000Z');
+      assert.deepStrictEqual(data.subject.sex, 'OTHER');
+      assert.deepStrictEqual(data.subject.race, 'OTHER');
+      assert.deepStrictEqual(data.subject.driverLicense, 'DL-CARE');
+      assert.deepStrictEqual(data.subject.addressLine1, null);
+      assert.deepStrictEqual(data.subject.localId, null);
+      assert.deepStrictEqual(data.narcoticsSubstance, true);
+      assert.deepStrictEqual(data.narcoticsParaphernalia, true);
+      assert.deepStrictEqual(data.drugUseEvidence, true);
+      assert.deepStrictEqual(data.drugType, 'ALCOHOL');
+
+      const subject = await prisma.subject.findUnique({
+        where: { id: 'a95b66ee-f5f3-4e59-87d8-b56afdfd7ab5' },
+      });
+      assert.deepStrictEqual(subject.firstName, 'Care');
+      assert.deepStrictEqual(subject.lastName, 'Edited');
+      assert.deepStrictEqual(subject.middleInitial, 'Q');
+      assert.deepStrictEqual(subject.dateOfBirth, new Date('1991-06-15T00:00:00.000Z'));
+      assert.deepStrictEqual(subject.sex, 'OTHER');
+      assert.deepStrictEqual(subject.race, 'OTHER');
+      assert.deepStrictEqual(subject.driverLicense, 'DL-CARE');
+      assert.deepStrictEqual(subject.addressLine1, existingSubject.addressLine1);
+      assert.deepStrictEqual(subject.localId, existingSubject.localId);
+
+      const deflection = await prisma.deflection.findUnique({
+        where: { id: 4 },
+      });
+      assert.deepStrictEqual(deflection.narcoticsSubstance, true);
+      assert.deepStrictEqual(deflection.narcoticsParaphernalia, true);
+      assert.deepStrictEqual(deflection.drugUseEvidence, true);
+      assert.deepStrictEqual(deflection.drugType, 'ALCOHOL');
     });
   });
 


### PR DESCRIPTION
## Summary

Allows medical staff to view substance-related details. Allows medical staff to edit (and save changes to) key PII. Addresses 3 different but related issues #458, #124, #670. 

## Details
- Added substance-use visibility to Care personal details:
  - Shows `Signs of substance use` as Yes/No.
  - Shows `Substance used (suspected)` when substance use is marked "Yes" and a drug type is present. Deviation from design slightly to adjust label.
- Updated custody/care personal detail copy:
  - Renamed `Substance details` to `Substance-related details`.
  - Renamed `Substance used` to `Substance used (suspected)`.
  - Removed red/teal coloring from custody Yes/No substance responses so they render as standard text.
- Added Care-user personal details editing:
  - Added `/care/:id/subject` route.
  - Added a Care-focused edit form for first name, last name, middle initial, DOB, sex, race, and driver’s license number.
  - Added an `Edit` button beneath Care personal details.
  - Shows success/failure toasts and returns to the standard Care details view after save.
- Updated backend behavior for Care users:
  - Allows Care users to update only the permitted PII subject fields.
  - Preserves substance/deflection fields server-side during Care edits.
  - Allows Care users to read middle initial and driver’s license while continuing to redact address/local ID fields.

## Notes
The `CareSubjectForm` has some duplication of `SubjectForm` which could be optimized - e.g., standardize the identity field block, create answer option constants, add payload helpers, etc. - but given the complexities of doing this right and the need to touch already well-validated `SubjectForm` code, I punted. 

Closes #458 
Closes #124 
Closes #670 