### PR TITLE
Correctly handles declined consent in schema (#436)

### DIFF
--- a/docs/SYNTHETIC_DATA_GUIDELINES.md
+++ b/docs/SYNTHETIC_DATA_GUIDELINES.md
@@ -340,7 +340,7 @@ Required (from `IN_CHAIR` or `RELEASED`):
 - `exitConnectedToCare`: `YES`, `NO`, or `UNKNOWN`
 - `exitSFResident`: `YES`, `NO`, `UNKNOWN`, or `DECLINED_CONSENT`
 
-Note: `DECLINED_CONSENT` is stored as `UNKNOWN` in the database.
+Note: `DECLINED_CONSENT` is stored distinctly in the database for SF residency.
 
 ### Exit to Jail (`/exit-to-jail`)
 Role required: `CUSTODY`
@@ -614,6 +614,7 @@ FacilityStatusEnum:   CLOSED | OPEN_NOT_ACCEPTING | OPEN_ACCEPTING
 FacilityTypeEnum:     DIDO | LESC
 BedTypeEnum:          BED | CHAIR
 TernaryEnum:          YES | NO | UNKNOWN
+SFResidentEnum:       YES | NO | UNKNOWN | DECLINED_CONSENT
 RoleEnum:             FIELD | CUSTODY | CARE
 SexEnum:              MALE | FEMALE | OTHER
 ```

--- a/server/models/deflection.js
+++ b/server/models/deflection.js
@@ -1,4 +1,4 @@
-import { Prisma, DrugTypeEnum, HoldStatusEnum, PropertyEnum, PropertyNotReturnedReasonEnum, SubjectStatusEnum, TernaryEnum } from '@prisma/client';
+import { Prisma, DrugTypeEnum, HoldStatusEnum, PropertyEnum, PropertyNotReturnedReasonEnum, SFResidentEnum, SubjectStatusEnum, TernaryEnum } from '@prisma/client';
 import { z } from 'zod';
 
 import Base from './base.js';
@@ -91,7 +91,7 @@ const DeflectionResponseSchema = DeflectionCreateSchema.extend({
   exitHousingStatusId: z.string().nullable(),
   exitHousingStatus: DeflectionExitHousingStatus.ResponseSchema.nullable().optional(),
   exitConnectedToCare: z.enum(Object.values(TernaryEnum)).nullable(),
-  exitSFResident: z.enum(Object.values(TernaryEnum)).nullable(),
+  exitSFResident: z.enum(Object.values(SFResidentEnum)).nullable(),
   currentOfficerId: z.string().uuid().nullable().optional(),
   createdById: z.string().uuid(),
   createdBy: User.ResponseSchema.optional(),
@@ -106,6 +106,7 @@ export class Deflection extends Base {
   static HoldStatus = HoldStatusEnum;
   static SubjectStatus = SubjectStatusEnum;
   static Ternary = TernaryEnum;
+  static SFResident = SFResidentEnum;
   static PropertyNotReturnedReason = PropertyNotReturnedReasonEnum;
 
   constructor (data) {

--- a/server/prisma/ERD.md
+++ b/server/prisma/ERD.md
@@ -16,6 +16,15 @@ UNKNOWN UNKNOWN
     
 
 
+        SFResidentEnum {
+            YES YES
+NO NO
+UNKNOWN UNKNOWN
+DECLINED_CONSENT DECLINED_CONSENT
+        }
+    
+
+
         FacilityTypeEnum {
             DIDO DIDO
 LESC LESC
@@ -456,7 +465,7 @@ DEATH_IN_CUSTODY DEATH_IN_CUSTODY
     String exitDestinationId "❓"
     String exitHousingStatusId "❓"
     TernaryEnum exitConnectedToCare "❓"
-    TernaryEnum exitSFResident "❓"
+    SFResidentEnum exitSFResident "❓"
     DateTime handoffReadyAt "❓"
     DateTime updatedAt 
     }
@@ -480,7 +489,7 @@ DEATH_IN_CUSTODY DEATH_IN_CUSTODY
     String exitDestinationId "❓"
     String exitHousingStatusId "❓"
     TernaryEnum exitConnectedToCare "❓"
-    TernaryEnum exitSFResident "❓"
+    SFResidentEnum exitSFResident "❓"
     DateTime updatedAt 
     String updatedById 
     }
@@ -762,7 +771,7 @@ DEATH_IN_CUSTODY DEATH_IN_CUSTODY
     "Deflection" o|--|o "DeflectionExitDestination" : "exitDestination"
     "Deflection" o|--|o "DeflectionExitHousingStatus" : "exitHousingStatus"
     "Deflection" o|--|o "TernaryEnum" : "enum:exitConnectedToCare"
-    "Deflection" o|--|o "TernaryEnum" : "enum:exitSFResident"
+    "Deflection" o|--|o "SFResidentEnum" : "enum:exitSFResident"
     "Deflection" o{--}o "DeflectionUpdate" : ""
     "Deflection" o{--}o "DeflectionDocument" : ""
     "Deflection" o{--}o "PropertyPhoto" : ""
@@ -776,7 +785,7 @@ DEATH_IN_CUSTODY DEATH_IN_CUSTODY
     "DeflectionUpdate" o|--|o "DeflectionExitDestination" : "exitDestination"
     "DeflectionUpdate" o|--|o "DeflectionExitHousingStatus" : "exitHousingStatus"
     "DeflectionUpdate" o|--|o "TernaryEnum" : "enum:exitConnectedToCare"
-    "DeflectionUpdate" o|--|o "TernaryEnum" : "enum:exitSFResident"
+    "DeflectionUpdate" o|--|o "SFResidentEnum" : "enum:exitSFResident"
     "DeflectionUpdate" o|--|| "User" : "updatedBy"
     "DeflectionCancelReason" o|--|| "User" : "createdBy"
     "DeflectionCancelReason" o|--|| "User" : "updatedBy"

--- a/server/prisma/migrations/20260421120000_add_sf_resident_enum/migration.sql
+++ b/server/prisma/migrations/20260421120000_add_sf_resident_enum/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "public"."SFResidentEnum" AS ENUM ('YES', 'NO', 'UNKNOWN', 'DECLINED_CONSENT');
+
+-- AlterTable
+ALTER TABLE "public"."Deflection"
+ALTER COLUMN "exitSFResident" TYPE "public"."SFResidentEnum"
+USING "exitSFResident"::text::"public"."SFResidentEnum";
+
+-- AlterTable
+ALTER TABLE "public"."DeflectionUpdate"
+ALTER COLUMN "exitSFResident" TYPE "public"."SFResidentEnum"
+USING "exitSFResident"::text::"public"."SFResidentEnum";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -33,6 +33,13 @@ enum TernaryEnum {
   UNKNOWN
 }
 
+enum SFResidentEnum {
+  YES
+  NO
+  UNKNOWN
+  DECLINED_CONSENT
+}
+
 enum FacilityTypeEnum {
   DIDO
   LESC
@@ -582,7 +589,7 @@ model Deflection {
   exitHousingStatus            DeflectionExitHousingStatus? @relation(fields: [exitHousingStatusId], references: [id])
   exitHousingStatusId          String?
   exitConnectedToCare          TernaryEnum?
-  exitSFResident               TernaryEnum?
+  exitSFResident               SFResidentEnum?
   handoffReadyAt               DateTime?
   updatedAt                    DateTime                @updatedAt
 
@@ -615,7 +622,7 @@ model DeflectionUpdate {
   exitHousingStatus            DeflectionExitHousingStatus? @relation(fields: [exitHousingStatusId], references: [id])
   exitHousingStatusId          String?
   exitConnectedToCare          TernaryEnum?
-  exitSFResident               TernaryEnum?
+  exitSFResident               SFResidentEnum?
   updatedAt                    DateTime                @default(now())
   updatedBy                    User                    @relation(fields: [updatedById], references: [id], onDelete: Cascade)
   updatedById                  String                  @db.Uuid

--- a/server/prisma/seeds/historicalData.js
+++ b/server/prisma/seeds/historicalData.js
@@ -174,9 +174,8 @@ function exitData (careUser, exitDestId, housingStatusId, t) {
     exitConnectedToCare: weightedPick([
       { v: 'YES', w: 30 }, { v: 'NO', w: 50 }, { v: 'UNKNOWN', w: 20 },
     ]),
-    // Route input may include DECLINED_CONSENT, but the stored DB value is UNKNOWN.
     exitSFResident: weightedPick([
-      { v: 'YES', w: 50 }, { v: 'NO', w: 30 }, { v: 'UNKNOWN', w: 20 },
+      { v: 'YES', w: 45 }, { v: 'NO', w: 30 }, { v: 'UNKNOWN', w: 15 }, { v: 'DECLINED_CONSENT', w: 10 },
     ]),
     subjectStatus: 'EXITED',
   };

--- a/server/routes/api/deflections/exit-details.js
+++ b/server/routes/api/deflections/exit-details.js
@@ -1,28 +1,14 @@
 import { StatusCodes } from 'http-status-codes';
-import { TernaryEnum } from '@prisma/client';
+import { SFResidentEnum, TernaryEnum } from '@prisma/client';
 import { z } from 'zod';
 
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 
-const ResidencyEnum = z.enum([
-  'YES',
-  'NO',
-  'UNKNOWN',
-  'DECLINED_CONSENT',
-]);
+const ResidencyEnum = z.enum(Object.values(SFResidentEnum));
 
-const ConnectionToCareEnum = z.enum([
-  'YES',
-  'NO',
-  'UNKNOWN',
-]);
-
-function toTernary (value) {
-  if (value === 'DECLINED_CONSENT') return TernaryEnum.UNKNOWN;
-  return value;
-}
+const ConnectionToCareEnum = z.enum(Object.values(TernaryEnum));
 
 const EXIT_DETAIL_EDITABLE_STATUSES = [
   Deflection.SubjectStatus.IN_CHAIR,
@@ -81,7 +67,7 @@ export default async function (fastify, opts) {
             exitDestinationId,
             exitHousingStatusId,
             exitConnectedToCare,
-            exitSFResident: toTernary(exitSFResident),
+            exitSFResident,
             updatedById: request.user.id,
             updatedAt: now,
           },
@@ -93,7 +79,7 @@ export default async function (fastify, opts) {
             exitDestinationId,
             exitHousingStatusId,
             exitConnectedToCare,
-            exitSFResident: toTernary(exitSFResident),
+            exitSFResident,
             updatedAt: now,
           },
           include: {

--- a/server/routes/api/deflections/exit.js
+++ b/server/routes/api/deflections/exit.js
@@ -1,28 +1,14 @@
 import { StatusCodes } from 'http-status-codes';
-import { TernaryEnum } from '@prisma/client';
+import { SFResidentEnum, TernaryEnum } from '@prisma/client';
 import { z } from 'zod';
 
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 
-const ResidencyEnum = z.enum([
-  'YES',
-  'NO',
-  'UNKNOWN',
-  'DECLINED_CONSENT',
-]);
+const ResidencyEnum = z.enum(Object.values(SFResidentEnum));
 
-const ConnectionToCareEnum = z.enum([
-  'YES',
-  'NO',
-  'UNKNOWN',
-]);
-
-function toTernary (value) {
-  if (value === 'DECLINED_CONSENT') return TernaryEnum.UNKNOWN;
-  return value;
-}
+const ConnectionToCareEnum = z.enum(Object.values(TernaryEnum));
 
 const EXITABLE_STATUSES = [
   Deflection.SubjectStatus.IN_CHAIR,
@@ -91,7 +77,7 @@ export default async function (fastify, opts) {
             exitDestinationId,
             exitHousingStatusId,
             exitConnectedToCare,
-            exitSFResident: toTernary(exitSFResident),
+            exitSFResident,
             updatedById: request.user.id,
             updatedAt: now,
           },
@@ -106,7 +92,7 @@ export default async function (fastify, opts) {
             exitDestinationId,
             exitHousingStatusId,
             exitConnectedToCare,
-            exitSFResident: toTernary(exitSFResident),
+            exitSFResident,
             updatedAt: now,
           },
           include: {

--- a/server/test/helper.js
+++ b/server/test/helper.js
@@ -2,7 +2,7 @@
 // between our tests.
 
 import util from 'node:util';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import helper from 'fastify-cli/helper.js';
 import path from 'node:path';
@@ -11,7 +11,7 @@ import YAML from 'yaml';
 import { StatusCodes } from 'http-status-codes';
 import * as nodemailerMock from 'nodemailer-mock';
 
-import { GenericContainer } from 'testcontainers';
+import { GenericContainer, Wait } from 'testcontainers';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import {
   Builder,
@@ -28,6 +28,9 @@ import { configureMailer } from '#lib/mailer.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const AppPath = path.join(__dirname, '..', 'app.js');
+const POSTGRES_PORT = 5432;
+const MINIO_PORT = 9000;
+const TEST_CONTAINER_STARTUP_TIMEOUT_MS = Number(process.env.TESTCONTAINERS_STARTUP_TIMEOUT_MS ?? 120_000);
 
 // Disable pg-boss in tests — the plugin will decorate a no-op stub
 process.env.PGBOSS_ENABLED = 'false';
@@ -55,19 +58,19 @@ async function buildPostgres (t) {
   const compose = YAML.parse(await fs.readFile(path.join(__dirname, '../..', 'compose.yml'), 'utf8'));
   const testcontainersNetworkMode = process.env.TESTCONTAINERS_NETWORK_MODE;
   // extract current version of postgres image being used, start a new test container
-  let dbContainer = new PostgreSqlContainer(compose.services.db.image);
-  if (testcontainersNetworkMode) {
-    dbContainer = dbContainer.withNetworkMode(testcontainersNetworkMode);
-  }
-  const startedDbContainer = await dbContainer.start();
+  const startedDbContainer = await startDbContainer(compose.services.db.image, testcontainersNetworkMode);
   // set up the default template (template1) with the schema and fixtures
   const templateDbUrl = new URL(`postgresql://${startedDbContainer.getUsername()}:${startedDbContainer.getPassword()}@${startedDbContainer.getHost()}:${startedDbContainer.getPort()}/template1`);
   templateDbUrl.searchParams.set('connection_limit', '1');
   const TEMPLATE_DATABASE_URL = templateDbUrl.toString();
   // run the migrations
   const schemaPath = path.join(__dirname, '..', 'prisma', 'schema.prisma');
-  await util.promisify(exec)(`DATABASE_URL=${TEMPLATE_DATABASE_URL} npx prisma db push --schema ${schemaPath}`, {
+  await util.promisify(execFile)('npx', ['prisma', 'db', 'push', '--schema', schemaPath], {
     cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      DATABASE_URL: TEMPLATE_DATABASE_URL,
+    },
   });
   const prisma = new PrismaClient({
     datasourceUrl: TEMPLATE_DATABASE_URL,
@@ -87,18 +90,12 @@ async function buildPostgres (t) {
   t.prisma = new PrismaClient({ datasourceUrl: process.env.DATABASE_URL });
 
   // set up a new storage container
-  let storageContainer = new GenericContainer(compose.services.storage.image)
-    .withEntrypoint(['minio', 'server', '/data'])
-    .withExposedPorts(9000);
-  if (testcontainersNetworkMode) {
-    storageContainer = storageContainer.withNetworkMode(testcontainersNetworkMode);
-  }
-  const startedStorageContainer = await storageContainer.start();
+  const startedStorageContainer = await startStorageContainer(compose.services.storage.image, testcontainersNetworkMode);
   process.env.AWS_S3_ACCESS_KEY_ID = 'minioadmin';
   process.env.AWS_S3_SECRET_ACCESS_KEY = 'minioadmin';
   process.env.AWS_S3_BUCKET = 'app';
   process.env.AWS_S3_REGION = 'us-east-1';
-  process.env.AWS_S3_ENDPOINT = `http://${startedStorageContainer.getHost()}:${startedStorageContainer.getMappedPort(9000)}`;
+  process.env.AWS_S3_ENDPOINT = `http://${startedStorageContainer.getHost()}:${startedStorageContainer.getPort()}`;
 
   // Reset S3 client to ensure it uses the new environment variables
   s3.reset();
@@ -200,6 +197,131 @@ async function buildPostgres (t) {
   });
 
   return app;
+}
+
+async function startDbContainer (image, networkMode) {
+  if (!networkMode) {
+    return new StartedTestDbContainer(
+      await new PostgreSqlContainer(image)
+        .withStartupTimeout(TEST_CONTAINER_STARTUP_TIMEOUT_MS)
+        .start()
+    );
+  }
+
+  const networkAlias = testContainerAlias('care-connect-test-db');
+  const container = await new GenericContainer(image)
+    .withEnvironment({
+      POSTGRES_DB: 'test',
+      POSTGRES_USER: 'test',
+      POSTGRES_PASSWORD: 'test',
+    })
+    .withHealthCheck({
+      test: [
+        'CMD-SHELL',
+        'PGPASSWORD=test pg_isready --host localhost --username test --dbname test',
+      ],
+      interval: 250,
+      timeout: 1000,
+      retries: 1000,
+    })
+    .withWaitStrategy(Wait.forHealthCheck())
+    .withStartupTimeout(TEST_CONTAINER_STARTUP_TIMEOUT_MS)
+    .withNetworkMode(networkMode)
+    .withNetworkAliases(networkAlias)
+    .start();
+
+  return new StartedTestDbContainer(container, {
+    host: networkAlias,
+    port: POSTGRES_PORT,
+    database: 'test',
+    username: 'test',
+    password: 'test',
+  });
+}
+
+async function startStorageContainer (image, networkMode) {
+  if (!networkMode) {
+    return new StartedTestStorageContainer(
+      await new GenericContainer(image)
+        .withEntrypoint(['minio', 'server', '/data'])
+        .withExposedPorts(MINIO_PORT)
+        .withStartupTimeout(TEST_CONTAINER_STARTUP_TIMEOUT_MS)
+        .start()
+    );
+  }
+
+  const networkAlias = testContainerAlias('care-connect-test-storage');
+  const container = await new GenericContainer(image)
+    .withEntrypoint(['minio', 'server', '/data'])
+    .withWaitStrategy(Wait.forLogMessage('API:'))
+    .withStartupTimeout(TEST_CONTAINER_STARTUP_TIMEOUT_MS)
+    .withNetworkMode(networkMode)
+    .withNetworkAliases(networkAlias)
+    .start();
+
+  return new StartedTestStorageContainer(container, {
+    host: networkAlias,
+    port: MINIO_PORT,
+  });
+}
+
+class StartedTestDbContainer {
+  constructor (container, options = {}) {
+    this.container = container;
+    this.host = options.host ?? container.getHost();
+    this.port = options.port ?? container.getPort();
+    this.database = options.database ?? container.getDatabase();
+    this.username = options.username ?? container.getUsername();
+    this.password = options.password ?? container.getPassword();
+  }
+
+  getHost () {
+    return this.host;
+  }
+
+  getPort () {
+    return this.port;
+  }
+
+  getDatabase () {
+    return this.database;
+  }
+
+  getUsername () {
+    return this.username;
+  }
+
+  getPassword () {
+    return this.password;
+  }
+
+  stop () {
+    return this.container.stop();
+  }
+}
+
+class StartedTestStorageContainer {
+  constructor (container, options = {}) {
+    this.container = container;
+    this.host = options.host ?? container.getHost();
+    this.port = options.port ?? container.getMappedPort(MINIO_PORT);
+  }
+
+  getHost () {
+    return this.host;
+  }
+
+  getPort () {
+    return this.port;
+  }
+
+  stop () {
+    return this.container.stop();
+  }
+}
+
+function testContainerAlias (prefix) {
+  return `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
 }
 
 async function authenticate (app, email, password) {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -1077,7 +1077,7 @@ test('/api/deflections', async (t) => {
         .payload({
           exitDestinationId: 'home',
           exitHousingStatusId: 'permanent',
-          exitSFResident: 'UNKNOWN',
+          exitSFResident: 'DECLINED_CONSENT',
           exitConnectedToCare: 'YES',
         });
 
@@ -1087,7 +1087,7 @@ test('/api/deflections', async (t) => {
       assert.strictEqual(data.subjectStatus, 'IN_CHAIR');
       assert.strictEqual(data.exitDestinationId, 'home');
       assert.strictEqual(data.exitHousingStatusId, 'permanent');
-      assert.strictEqual(data.exitSFResident, 'UNKNOWN');
+      assert.strictEqual(data.exitSFResident, 'DECLINED_CONSENT');
       assert.strictEqual(data.exitConnectedToCare, 'YES');
       // Should not set exitedAt/exitedById
       assert.strictEqual(data.exitedAt, null);
@@ -1098,7 +1098,7 @@ test('/api/deflections', async (t) => {
       assert.strictEqual(dbDeflection.subjectStatus, 'IN_CHAIR');
       assert.strictEqual(dbDeflection.exitDestinationId, 'home');
       assert.strictEqual(dbDeflection.exitHousingStatusId, 'permanent');
-      assert.strictEqual(dbDeflection.exitSFResident, 'UNKNOWN');
+      assert.strictEqual(dbDeflection.exitSFResident, 'DECLINED_CONSENT');
       assert.strictEqual(dbDeflection.exitConnectedToCare, 'YES');
 
       // Verify deflection update history
@@ -1107,7 +1107,7 @@ test('/api/deflections', async (t) => {
       assert.strictEqual(lastUpdate.subjectStatus, null); // Hasn't changed
       assert.strictEqual(lastUpdate.exitDestinationId, 'home');
       assert.strictEqual(lastUpdate.exitHousingStatusId, 'permanent');
-      assert.strictEqual(lastUpdate.exitSFResident, 'UNKNOWN');
+      assert.strictEqual(lastUpdate.exitSFResident, 'DECLINED_CONSENT');
       assert.strictEqual(lastUpdate.exitConnectedToCare, 'YES');
     });
 


### PR DESCRIPTION
## Summary

Handled DECLINED_CONSENT in exit questionnaire.

## Details

- Added a new Prisma `SFResidentEnum` with `YES`, `NO`, `UNKNOWN`, and `DECLINED_CONSENT`
- Updated `Deflection.exitSFResident` and `DeflectionUpdate.exitSFResident` to use `SFResidentEnum`
- Added a migration to create the enum and cast existing `exitSFResident` columns
- Updated exit routes to persist `DECLINED_CONSENT` directly instead of remapping it to `UNKNOWN`
- Updated response validation, route test expectations, synthetic data seed behavior, and docs

Also ran into some test problems:
- Hardened the test helper for containerized runs by using Docker network aliases when `TESTCONTAINERS_NETWORK_MODE` is set, avoiding flaky host-port binding timeouts
- Switched the Prisma test setup command from shell-string `exec` to `execFile` so schema paths with spaces are handled correctly (this was an issue for me locally - file path had spaces)

Closes #436 