### PR TITLE
Increases default hold time to 90 minutes (#580)

### DIFF
--- a/client/src/lesc/components/Holds.jsx
+++ b/client/src/lesc/components/Holds.jsx
@@ -295,7 +295,7 @@ function Holds () {
     mutationFn: (id) => Api.incidents.extend(id),
     onSuccess: (response) => {
       queryClient.setQueryData(['deflections', incident?.id, 'active'], response.data);
-      showToast('All active holds have been reset to 60 minutes.', 'success');
+      showToast('All active holds have been reset to 90 minutes.', 'success');
       setHoldsHighlighted(true);
     },
     onError: () => {

--- a/client/src/lesc/components/Holds.test.jsx
+++ b/client/src/lesc/components/Holds.test.jsx
@@ -227,7 +227,7 @@ describe('Holds', () => {
 
     await waitFor(() => {
       expect(mockShowToast).toHaveBeenCalledWith(
-        'All active holds have been reset to 60 minutes.',
+        'All active holds have been reset to 90 minutes.',
         'success'
       );
     });

--- a/server/lib/holds.js
+++ b/server/lib/holds.js
@@ -1,0 +1,5 @@
+export const HOLD_DURATION_MINUTES = 90;
+
+export function holdExpiresAt (now = Date.now()) {
+  return new Date(now + HOLD_DURATION_MINUTES * 60 * 1000);
+}

--- a/server/prisma/migrations/20260421000000_change_default_hold_duration_to_90_minutes/migration.sql
+++ b/server/prisma/migrations/20260421000000_change_default_hold_duration_to_90_minutes/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Deflection" ALTER COLUMN "expiresAt" SET DEFAULT (now() + '01:30:00'::interval);

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -538,7 +538,7 @@ model Deflection {
   createdAt                    DateTime                @default(now())
   createdBy                    User                    @relation("CreatedBy", fields: [createdById], references: [id])
   createdById                  String                  @db.Uuid
-  expiresAt                    DateTime                @default(dbgenerated("(now() + '01:00:00'::interval)"))
+  expiresAt                    DateTime                @default(dbgenerated("(now() + '01:30:00'::interval)"))
   completedAt                  DateTime?
   status                       HoldStatusEnum          @default(ACTIVE)
   extensionCount               Int                     @default(0)

--- a/server/routes/api/deflections/reopen.js
+++ b/server/routes/api/deflections/reopen.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
 import Deflection from '#models/deflection.js';
+import { holdExpiresAt } from '#lib/holds.js';
 
 export default async function (fastify, opts) {
   fastify.post('/:id/reopen', {
@@ -96,7 +97,7 @@ export default async function (fastify, opts) {
         data: {
           deflectionId: id,
           status: Deflection.HoldStatus.ACTIVE,
-          expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+          expiresAt: holdExpiresAt(),
           updatedById: request.user.id,
           updatedAt: new Date(),
         },

--- a/server/routes/api/incidents/extend.js
+++ b/server/routes/api/incidents/extend.js
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { getOfficerPermissions } from '#lib/incidentPermissions.js';
+import { holdExpiresAt } from '#lib/holds.js';
 
 export default async function (fastify, opts) {
   fastify.patch('/:id/extend',
@@ -46,7 +47,7 @@ export default async function (fastify, opts) {
           },
         });
 
-        const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+        const expiresAt = holdExpiresAt();
         const deflectionUpdates = deflections.map((deflection) => ({
           deflectionId: deflection.id,
           expiresAt,

--- a/server/test/fixtures/db/deflections.yml
+++ b/server/test/fixtures/db/deflections.yml
@@ -5,7 +5,7 @@ items:
     facility: '@lescFacility1'
     bedType: '@lescFacility1BedType'
     incident: '@incident2'
-    expiresAt: <%= new Date(Date.now() + 60 * 60 * 1000).toISOString() %>
+    expiresAt: <%= new Date(Date.now() + 90 * 60 * 1000).toISOString() %>
     status: 'ACTIVE'
     subjectStatus: 'DETAINED'
     createdBy: '@user4'
@@ -34,7 +34,7 @@ items:
     bedType: '@lescFacility1BedType'
     subject: '@subject1'
     incident: '@incident1'
-    expiresAt: <%= new Date(Date.now() + 60 * 60 * 1000).toISOString() %>
+    expiresAt: <%= new Date(Date.now() + 90 * 60 * 1000).toISOString() %>
     status: 'ACTIVE'
     subjectStatus: 'DETAINED'
     createdBy: '@user2'

--- a/server/test/helper.js
+++ b/server/test/helper.js
@@ -66,7 +66,7 @@ async function buildPostgres (t) {
   const TEMPLATE_DATABASE_URL = templateDbUrl.toString();
   // run the migrations
   const schemaPath = path.join(__dirname, '..', 'prisma', 'schema.prisma');
-  await util.promisify(exec)(`DATABASE_URL=${TEMPLATE_DATABASE_URL} npx prisma db push --schema ${schemaPath}`, {
+  await util.promisify(exec)(`DATABASE_URL=${TEMPLATE_DATABASE_URL} npx prisma db push --schema "${schemaPath}"`, {
     cwd: path.join(__dirname, '..'),
   });
   const prisma = new PrismaClient({

--- a/server/test/routes/api/incidents.test.js
+++ b/server/test/routes/api/incidents.test.js
@@ -225,15 +225,15 @@ test('/api/incidents', async (t) => {
       const data = JSON.parse(response.body);
       assert.deepStrictEqual(data.length, 2);
 
-      const oneHourLater = DateTime.now().plus({ hours: 1 });
+      const ninetyMinutesLater = DateTime.now().plus({ minutes: 90 });
 
       const expiresAt0 = DateTime.fromISO(data[0].expiresAt);
-      const diff0 = expiresAt0.diff(oneHourLater, 'minutes').minutes;
-      assert.ok(Math.abs(diff0) < 1, `Expected data[0].expiresAt to be close to ${oneHourLater.toISO()}, got ${expiresAt0.toISO()}`);
+      const diff0 = expiresAt0.diff(ninetyMinutesLater, 'minutes').minutes;
+      assert.ok(Math.abs(diff0) < 1, `Expected data[0].expiresAt to be close to ${ninetyMinutesLater.toISO()}, got ${expiresAt0.toISO()}`);
 
       const expiresAt1 = DateTime.fromISO(data[1].expiresAt);
-      const diff1 = expiresAt1.diff(oneHourLater, 'minutes').minutes;
-      assert.ok(Math.abs(diff1) < 1, `Expected data[1].expiresAt to be close to ${oneHourLater.toISO()}, got ${expiresAt1.toISO()}`);
+      const diff1 = expiresAt1.diff(ninetyMinutesLater, 'minutes').minutes;
+      assert.ok(Math.abs(diff1) < 1, `Expected data[1].expiresAt to be close to ${ninetyMinutesLater.toISO()}, got ${expiresAt1.toISO()}`);
     });
   });
 


### PR DESCRIPTION
## Summary

- Increased the default hold duration from 60 minutes to 90 minutes.
- Updated manual hold extensions to reset active holds to 90 minutes.
- Updated reopened holds to use the same 90-minute expiration helper.
- Changed the database default for new deflection holds to expire after 90 minutes.
- Updated UI copy, tests, and fixtures to reflect the new 90-minute hold duration.
- Fixed the backend test helper to quote the Prisma schema path so tests can run from workspace paths containing spaces.

Closes #580 