### PR TITLE
Shows incident details from hold add details not before (#582)

### DIFF
--- a/client/src/components/IconButtonLink.jsx
+++ b/client/src/components/IconButtonLink.jsx
@@ -4,6 +4,14 @@ import { Link } from 'react-router';
 import classes from './IconButtonLink.module.css';
 
 function IconButtonLink ({ to, variant, color, icon: Icon, onClick }) {
+  if (!to) {
+    return (
+      <Button className={variant === 'primary' ? '' : classes.default} color={color} classNames={classes} onClick={onClick} type='button'>
+        <Icon size={20} />
+      </Button>
+    );
+  }
+
   return (
     <Button className={variant === 'primary' ? '' : classes.default} color={color} classNames={classes} component={Link} to={to} onClick={onClick}>
       <Icon size={20} />

--- a/client/src/lesc/components/Holds.jsx
+++ b/client/src/lesc/components/Holds.jsx
@@ -14,6 +14,7 @@ import { useToast } from '@/components/ToastContext';
 import { useFacilityContext } from '@/FacilityContext';
 import useSessionState from '@/hooks/useSessionState';
 import { formatTime } from '@/utils/format';
+import { isValidIncident } from '@/utils/validators';
 
 import FacilityStatusBanner from '@/components/FacilityStatusBanner';
 import CancelHoldModal from './CancelHoldModal';
@@ -32,6 +33,24 @@ import {
   detectAutoCancelledExpiredHolds,
   mergeHistoryDeflections,
 } from './holdsViewModel';
+
+function buildBlankIncident (facilityId) {
+  return {
+    facilityId,
+    cadNumber: null,
+    caseNumber: null,
+    encounteredVia: null,
+    addressLine1: null,
+    addressLine2: null,
+    city: null,
+    state: null,
+    postalCode: null,
+    latitude: null,
+    longitude: null,
+    arrestedAt: DateTime.now().toISO(),
+    supervisorBadgeNumber: null,
+  };
+}
 
 function parseAutoCancelledNoticeState (value) {
   if (!value) return null;
@@ -291,6 +310,19 @@ function Holds () {
     },
   });
 
+  const createIncidentMutation = useMutation({
+    mutationFn: ({ bedTypeId }) => Api.incidents.create(buildBlankIncident(facility.id), { bedTypeId }),
+    onSuccess: async (response) => {
+      await queryClient.setQueryData(['facilities', facility.id, 'active-incident'], response.data);
+      await queryClient.invalidateQueries({ queryKey: ['facilities', facility.id, 'bed-types'] });
+      await queryClient.invalidateQueries({ queryKey: ['deflections', response.data.id, 'active'] });
+      setTab('active');
+    },
+    onError: () => {
+      showToast('We couldn’t place the hold', 'error', 4000, 'Something went wrong. Try again later.');
+    },
+  });
+
   const extendAllHoldsMutation = useMutation({
     mutationFn: (id) => Api.incidents.extend(id),
     onSuccess: (response) => {
@@ -305,13 +337,14 @@ function Holds () {
 
   function onHoldClick () {
     let bedTypeId;
-    if (bedTypes?.length === 1) {
-      bedTypeId = bedTypes[0].id;
+    const availableBedTypes = bedTypes ?? facility.bedTypes;
+    if (availableBedTypes?.length === 1) {
+      bedTypeId = availableBedTypes[0].id;
     } else {
       // TODO
     }
     if (!incident) {
-      navigate(`/incident${bedTypeId ? `?bedTypeId=${bedTypeId}` : ''}`);
+      createIncidentMutation.mutate({ bedTypeId });
     } else {
       createDeflectionMutation.mutate({
         facilityId: facility.id,
@@ -462,6 +495,7 @@ function Holds () {
     !permissions.canCreateHold ||
     isArrivalPending ||
     createDeflectionMutation.isPending ||
+    createIncidentMutation.isPending ||
     isClosed ||
     isFull ||
     !primaryBedType ||
@@ -469,6 +503,7 @@ function Holds () {
   );
   const showExtendActiveHoldsAction = (displayActiveDeflections?.length ?? 0) > 0;
   const incidentHasDetailedHolds = !!displayActiveDeflections?.some(deflection => deflection.subjectId);
+  const incidentDetailsComplete = incident?.permissions?.incidentDetailsComplete ?? isValidIncident(incident);
 
   return (
     <>
@@ -513,6 +548,7 @@ function Holds () {
               updatedAtMs={lastSyncedAtMs}
               holdsHighlighted={holdsHighlighted}
               currentUserId={user?.id}
+              incidentDetailsComplete={incidentDetailsComplete}
             />
           )}
           {tab === 'history' && (

--- a/client/src/lesc/components/Holds.test.jsx
+++ b/client/src/lesc/components/Holds.test.jsx
@@ -15,6 +15,7 @@ const {
   mockDeflectionsList,
   mockIncidentLeft,
   mockIncidentExtend,
+  mockIncidentCreate,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockShowToast: vi.fn(),
@@ -23,6 +24,7 @@ const {
   mockDeflectionsList: vi.fn(),
   mockIncidentLeft: vi.fn(),
   mockIncidentExtend: vi.fn(),
+  mockIncidentCreate: vi.fn(),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -51,6 +53,7 @@ vi.mock('@/Api', () => ({
       list: mockDeflectionsList,
     },
     incidents: {
+      create: mockIncidentCreate,
       left: mockIncidentLeft,
       extend: mockIncidentExtend,
     },
@@ -159,6 +162,24 @@ beforeEach(() => {
   mockIncidentExtend.mockResolvedValue({
     data: [],
   });
+  mockIncidentCreate.mockResolvedValue({
+    data: {
+      id: 56,
+      facilityId: 1,
+      permissions: {
+        isCreator: true,
+        canExtend: true,
+        canArrive: true,
+        canLeave: false,
+        canCancelIncident: true,
+        canEditIncident: true,
+        canCreateHold: true,
+        canHandoff: false,
+        incidentDetailsComplete: false,
+      },
+      totalActiveHolds: 1,
+    },
+  });
 });
 
 afterEach(() => {
@@ -229,6 +250,82 @@ describe('Holds', () => {
       expect(mockShowToast).toHaveBeenCalledWith(
         'All active holds have been reset to 60 minutes.',
         'success'
+      );
+    });
+  });
+
+  it('places the first hold without navigating to incident details', async () => {
+    mockActiveIncident.mockResolvedValue({ data: null });
+
+    renderHolds();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Hold a bedtype\.chair/i }));
+
+    await waitFor(() => {
+      expect(mockIncidentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          facilityId: 1,
+          cadNumber: null,
+          caseNumber: null,
+          arrestedAt: expect.any(String),
+        }),
+        { bedTypeId: 99 }
+      );
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalledWith(expect.stringContaining('/incident'));
+  });
+
+  it('routes first add-details tap through incident confirmation when incident details are incomplete', async () => {
+    mockActiveIncident.mockResolvedValue({
+      data: {
+        id: 55,
+        arrivedAt: null,
+        leftAt: null,
+        addressLine1: null,
+        createdById: 1,
+        permissions: {
+          isCreator: true,
+          canExtend: true,
+          canArrive: true,
+          canLeave: false,
+          canCancelIncident: true,
+          canEditIncident: true,
+          canCreateHold: true,
+          canHandoff: false,
+          incidentDetailsComplete: false,
+        },
+        totalActiveHolds: 1,
+      },
+    });
+    mockDeflectionsList.mockImplementation(({ incidentId, facilityId, active, subjectStatus }) => {
+      if (incidentId === 55 && active === true) {
+        return Promise.resolve({
+          data: [{
+            id: 88,
+            incidentId: 55,
+            subjectId: null,
+            status: 'ACTIVE',
+            subjectStatus: 'DETAINED',
+          }],
+        });
+      }
+      if (facilityId === 1 && active === false) {
+        return Promise.resolve({ data: [] });
+      }
+      if (facilityId === 1 && active === true && subjectStatus) {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderHolds();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Add Details' }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/incident?next=${encodeURIComponent('/holds/88/subject?isNew=true')}`
       );
     });
   });

--- a/client/src/lesc/components/HoldsActive.jsx
+++ b/client/src/lesc/components/HoldsActive.jsx
@@ -52,6 +52,7 @@ function HoldsActive ({
   updatedAtMs = 0,
   holdsHighlighted = false,
   currentUserId,
+  incidentDetailsComplete = false,
 }) {
   const navigate = useNavigate();
 
@@ -126,7 +127,18 @@ function HoldsActive ({
                     isHandedOff={isHandedOff}
                     onCancelClick={() => onCancelHoldClick(deflection)}
                     onDetailsClick={() => {
-                      navigate(deflection.subjectId ? `/holds/${deflection.id}` : `/holds/${deflection.id}/subject?isNew=true`);
+                      if (deflection.subjectId) {
+                        navigate(`/holds/${deflection.id}`);
+                        return;
+                      }
+
+                      const subjectPath = `/holds/${deflection.id}/subject?isNew=true`;
+                      if (incidentDetailsComplete) {
+                        navigate(subjectPath);
+                        return;
+                      }
+
+                      navigate(`/incident?next=${encodeURIComponent(subjectPath)}`);
                     }}
                   />
                 );

--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -47,6 +47,51 @@ const initialValues = {
   supervisorBadgeNumber: '',
 };
 
+function normalizeIncidentFormValues (values) {
+  return {
+    ...initialValues,
+    ...values,
+    cadNumber: values?.cadNumber ?? '',
+    caseNumber: values?.caseNumber ?? '',
+    encounteredVia: values?.encounteredVia ?? '',
+    addressLine1: values?.addressLine1 ?? '',
+    addressLine2: values?.addressLine2 ?? '',
+    city: values?.city ?? '',
+    state: values?.state ?? '',
+    postalCode: values?.postalCode ?? '',
+    latitude: values?.latitude ?? '',
+    longitude: values?.longitude ?? '',
+    arrestedAt: values?.arrestedAt ?? '',
+    supervisorBadgeNumber: values?.supervisorBadgeNumber ?? '',
+  };
+}
+
+function emptyStringToNull (value) {
+  return value === '' ? null : value;
+}
+
+function buildIncidentPayload (values) {
+  const arrestedAt = DateTime.fromISO(values.arrestedAt, {
+    zone: 'local',
+  });
+
+  return {
+    ...values,
+    cadNumber: emptyStringToNull(values.cadNumber),
+    caseNumber: emptyStringToNull(values.caseNumber),
+    encounteredVia: emptyStringToNull(values.encounteredVia),
+    addressLine1: emptyStringToNull(values.addressLine1),
+    addressLine2: emptyStringToNull(values.addressLine2),
+    city: emptyStringToNull(values.city),
+    state: emptyStringToNull(values.state),
+    postalCode: emptyStringToNull(values.postalCode),
+    latitude: emptyStringToNull(values.latitude),
+    longitude: emptyStringToNull(values.longitude),
+    arrestedAt: arrestedAt.isValid ? arrestedAt.toISO() : null,
+    supervisorBadgeNumber: emptyStringToNull(values.supervisorBadgeNumber),
+  };
+}
+
 function normalizeCadNumber (value) {
   return String(value ?? '')
     .replace(/[^0-9a-z]/gi, '')
@@ -56,6 +101,9 @@ function normalizeCadNumber (value) {
 function IncidentForm () {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
+  const initialNextPathRef = useRef(searchParams.get('next'));
+  const nextPath = initialNextPathRef.current;
+  const isConfirmIncidentFlow = !!nextPath;
   const queryClient = useQueryClient();
   const { showToast } = useToast();
   const { facility } = useFacilityContext();
@@ -68,12 +116,7 @@ function IncidentForm () {
   const form = useForm({
     mode: 'uncontrolled',
     initialValues,
-    transformValues: values => ({
-      ...values,
-      arrestedAt: DateTime.fromISO(values.arrestedAt, {
-        zone: 'local',
-      }).toISO(),
-    }),
+    transformValues: buildIncidentPayload,
   });
 
   const { data, isLoading } = useQuery({
@@ -98,11 +141,13 @@ function IncidentForm () {
           includeOffset: false,
           precision: 'seconds',
         });
-        form.initialize({
+        form.initialize(normalizeIncidentFormValues({
           ...data,
           arrestedAt,
-        });
-        form.setErrors(validateIncident(data));
+        }));
+        if (!isConfirmIncidentFlow) {
+          form.setErrors(validateIncident(data));
+        }
         setInitialized(true);
       } else {
         const now = DateTime.now().toISO({
@@ -165,7 +210,7 @@ function IncidentForm () {
         response.data
       );
       window.sessionStorage.setItem('_session-holds', 'active');
-      navigate('/holds');
+      navigate(nextPath || '/holds');
     },
     onError: () => {
       showToast('We couldn’t create the incident', 'error', 4000, 'Something went wrong. Try again later.');
@@ -237,7 +282,7 @@ function IncidentForm () {
       </Header>
       <Container>
         <Text c='dimmed' size='xl'>
-          Start an incident
+          {isConfirmIncidentFlow ? 'First, confirm incident details' : 'Start an incident'}
         </Text>
         <Title order={3} mb='xl'>
           Enter these details once. They apply to all holds in this
@@ -405,7 +450,7 @@ function IncidentForm () {
               </Stack>
               <Stack gap='sm'>
                 <Button type='submit' style={{ alignSelf: 'flex-start' }}>
-                  {data?.id ? 'Save incident details' : 'Create incident & hold'}
+                  {isConfirmIncidentFlow ? 'Continue to person details' : data?.id ? 'Save incident details' : 'Create incident & hold'}
                 </Button>
                 {canCancelIncident && (
                   <Button


### PR DESCRIPTION
## Summary

This PR updates the first-hold details flow for arresting users so incident details are collected later, when the LEO first chooses to add person details.

## Changes

- Allows the first hold to be placed immediately without showing the incident details form.
- Creates the incident in the background with blank nullable incident fields and an automatic arrest timestamp.
- When the officer first taps **Add Details** on an empty hold, routes them through the incident details confirmation form.
- Retitles that first incident-details form to **First, confirm incident details** to make it clearer this is a necessary first step.
- Changes the first-flow submit button to **Continue to person details**.
- After confirming incident details, sends the officer directly to the person details form for that hold.
- Skips initial red validation nudges on the first confirmation view, while preserving them for later incident edit views.
- Ensures canceling the cancel-incident modal does not change the confirmation-flow CTA (and renders icon-only controls without a `to` prop as buttons instead of router links, to prevent modal close button from accidentally affecting routing).

Closes #582 

