### PR TITLE
Adds slight friction to hold button, avoid unintentional presses (#604)

### DIFF
--- a/client/src/components/SunburstLoader.jsx
+++ b/client/src/components/SunburstLoader.jsx
@@ -1,0 +1,37 @@
+import { forwardRef } from 'react';
+import { Box } from '@mantine/core';
+
+import classes from './SunburstLoader.module.css';
+
+/**
+ * Radial/sunburst spinner from the Figma design, used for loading states on
+ * indigo-background buttons (e.g., "Placing hold..." in Holds.jsx).
+ *
+ * Fixed 20x20 and hardcoded white fill — intended for dark/primary surfaces.
+ * For other contexts, use Mantine's built-in <Loader> with an appropriate
+ * type/size/color.
+ */
+const SunburstLoader = forwardRef(function SunburstLoader (props, ref) {
+  return (
+    <Box component='span' ref={ref} className={classes.sunburstLoader} {...props}>
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        width='20'
+        height='20'
+        viewBox='0 0 20 20'
+        fill='none'
+        aria-hidden='true'
+        focusable='false'
+      >
+        <path
+          fillRule='evenodd'
+          clipRule='evenodd'
+          d='M10 0C10.5523 0 11 0.447715 11 1V4C11 4.55228 10.5523 5 10 5C9.44771 5 9 4.55228 9 4V1C9 0.447715 9.44771 0 10 0ZM2.89287 2.89287C3.28339 2.50234 3.91656 2.50234 4.30708 2.89287L6.45708 5.04287C6.84761 5.43339 6.84761 6.06656 6.45708 6.45708C6.06656 6.84761 5.43339 6.84761 5.04287 6.45708L2.89287 4.30708C2.50234 3.91656 2.50234 3.28339 2.89287 2.89287ZM17.1071 2.89287C17.4976 3.28339 17.4976 3.91656 17.1071 4.30708L14.9571 6.45708C14.5666 6.84761 13.9334 6.84761 13.5429 6.45708C13.1524 6.06656 13.1524 5.43339 13.5429 5.04287L15.6929 2.89287C16.0834 2.50234 16.7166 2.50234 17.1071 2.89287ZM0 10C0 9.44771 0.447715 9 1 9H4C4.55228 9 5 9.44771 5 10C5 10.5523 4.55228 11 4 11H1C0.447715 11 0 10.5523 0 10ZM15 10C15 9.44771 15.4477 9 16 9H19C19.5523 9 20 9.44771 20 10C20 10.5523 19.5523 11 19 11H16C15.4477 11 15 10.5523 15 10ZM6.45708 13.5429C6.84761 13.9334 6.84761 14.5666 6.45708 14.9571L4.30708 17.1071C3.91656 17.4976 3.28339 17.4976 2.89287 17.1071C2.50234 16.7166 2.50234 16.0834 2.89287 15.6929L5.04287 13.5429C5.43339 13.1524 6.06656 13.1524 6.45708 13.5429ZM13.5429 13.5429C13.9334 13.1524 14.5666 13.1524 14.9571 13.5429L17.1071 15.6929C17.4976 16.0834 17.4976 16.7166 17.1071 17.1071C16.7166 17.4976 16.0834 17.4976 15.6929 17.1071L13.5429 14.9571C13.1524 14.5666 13.1524 13.9334 13.5429 13.5429ZM10 15C10.5523 15 11 15.4477 11 16V19C11 19.5523 10.5523 20 10 20C9.44771 20 9 19.5523 9 19V16C9 15.4477 9.44771 15 10 15Z'
+          fill='white'
+        />
+      </svg>
+    </Box>
+  );
+});
+
+export default SunburstLoader;

--- a/client/src/components/SunburstLoader.module.css
+++ b/client/src/components/SunburstLoader.module.css
@@ -1,0 +1,16 @@
+.sunburstLoader {
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  animation: sunburstSpin 0.9s linear infinite;
+}
+
+@keyframes sunburstSpin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/client/src/lesc/components/Holds.jsx
+++ b/client/src/lesc/components/Holds.jsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import Api from '@/Api';
 import { useAuthContext } from '@/AuthContext';
 import ActionFooter from '@/components/ActionFooter';
+import SunburstLoader from '@/components/SunburstLoader';
 import { useToast } from '@/components/ToastContext';
 import { useFacilityContext } from '@/FacilityContext';
 import useSessionState from '@/hooks/useSessionState';
@@ -38,28 +39,6 @@ const HOLD_PLACEMENT_DELAY_MS = 2000;
 
 function wait (ms) {
   return new Promise((resolve) => window.setTimeout(resolve, ms));
-}
-
-function HoldPlacementLoaderIcon () {
-  return (
-    <svg
-      className={classes.holdPlacementLoader}
-      xmlns='http://www.w3.org/2000/svg'
-      width='20'
-      height='20'
-      viewBox='0 0 20 20'
-      fill='none'
-      aria-hidden='true'
-      focusable='false'
-    >
-      <path
-        fillRule='evenodd'
-        clipRule='evenodd'
-        d='M10 0C10.5523 0 11 0.447715 11 1V4C11 4.55228 10.5523 5 10 5C9.44771 5 9 4.55228 9 4V1C9 0.447715 9.44771 0 10 0ZM2.89287 2.89287C3.28339 2.50234 3.91656 2.50234 4.30708 2.89287L6.45708 5.04287C6.84761 5.43339 6.84761 6.06656 6.45708 6.45708C6.06656 6.84761 5.43339 6.84761 5.04287 6.45708L2.89287 4.30708C2.50234 3.91656 2.50234 3.28339 2.89287 2.89287ZM17.1071 2.89287C17.4976 3.28339 17.4976 3.91656 17.1071 4.30708L14.9571 6.45708C14.5666 6.84761 13.9334 6.84761 13.5429 6.45708C13.1524 6.06656 13.1524 5.43339 13.5429 5.04287L15.6929 2.89287C16.0834 2.50234 16.7166 2.50234 17.1071 2.89287ZM0 10C0 9.44771 0.447715 9 1 9H4C4.55228 9 5 9.44771 5 10C5 10.5523 4.55228 11 4 11H1C0.447715 11 0 10.5523 0 10ZM15 10C15 9.44771 15.4477 9 16 9H19C19.5523 9 20 9.44771 20 10C20 10.5523 19.5523 11 19 11H16C15.4477 11 15 10.5523 15 10ZM6.45708 13.5429C6.84761 13.9334 6.84761 14.5666 6.45708 14.9571L4.30708 17.1071C3.91656 17.4976 3.28339 17.4976 2.89287 17.1071C2.50234 16.7166 2.50234 16.0834 2.89287 15.6929L5.04287 13.5429C5.43339 13.1524 6.06656 13.1524 6.45708 13.5429ZM13.5429 13.5429C13.9334 13.1524 14.5666 13.1524 14.9571 13.5429L17.1071 15.6929C17.4976 16.0834 17.4976 16.7166 17.1071 17.1071C16.7166 17.4976 16.0834 17.4976 15.6929 17.1071L13.5429 14.9571C13.1524 14.5666 13.1524 13.9334 13.5429 13.5429ZM10 15C10.5523 15 11 15.4477 11 16V19C11 19.5523 10.5523 20 10 20C9.44771 20 9 19.5523 9 19V16C9 15.4477 9.44771 15 10 15Z'
-        fill='white'
-      />
-    </svg>
-  );
 }
 
 function parseAutoCancelledNoticeState (value) {
@@ -627,8 +606,8 @@ function Holds () {
             onClick={onHoldClick}
             disabled={isHoldButtonDisabled && !isHoldPlacementDelayed}
             aria-disabled={isHoldButtonDisabled}
-            leftSection={isHoldPlacementDelayed ? <HoldPlacementLoaderIcon /> : undefined}
-            style={isHoldPlacementDelayed ? { pointerEvents: 'none' } : undefined}
+            leftSection={isHoldPlacementDelayed ? <SunburstLoader /> : undefined}
+            className={isHoldPlacementDelayed ? classes.holdPlacementDelayed : undefined}
           >
             {isHoldPlacementDelayed ? 'Placing hold...' : `Hold a ${primaryBedTypeLabel}`}
           </Button>

--- a/client/src/lesc/components/Holds.jsx
+++ b/client/src/lesc/components/Holds.jsx
@@ -32,6 +32,35 @@ import {
   detectAutoCancelledExpiredHolds,
   mergeHistoryDeflections,
 } from './holdsViewModel';
+import classes from './Holds.module.css';
+
+const HOLD_PLACEMENT_DELAY_MS = 2000;
+
+function wait (ms) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}
+
+function HoldPlacementLoaderIcon () {
+  return (
+    <svg
+      className={classes.holdPlacementLoader}
+      xmlns='http://www.w3.org/2000/svg'
+      width='20'
+      height='20'
+      viewBox='0 0 20 20'
+      fill='none'
+      aria-hidden='true'
+      focusable='false'
+    >
+      <path
+        fillRule='evenodd'
+        clipRule='evenodd'
+        d='M10 0C10.5523 0 11 0.447715 11 1V4C11 4.55228 10.5523 5 10 5C9.44771 5 9 4.55228 9 4V1C9 0.447715 9.44771 0 10 0ZM2.89287 2.89287C3.28339 2.50234 3.91656 2.50234 4.30708 2.89287L6.45708 5.04287C6.84761 5.43339 6.84761 6.06656 6.45708 6.45708C6.06656 6.84761 5.43339 6.84761 5.04287 6.45708L2.89287 4.30708C2.50234 3.91656 2.50234 3.28339 2.89287 2.89287ZM17.1071 2.89287C17.4976 3.28339 17.4976 3.91656 17.1071 4.30708L14.9571 6.45708C14.5666 6.84761 13.9334 6.84761 13.5429 6.45708C13.1524 6.06656 13.1524 5.43339 13.5429 5.04287L15.6929 2.89287C16.0834 2.50234 16.7166 2.50234 17.1071 2.89287ZM0 10C0 9.44771 0.447715 9 1 9H4C4.55228 9 5 9.44771 5 10C5 10.5523 4.55228 11 4 11H1C0.447715 11 0 10.5523 0 10ZM15 10C15 9.44771 15.4477 9 16 9H19C19.5523 9 20 9.44771 20 10C20 10.5523 19.5523 11 19 11H16C15.4477 11 15 10.5523 15 10ZM6.45708 13.5429C6.84761 13.9334 6.84761 14.5666 6.45708 14.9571L4.30708 17.1071C3.91656 17.4976 3.28339 17.4976 2.89287 17.1071C2.50234 16.7166 2.50234 16.0834 2.89287 15.6929L5.04287 13.5429C5.43339 13.1524 6.06656 13.1524 6.45708 13.5429ZM13.5429 13.5429C13.9334 13.1524 14.5666 13.1524 14.9571 13.5429L17.1071 15.6929C17.4976 16.0834 17.4976 16.7166 17.1071 17.1071C16.7166 17.4976 16.0834 17.4976 15.6929 17.1071L13.5429 14.9571C13.1524 14.5666 13.1524 13.9334 13.5429 13.5429ZM10 15C10.5523 15 11 15.4477 11 16V19C11 19.5523 10.5523 20 10 20C9.44771 20 9 19.5523 9 19V16C9 15.4477 9.44771 15 10 15Z'
+        fill='white'
+      />
+    </svg>
+  );
+}
 
 function parseAutoCancelledNoticeState (value) {
   if (!value) return null;
@@ -51,6 +80,7 @@ function Holds () {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
   const [holdsHighlighted, setHoldsHighlighted] = useState(false);
+  const [isHoldPlacementDelayed, setIsHoldPlacementDelayed] = useState(false);
   const [scanHandoffModalOpened, setScanHandoffModalOpened] = useState(false);
 
   const { data: bedTypes } = useQuery({
@@ -61,7 +91,7 @@ function Holds () {
     refetchOnMount: 'always',
   });
 
-  const { data: incident, dataUpdatedAt: incidentUpdatedAt } = useQuery({
+  const { data: incident, isLoading: isLoadingIncident, dataUpdatedAt: incidentUpdatedAt } = useQuery({
     queryKey: ['facilities', facility.id, 'active-incident'],
     queryFn: () => Api.facilities.activeIncident(facility.id).then(response => response.data),
     refetchOnWindowFocus: true,
@@ -288,6 +318,17 @@ function Holds () {
       }
       queryClient.invalidateQueries(['facilities', facility.id, 'bed-types']);
       setTab('active');
+      showToast(
+        'Hold placed',
+        'success',
+        4000,
+        `1 ${primaryBedTypeLabel} reserved. Hold expires in 90 minutes.`
+      );
+      setIsHoldPlacementDelayed(false);
+    },
+    onError: () => {
+      showToast('Couldn’t place hold', 'error', 4000, 'Please try again.');
+      setIsHoldPlacementDelayed(false);
     },
   });
 
@@ -303,7 +344,9 @@ function Holds () {
     },
   });
 
-  function onHoldClick () {
+  async function onHoldClick () {
+    if (isHoldPlacementDelayed || createDeflectionMutation.isPending) return;
+
     let bedTypeId;
     if (bedTypes?.length === 1) {
       bedTypeId = bedTypes[0].id;
@@ -313,6 +356,9 @@ function Holds () {
     if (!incident) {
       navigate(`/incident${bedTypeId ? `?bedTypeId=${bedTypeId}` : ''}`);
     } else {
+      setIsHoldPlacementDelayed(true);
+      await wait(HOLD_PLACEMENT_DELAY_MS);
+
       createDeflectionMutation.mutate({
         facilityId: facility.id,
         incidentId: incident.id,
@@ -450,6 +496,7 @@ function Holds () {
 
   const showActionFooter = true;
   const primaryBedType = (bedTypes ?? facility.bedTypes)?.[0];
+  const primaryBedTypeLabel = primaryBedType ? t(`bedType.${primaryBedType.type}`).toLocaleLowerCase() : 'bed';
   const isClosed = facility.status === 'CLOSED';
   const isFull = ((bedTypes ?? facility.bedTypes)?.reduce((sum, bedType) => sum + bedType.available, 0) ?? 0) === 0;
   const myOfficerRecord = incident?.incidentOfficers?.[0];
@@ -460,7 +507,9 @@ function Holds () {
   const isArrivalPending = markArrivedMutation.isPending || markLeftMutation.isPending;
   const isHoldButtonDisabled = (
     !permissions.canCreateHold ||
+    isLoadingIncident ||
     isArrivalPending ||
+    isHoldPlacementDelayed ||
     createDeflectionMutation.isPending ||
     isClosed ||
     isFull ||
@@ -574,8 +623,14 @@ function Holds () {
               </Menu.Item>
             </Menu.Dropdown>
           </Menu>
-          <Button onClick={onHoldClick} disabled={isHoldButtonDisabled}>
-            Hold a {primaryBedType ? t(`bedType.${primaryBedType.type}`).toLocaleLowerCase() : 'bed'}
+          <Button
+            onClick={onHoldClick}
+            disabled={isHoldButtonDisabled && !isHoldPlacementDelayed}
+            aria-disabled={isHoldButtonDisabled}
+            leftSection={isHoldPlacementDelayed ? <HoldPlacementLoaderIcon /> : undefined}
+            style={isHoldPlacementDelayed ? { pointerEvents: 'none' } : undefined}
+          >
+            {isHoldPlacementDelayed ? 'Placing hold...' : `Hold a ${primaryBedTypeLabel}`}
           </Button>
         </ActionFooter>
       )}

--- a/client/src/lesc/components/Holds.module.css
+++ b/client/src/lesc/components/Holds.module.css
@@ -1,0 +1,13 @@
+.holdPlacementLoader {
+  animation: holdPlacementSpin 0.9s linear infinite;
+}
+
+@keyframes holdPlacementSpin {
+  from {
+    transform: rotate(0deg);
+  }
+
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/client/src/lesc/components/Holds.module.css
+++ b/client/src/lesc/components/Holds.module.css
@@ -1,13 +1,3 @@
-.holdPlacementLoader {
-  animation: holdPlacementSpin 0.9s linear infinite;
-}
-
-@keyframes holdPlacementSpin {
-  from {
-    transform: rotate(0deg);
-  }
-
-  to {
-    transform: rotate(360deg);
-  }
+.holdPlacementDelayed {
+  pointer-events: none;
 }

--- a/client/src/lesc/components/Holds.test.jsx
+++ b/client/src/lesc/components/Holds.test.jsx
@@ -13,6 +13,7 @@ const {
   mockBedTypesIndex,
   mockActiveIncident,
   mockDeflectionsList,
+  mockDeflectionCreate,
   mockIncidentLeft,
   mockIncidentExtend,
   mockIncidentCreate,
@@ -22,6 +23,7 @@ const {
   mockBedTypesIndex: vi.fn(),
   mockActiveIncident: vi.fn(),
   mockDeflectionsList: vi.fn(),
+  mockDeflectionCreate: vi.fn(),
   mockIncidentLeft: vi.fn(),
   mockIncidentExtend: vi.fn(),
   mockIncidentCreate: vi.fn(),
@@ -51,6 +53,7 @@ vi.mock('@/Api', () => ({
     },
     deflections: {
       list: mockDeflectionsList,
+      create: mockDeflectionCreate,
     },
     incidents: {
       create: mockIncidentCreate,
@@ -180,6 +183,15 @@ beforeEach(() => {
       totalActiveHolds: 1,
     },
   });
+  mockDeflectionCreate.mockResolvedValue({
+    data: {
+      id: 89,
+      incidentId: 55,
+      subjectId: null,
+      status: 'ACTIVE',
+      subjectStatus: 'DETAINED',
+    },
+  });
 });
 
 afterEach(() => {
@@ -259,7 +271,12 @@ describe('Holds', () => {
 
     renderHolds();
 
-    fireEvent.click(await screen.findByRole('button', { name: /Hold a bedtype\.chair/i }));
+    const button = await screen.findByRole('button', { name: /Hold a bedtype\.chair/i });
+    await waitFor(() => {
+      expect(button).not.toBeDisabled();
+    });
+
+    fireEvent.click(button);
 
     await waitFor(() => {
       expect(mockIncidentCreate).toHaveBeenCalledWith(
@@ -326,6 +343,81 @@ describe('Holds', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith(
         `/incident?next=${encodeURIComponent('/holds/88/subject?isNew=true')}`
+      );
+    });
+  });
+
+  it('delays placing an additional hold and then shows a 90 minute success toast', async () => {
+    mockActiveIncident.mockResolvedValue({
+      data: {
+        id: 55,
+        arrivedAt: null,
+        leftAt: null,
+        addressLine1: '1001 Polk St',
+        createdById: 1,
+        permissions: {
+          isCreator: true,
+          canExtend: true,
+          canArrive: true,
+          canLeave: true,
+          canCancelIncident: true,
+          canEditIncident: true,
+          canCreateHold: true,
+          canHandoff: true,
+          incidentDetailsComplete: true,
+        },
+        totalActiveHolds: 1,
+      },
+    });
+
+    mockDeflectionsList.mockImplementation(({ incidentId, facilityId, active, subjectStatus }) => {
+      if (incidentId === 55 && active === true) {
+        return Promise.resolve({
+          data: [{
+            id: 88,
+            incidentId: 55,
+            subjectId: 'subject-1',
+            status: 'ACTIVE',
+            subjectStatus: 'DETAINED',
+            subject: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+            },
+          }],
+        });
+      }
+      if (facilityId === 1 && active === false) {
+        return Promise.resolve({ data: [] });
+      }
+      if (facilityId === 1 && active === true && subjectStatus) {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderHolds();
+
+    expect(await screen.findByText('Hold 88')).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Hold a bedtype\.chair/i }));
+
+    expect(await screen.findByRole('button', { name: /Placing hold/i })).toBeInTheDocument();
+    expect(mockDeflectionCreate).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(mockDeflectionCreate).toHaveBeenCalledWith({
+        facilityId: 1,
+        incidentId: 55,
+        bedTypeId: 99,
+      });
+    }, { timeout: 3000 });
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Hold placed',
+        'success',
+        4000,
+        '1 bedtype.chair reserved. Hold expires in 90 minutes.'
       );
     });
   });

--- a/client/src/lesc/components/Holds.test.jsx
+++ b/client/src/lesc/components/Holds.test.jsx
@@ -13,6 +13,7 @@ const {
   mockBedTypesIndex,
   mockActiveIncident,
   mockDeflectionsList,
+  mockDeflectionCreate,
   mockIncidentLeft,
   mockIncidentExtend,
 } = vi.hoisted(() => ({
@@ -21,6 +22,7 @@ const {
   mockBedTypesIndex: vi.fn(),
   mockActiveIncident: vi.fn(),
   mockDeflectionsList: vi.fn(),
+  mockDeflectionCreate: vi.fn(),
   mockIncidentLeft: vi.fn(),
   mockIncidentExtend: vi.fn(),
 }));
@@ -49,6 +51,7 @@ vi.mock('@/Api', () => ({
     },
     deflections: {
       list: mockDeflectionsList,
+      create: mockDeflectionCreate,
     },
     incidents: {
       left: mockIncidentLeft,
@@ -159,6 +162,15 @@ beforeEach(() => {
   mockIncidentExtend.mockResolvedValue({
     data: [],
   });
+  mockDeflectionCreate.mockResolvedValue({
+    data: {
+      id: 89,
+      incidentId: 55,
+      subjectId: null,
+      status: 'ACTIVE',
+      subjectStatus: 'DETAINED',
+    },
+  });
 });
 
 afterEach(() => {
@@ -231,6 +243,98 @@ describe('Holds', () => {
         'success'
       );
     });
+  });
+
+  it('delays placing an additional hold and then shows a 90 minute success toast', async () => {
+    mockActiveIncident.mockResolvedValue({
+      data: {
+        id: 55,
+        arrivedAt: null,
+        leftAt: null,
+        addressLine1: '1001 Polk St',
+        createdById: 1,
+        permissions: {
+          isCreator: true,
+          canExtend: true,
+          canArrive: true,
+          canLeave: true,
+          canCancelIncident: true,
+          canEditIncident: true,
+          canCreateHold: true,
+          canHandoff: true,
+          incidentDetailsComplete: true,
+        },
+        totalActiveHolds: 1,
+      },
+    });
+    mockDeflectionsList.mockImplementation(({ incidentId, facilityId, active, subjectStatus }) => {
+      if (incidentId === 55 && active === true) {
+        return Promise.resolve({
+          data: [{
+            id: 88,
+            incidentId: 55,
+            subjectId: 'subject-1',
+            status: 'ACTIVE',
+            subjectStatus: 'DETAINED',
+            subject: {
+              firstName: 'Jane',
+              lastName: 'Doe',
+            },
+          }],
+        });
+      }
+      if (facilityId === 1 && active === false) {
+        return Promise.resolve({ data: [] });
+      }
+      if (facilityId === 1 && active === true && subjectStatus) {
+        return Promise.resolve({ data: [] });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderHolds();
+
+    expect(await screen.findByText('Hold 88')).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Hold a bedtype\.chair/i }));
+
+    expect(await screen.findByRole('button', { name: /Placing hold/i })).toBeInTheDocument();
+    expect(mockDeflectionCreate).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(mockDeflectionCreate).toHaveBeenCalledWith({
+        facilityId: 1,
+        incidentId: 55,
+        bedTypeId: 99,
+      });
+    }, { timeout: 3000 });
+
+    await waitFor(() => {
+      expect(mockShowToast).toHaveBeenCalledWith(
+        'Hold placed',
+        'success',
+        4000,
+        '1 bedtype.chair reserved. Hold expires in 90 minutes.'
+      );
+    });
+  });
+
+  it('navigates to incident details immediately for the first hold', async () => {
+    mockActiveIncident.mockResolvedValue({ data: null });
+
+    renderHolds();
+
+    const holdButton = await screen.findByRole('button', { name: /Hold a bedtype\.chair/i });
+
+    await waitFor(() => {
+      expect(holdButton).not.toBeDisabled();
+    });
+
+    fireEvent.click(holdButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/incident?bedTypeId=99');
+    expect(screen.queryByRole('button', { name: /Placing hold/i })).not.toBeInTheDocument();
+    expect(mockDeflectionCreate).not.toHaveBeenCalled();
   });
 
   it('navigates to incident details from the incident overflow menu', async () => {


### PR DESCRIPTION
## Summary

Adds a small amount of friction to placing additional holds so users get clear feedback after tapping “Hold a chair” and are less likely to tap repeatedly.

## Details
- Shows a short `Placing hold...` state before creating an additional hold
- Disables repeat interaction while the hold placement delay/create request is in progress
- Uses the Figma-provided loader SVG and rotates it in CSS*
- Shows a success toast after hold creation: `Hold placed` / `1 chair reserved. Hold expires in 90 minutes.` (Note that this assumes #675 gets approved and merged.)
- Leaves the first-hold path untouched: if no active incident exists, the button still routes immediately to incident creation/details. This is to avoid clashing with the separate [PR](fix/582-incident-details-on-add-details) that changes the ordering on when the incident form first appears. May need some refactoring once that merges.

*Note on inline SVG
The closest Tabler/Mantine loader icon is different to the Figma loader glyph and in rotation does not visually match design. SVG inline is not great but matches design intent and avoids adding assets.

Closes #604 