### PR TITLE
Adds scan button on legally released tab for SFSO users (#651)

### DIFF
--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -120,6 +120,7 @@ function Custody () {
   });
 
   function handleScanSuccess () {
+    setTab('in-custody');
     queryClient.invalidateQueries({ queryKey: ['deflections', facility.id] });
   }
 
@@ -313,17 +314,15 @@ function Custody () {
           )}
         </Stack>
       </Container>
-      {tab === 'in-custody' && (
-        <ActionFooter>
-          <Button
-            variant='secondary'
-            leftSection={<ScanTransferCodeIcon size={20} color='var(--mantine-color-indigo-6)' />}
-            onClick={() => setScanModalOpened(true)}
-          >
-            Take custody
-          </Button>
-        </ActionFooter>
-      )}
+      <ActionFooter>
+        <Button
+          variant='secondary'
+          leftSection={<ScanTransferCodeIcon size={20} color='var(--mantine-color-indigo-6)' />}
+          onClick={() => setScanModalOpened(true)}
+        >
+          Take custody
+        </Button>
+      </ActionFooter>
       {scanModalOpened && (
         <ScanTransferCodeModal
           opened={scanModalOpened}

--- a/client/src/lesc/components/custody/Custody.test.jsx
+++ b/client/src/lesc/components/custody/Custody.test.jsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MantineProvider } from '@mantine/core';
@@ -10,10 +10,14 @@ import Custody from './Custody';
 const {
   mockBedTypesIndex,
   mockDeflectionsList,
+  mockSessionStateValue,
+  mockSetSessionState,
   mockShowToast,
 } = vi.hoisted(() => ({
   mockBedTypesIndex: vi.fn(),
   mockDeflectionsList: vi.fn(),
+  mockSessionStateValue: { current: 'in-custody' },
+  mockSetSessionState: vi.fn(),
   mockShowToast: vi.fn(),
 }));
 
@@ -47,8 +51,20 @@ vi.mock('@/components/ToastContext', () => ({
 }));
 
 vi.mock('@/hooks/useSessionState', () => ({
-  default: () => ['in-custody', vi.fn()],
+  default: () => [mockSessionStateValue.current, mockSetSessionState],
 }));
+
+vi.mock('./ScanTransferCodeModal', async () => {
+  const React = await import('react');
+  return {
+    default: ({ onClose, onSuccess }) => React.createElement(
+      'div',
+      { role: 'dialog', 'aria-label': 'Scan transfer code' },
+      React.createElement('button', { type: 'button', onClick: onSuccess }, 'scan success'),
+      React.createElement('button', { type: 'button', onClick: onClose }, 'cancel scan')
+    ),
+  };
+});
 
 vi.mock('@unhead/react', () => ({
   Head: ({ children }) => <>{children}</>,
@@ -75,6 +91,7 @@ function renderCustody () {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockSessionStateValue.current = 'in-custody';
 
   mockBedTypesIndex.mockResolvedValue({
     data: [{ id: 1, available: 17, inTransit: 2, occupied: 2, type: 'CHAIR' }],
@@ -124,5 +141,35 @@ describe('Custody', () => {
     expect(await screen.findByText('17 chairs available')).toBeInTheDocument();
     expect(screen.getByText('2 in transit')).toBeInTheDocument();
     expect(screen.getByText('2 occupied')).toBeInTheDocument();
+  });
+
+  it('shows the Take custody button on the Legally released tab', async () => {
+    mockSessionStateValue.current = 'released';
+
+    renderCustody();
+
+    expect(await screen.findByRole('button', { name: /take custody/i })).toBeInTheDocument();
+  });
+
+  it('switches to In custody when transfer scan succeeds from the Legally released tab', async () => {
+    mockSessionStateValue.current = 'released';
+
+    renderCustody();
+
+    fireEvent.click(await screen.findByRole('button', { name: /take custody/i }));
+    fireEvent.click(screen.getByRole('button', { name: /scan success/i }));
+
+    expect(mockSetSessionState).toHaveBeenCalledWith('in-custody');
+  });
+
+  it('leaves the user on the Legally released tab when transfer scan is canceled', async () => {
+    mockSessionStateValue.current = 'released';
+
+    renderCustody();
+
+    fireEvent.click(await screen.findByRole('button', { name: /take custody/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancel scan/i }));
+
+    expect(mockSetSessionState).not.toHaveBeenCalled();
   });
 });

--- a/client/src/lesc/components/custody/ScanTransferCodeModal.component.test.jsx
+++ b/client/src/lesc/components/custody/ScanTransferCodeModal.component.test.jsx
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+
+import ScanTransferCodeModal from './ScanTransferCodeModal';
+
+const {
+  mockDeflectionsTransfer,
+  mockShowToast,
+} = vi.hoisted(() => ({
+  mockDeflectionsTransfer: vi.fn(),
+  mockShowToast: vi.fn(),
+}));
+
+vi.mock('@/Api', () => ({
+  default: {
+    deflections: {
+      transfer: mockDeflectionsTransfer,
+    },
+  },
+}));
+
+vi.mock('@/FacilityContext', () => ({
+  useFacilityContext: () => ({
+    facility: {
+      name: 'LESC',
+    },
+  }),
+}));
+
+vi.mock('@/components/ToastContext', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+  }),
+}));
+
+vi.mock('@/components/ScanCodeModal', async () => {
+  const React = await import('react');
+  return {
+    default: ({ onManualSubmitCodes }) => (
+      <button type='button' onClick={() => onManualSubmitCodes(['not-a-code'])}>
+        submit invalid codes
+      </button>
+    ),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ScanTransferCodeModal', () => {
+  it('does not call success when manual code submission has no successful transfers', () => {
+    const onSuccess = vi.fn();
+
+    render(
+      <ScanTransferCodeModal
+        opened
+        onClose={vi.fn()}
+        onSuccess={onSuccess}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /submit invalid codes/i }));
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(mockDeflectionsTransfer).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/lesc/components/custody/ScanTransferCodeModal.jsx
+++ b/client/src/lesc/components/custody/ScanTransferCodeModal.jsx
@@ -46,8 +46,8 @@ function ScanTransferCodeModal ({ opened, onClose, onSuccess, _debugScanPhase })
 
     if (lastDeflectionId) {
       window.sessionStorage.setItem('custodyHighlightTarget', String(lastDeflectionId));
+      onSuccess?.();
     }
-    onSuccess?.();
     if (transferResults.every((r) => !r.error)) {
       showToast(
         'Person received',

--- a/server/test/helper.js
+++ b/server/test/helper.js
@@ -2,7 +2,7 @@
 // between our tests.
 
 import util from 'node:util';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs/promises';
 import helper from 'fastify-cli/helper.js';
 import path from 'node:path';
@@ -11,7 +11,7 @@ import YAML from 'yaml';
 import { StatusCodes } from 'http-status-codes';
 import * as nodemailerMock from 'nodemailer-mock';
 
-import { GenericContainer } from 'testcontainers';
+import { GenericContainer, Wait } from 'testcontainers';
 import { PostgreSqlContainer } from '@testcontainers/postgresql';
 import {
   Builder,
@@ -54,20 +54,53 @@ async function buildPostgres (t) {
   process.env.TESTCONTAINERS_RYUK_DISABLED = 'true';
   const compose = YAML.parse(await fs.readFile(path.join(__dirname, '../..', 'compose.yml'), 'utf8'));
   const testcontainersNetworkMode = process.env.TESTCONTAINERS_NETWORK_MODE;
+  const useNetworkAliases = Boolean(testcontainersNetworkMode);
+  const aliasSuffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   // extract current version of postgres image being used, start a new test container
-  let dbContainer = new PostgreSqlContainer(compose.services.db.image);
-  if (testcontainersNetworkMode) {
-    dbContainer = dbContainer.withNetworkMode(testcontainersNetworkMode);
-  }
+  const dbUsername = 'test';
+  const dbPassword = 'test';
+  const dbName = 'test';
+  const dbPort = 5432;
+  const dbAlias = `care-connect-test-db-${aliasSuffix}`;
+  const dbContainer = useNetworkAliases
+    ? new GenericContainer(compose.services.db.image)
+      .withNetworkMode(testcontainersNetworkMode)
+      .withNetworkAliases(dbAlias)
+      .withEnvironment({
+        POSTGRES_DB: dbName,
+        POSTGRES_USER: dbUsername,
+        POSTGRES_PASSWORD: dbPassword,
+      })
+      .withHealthCheck({
+        test: [
+          'CMD-SHELL',
+          `PGPASSWORD=${dbPassword} pg_isready --host localhost --username ${dbUsername} --dbname ${dbName}`,
+        ],
+        interval: 250,
+        timeout: 1000,
+        retries: 1000,
+      })
+      .withWaitStrategy(Wait.forHealthCheck())
+      .withStartupTimeout(120_000)
+    : new PostgreSqlContainer(compose.services.db.image);
   const startedDbContainer = await dbContainer.start();
+  const dbHost = useNetworkAliases ? dbAlias : startedDbContainer.getHost();
+  const dbMappedPort = useNetworkAliases ? dbPort : startedDbContainer.getPort();
+  const getDbUrl = (database) => {
+    const url = new URL(`postgresql://${dbUsername}:${dbPassword}@${dbHost}:${dbMappedPort}/${database}`);
+    url.searchParams.set('connection_limit', '1');
+    return url;
+  };
   // set up the default template (template1) with the schema and fixtures
-  const templateDbUrl = new URL(`postgresql://${startedDbContainer.getUsername()}:${startedDbContainer.getPassword()}@${startedDbContainer.getHost()}:${startedDbContainer.getPort()}/template1`);
-  templateDbUrl.searchParams.set('connection_limit', '1');
-  const TEMPLATE_DATABASE_URL = templateDbUrl.toString();
+  const TEMPLATE_DATABASE_URL = getDbUrl('template1').toString();
   // run the migrations
   const schemaPath = path.join(__dirname, '..', 'prisma', 'schema.prisma');
-  await util.promisify(exec)(`DATABASE_URL=${TEMPLATE_DATABASE_URL} npx prisma db push --schema ${schemaPath}`, {
+  await util.promisify(execFile)('npx', ['prisma', 'db', 'push', '--schema', schemaPath], {
     cwd: path.join(__dirname, '..'),
+    env: {
+      ...process.env,
+      DATABASE_URL: TEMPLATE_DATABASE_URL,
+    },
   });
   const prisma = new PrismaClient({
     datasourceUrl: TEMPLATE_DATABASE_URL,
@@ -83,22 +116,30 @@ async function buildPostgres (t) {
   }
   await prisma.$disconnect();
   // configure test database url
-  process.env.DATABASE_URL = `postgresql://${startedDbContainer.getUsername()}:${startedDbContainer.getPassword()}@${startedDbContainer.getHost()}:${startedDbContainer.getPort()}/${startedDbContainer.getDatabase()}`;
+  process.env.DATABASE_URL = getDbUrl(dbName).toString();
   t.prisma = new PrismaClient({ datasourceUrl: process.env.DATABASE_URL });
 
   // set up a new storage container
+  const storageAlias = `care-connect-test-storage-${aliasSuffix}`;
   let storageContainer = new GenericContainer(compose.services.storage.image)
-    .withEntrypoint(['minio', 'server', '/data'])
-    .withExposedPorts(9000);
-  if (testcontainersNetworkMode) {
-    storageContainer = storageContainer.withNetworkMode(testcontainersNetworkMode);
+    .withEntrypoint(['minio', 'server', '/data']);
+  if (useNetworkAliases) {
+    storageContainer = storageContainer
+      .withNetworkMode(testcontainersNetworkMode)
+      .withNetworkAliases(storageAlias)
+      .withStartupTimeout(120_000);
+  } else {
+    storageContainer = storageContainer
+      .withExposedPorts(9000);
   }
   const startedStorageContainer = await storageContainer.start();
   process.env.AWS_S3_ACCESS_KEY_ID = 'minioadmin';
   process.env.AWS_S3_SECRET_ACCESS_KEY = 'minioadmin';
   process.env.AWS_S3_BUCKET = 'app';
   process.env.AWS_S3_REGION = 'us-east-1';
-  process.env.AWS_S3_ENDPOINT = `http://${startedStorageContainer.getHost()}:${startedStorageContainer.getMappedPort(9000)}`;
+  process.env.AWS_S3_ENDPOINT = useNetworkAliases
+    ? `http://${storageAlias}:9000`
+    : `http://${startedStorageContainer.getHost()}:${startedStorageContainer.getMappedPort(9000)}`;
 
   // Reset S3 client to ensure it uses the new environment variables
   s3.reset();
@@ -153,7 +194,6 @@ async function buildPostgres (t) {
     await app.prisma.$disconnect();
     const templatePrisma = new PrismaClient({ datasourceUrl: TEMPLATE_DATABASE_URL });
     await templatePrisma.$connect();
-    const dbName = startedDbContainer.getDatabase();
     // Quote database name to handle special characters and ensure proper SQL escaping
     await templatePrisma.$executeRawUnsafe(`DROP DATABASE IF EXISTS "${dbName}" WITH (FORCE)`);
     await templatePrisma.$executeRawUnsafe('SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = \'template1\' AND pid <> pg_backend_pid();');


### PR DESCRIPTION
## Summary

- Keep the custody `Take custody` button visible on both `In custody` and `Legally released` tabs.
- Switch the custody view back to `In custody` after a successful transfer scan.
- Preserve the current tab when the scan flow is canceled or fails.
- Clean up: only fire transfer success for manual multi-code entry when at least one transfer actually succeeds.

Note: also made some changes to ensure tests were running locally; these may be duplicated in other PRs that I also worked on since I needed to clear tests on those also, so will require some clean up at merge.

Closes #651 