### PR TITLE
Adds no chairs as cancel reason for holds (#681)

### DIFF
--- a/server/prisma/migrations/20260421000000_add_no_chairs_available_cancel_reason/migration.sql
+++ b/server/prisma/migrations/20260421000000_add_no_chairs_available_cancel_reason/migration.sql
@@ -1,0 +1,17 @@
+INSERT INTO "DeflectionCancelReason" (
+  "id",
+  "name",
+  "createdById",
+  "updatedById"
+)
+SELECT
+  'no_chairs_available',
+  'No chairs available',
+  "User"."id",
+  "User"."id"
+FROM "User"
+ORDER BY ("User"."email" = 'admin@careconnectsf.org') DESC, "User"."createdAt" ASC
+LIMIT 1
+ON CONFLICT ("id") DO UPDATE SET
+  "name" = EXCLUDED."name",
+  "updatedAt" = CURRENT_TIMESTAMP;

--- a/server/prisma/seeds/deflectionCancelReasons.js
+++ b/server/prisma/seeds/deflectionCancelReasons.js
@@ -35,6 +35,12 @@ export default async function main (prisma) {
       updatedById: adminUser.id,
     },
     {
+      id: 'no_chairs_available',
+      name: 'No chairs available',
+      createdById: adminUser.id,
+      updatedById: adminUser.id,
+    },
+    {
       id: 'staffing_shortage',
       name: 'Staffing shortage',
       createdById: adminUser.id,

--- a/server/test/fixtures/db/deflectionCancelReasons.yml
+++ b/server/test/fixtures/db/deflectionCancelReasons.yml
@@ -21,6 +21,11 @@ items:
     name: 'Release on Scene'
     createdBy: '@user1'
     updatedBy: '@user1'
+  no_chairs_available:
+    id: 'no_chairs_available'
+    name: 'No chairs available'
+    createdBy: '@user1'
+    updatedBy: '@user1'
   staffing_shortage:
     id: 'staffing_shortage'
     name: 'Staffing shortage'

--- a/server/test/routes/api/deflections/cancel-reasons.test.js
+++ b/server/test/routes/api/deflections/cancel-reasons.test.js
@@ -19,13 +19,14 @@ test('/api/deflections/cancel-reasons', async (t) => {
       const reasons = JSON.parse(response.body);
 
       assert.ok(Array.isArray(reasons));
-      // From deflectionCancelReasons.yml there are 5 reasons
-      assert.ok(reasons.length >= 5);
+      // From deflectionCancelReasons.yml there are 6 reasons
+      assert.ok(reasons.length >= 6);
 
       const ids = reasons.map(r => r.id);
       assert.ok(ids.includes('5150'));
       assert.ok(ids.includes('jail'));
       assert.ok(ids.includes('hospital'));
+      assert.ok(ids.includes('no_chairs_available'));
       assert.ok(ids.includes('release_on_scene'));
       assert.ok(ids.includes('staffing_shortage'));
 


### PR DESCRIPTION
## Summary

Adds `No chairs available` as a hold cancellation reason for arresting officers canceling a hold before custody transfer.

## Changes

- Added `no_chairs_available` / `No chairs available` to deflection cancel reason seed data.
- Added a Prisma migration to insert the new cancel reason into deployed databases.
- Added the new reason to DB test fixtures.
- Updated the cancel-reasons API test to assert the new reason is returned.

## Note for anyone running tests locally

If you're not seeing the changes and are confused (as I wasn't and was), remember that the cancel reason list is loaded from the database via `/api/deflections/cancel-reasons`. Existing localhost databases will not show the new option until the migration is applied or the database is re-seeded.

Closes #681 