### PR TITLE
Fix officer fields on 647f form (#691)

### DIFF
--- a/server/lib/forms/647f/Form647f.jsx
+++ b/server/lib/forms/647f/Form647f.jsx
@@ -42,15 +42,15 @@ export default function Form647f ({ data = {} }) {
     arrestLocation = '',
     charge = '',
     cadNumber = '',
-    officerRank = '',
-    officerName = '',
-    officerBadge = '',
-    officerUnit = '',
-    officerAgency = '',
+    arrestingOfficerRank = '',
+    arrestingOfficerName = '',
+    arrestingOfficerBadge = '',
+    arrestingOfficerUnit = '',
+    arrestingOfficerAgency = '',
     supervisorBadgeNumber = '',
-    transferOfficerRank = '',
-    transferOfficerName = '',
-    transferOfficerBadge = '',
+    custodyReleaseOfficerRank = '',
+    custodyReleaseOfficerName = '',
+    custodyReleaseOfficerBadge = '',
     justification = '',
     hospitalCancellationReleaseNarrative = '',
     substanceFound = false,
@@ -60,8 +60,8 @@ export default function Form647f ({ data = {} }) {
     facilityAddress = '',
   } = data;
 
-  const arrestingOfficer = joinWords(officerRank, officerName, officerBadge && `#${officerBadge}`);
-  const transferOfficer = joinWords(transferOfficerRank, transferOfficerName, transferOfficerBadge && `#${transferOfficerBadge}`);
+  const arrestingOfficerDisplay = joinWords(arrestingOfficerRank, arrestingOfficerName, arrestingOfficerBadge && `#${arrestingOfficerBadge}`);
+  const custodyReleaseOfficerDisplay = joinWords(custodyReleaseOfficerRank, custodyReleaseOfficerName, custodyReleaseOfficerBadge && `#${custodyReleaseOfficerBadge}`);
   const substanceNot = substanceFound ? '' : 'not ';
   const paraphernaliaNot = paraphernaliaFound ? '' : 'not ';
   const narcoticsStatement = `SFPD Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
@@ -98,11 +98,11 @@ export default function Form647f ({ data = {} }) {
             <Row label='CAD Number' value={cadNumber} />
 
             <SectionHeader title='Officer Information' />
-            <Row label='Arresting Officer' value={arrestingOfficer} />
-            <Row label='Unit' value={officerUnit} />
-            <Row label='Agency' value={officerAgency} />
+            <Row label='Arresting Officer' value={arrestingOfficerDisplay} />
+            <Row label='Unit' value={arrestingOfficerUnit} />
+            <Row label='Agency' value={arrestingOfficerAgency} />
             <Row label="Supervising Sergeant's Star Number" value={supervisorBadgeNumber} />
-            <Row label='Officer Present at Custody Transfer' value={transferOfficer} />
+            <Row label='Officer Present at Custody Transfer' value={custodyReleaseOfficerDisplay} />
 
             <SectionHeader title='Additional Information' />
             <Row label='Hold ID' value={String(deflectionId)} />

--- a/server/lib/forms/647f/Form647f.jsx
+++ b/server/lib/forms/647f/Form647f.jsx
@@ -38,15 +38,16 @@ export default function Form647f ({ data = {} }) {
     subjectAddress = '',
     subjectDL = '',
     subjectLocalId = '',
-    cadNumber = '',
     arrestedAt = null,
-    officerName = '',
     arrestLocation = '',
-    officerUnit = '',
-    officerBadge = '',
-    supervisorBadgeNumber = '',
-    agency = '',
     charge = '',
+    cadNumber = '',
+    officerName = '',
+    officerBadge = '',
+    officerUnit = '',
+    agency = '',
+    supervisorBadgeNumber = '',
+    transferOfficerName = '',
     justification = '',
     hospitalCancellationReleaseNarrative = '',
     substanceFound = false,
@@ -86,15 +87,18 @@ export default function Form647f ({ data = {} }) {
             <Row label='Local ID / SF #' value={subjectLocalId} />
 
             <SectionHeader title='Arrest Information' />
-            <Row label='CAD Number' value={cadNumber} required />
             <Row label='Date/Time Arrested' value={formatDateTime24(arrestedAt)} required />
-            <Row label='Name of Transporting Officer' value={officerName} required />
             <Row label='Location Arrested' value={arrestLocation} required />
-            <Row label='Unit' value={officerUnit} required />
+            <Row label='Charge' value={charge || '647(f) RWS'} required />
+            <Row label='CAD Number' value={cadNumber} required />
+
+            <SectionHeader title='Officer Information' />
+            <Row label='Arresting Officer' value={officerName} required />
             <Row label='Badge Number / Star Number' value={officerBadge} required />
-            <Row label="Supervising Sergeant's Star Number" value={supervisorBadgeNumber} required />
+            <Row label='Unit' value={officerUnit} required />
             <Row label='Agency' value={agency} required />
-            <Row label='Charge' value={charge} required />
+            <Row label="Supervising Sergeant's Star Number" value={supervisorBadgeNumber} required />
+            <Row label='Officer Present at Custody Transfer' value={transferOfficerName} />
 
             <SectionHeader title='Additional Information' />
             <Row label='Hold ID' value={String(deflectionId)} />

--- a/server/lib/forms/647f/Form647f.jsx
+++ b/server/lib/forms/647f/Form647f.jsx
@@ -60,8 +60,8 @@ export default function Form647f ({ data = {} }) {
     facilityAddress = '',
   } = data;
 
-  const arrestingOfficer = joinWords(officerRank, officerName, `#${officerBadge}`);
-  const transferOfficer = joinWords(transferOfficerRank, transferOfficerName, `#${transferOfficerBadge}`);
+  const arrestingOfficer = joinWords(officerRank, officerName, officerBadge && `#${officerBadge}`);
+  const transferOfficer = joinWords(transferOfficerRank, transferOfficerName, transferOfficerBadge && `#${transferOfficerBadge}`);
   const substanceNot = substanceFound ? '' : 'not ';
   const paraphernaliaNot = paraphernaliaFound ? '' : 'not ';
   const narcoticsStatement = `SFPD Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;

--- a/server/lib/forms/647f/Form647f.jsx
+++ b/server/lib/forms/647f/Form647f.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FORM_TIMEZONE, formatDateTime24, formatDateOnly, titleCase } from '../shared/formUtils.js';
+import { FORM_TIMEZONE, formatDateTime24, formatDateOnly, titleCase, joinWords } from '../shared/formUtils.js';
 import { Header, Row, SectionHeader } from '../shared/formComponents.jsx';
 
 /*
@@ -42,12 +42,15 @@ export default function Form647f ({ data = {} }) {
     arrestLocation = '',
     charge = '',
     cadNumber = '',
+    officerRank = '',
     officerName = '',
     officerBadge = '',
     officerUnit = '',
-    agency = '',
+    officerAgency = '',
     supervisorBadgeNumber = '',
+    transferOfficerRank = '',
     transferOfficerName = '',
+    transferOfficerBadge = '',
     justification = '',
     hospitalCancellationReleaseNarrative = '',
     substanceFound = false,
@@ -57,6 +60,8 @@ export default function Form647f ({ data = {} }) {
     facilityAddress = '',
   } = data;
 
+  const arrestingOfficer = joinWords(officerRank, officerName, `#${officerBadge}`);
+  const transferOfficer = joinWords(transferOfficerRank, transferOfficerName, `#${transferOfficerBadge}`);
   const substanceNot = substanceFound ? '' : 'not ';
   const paraphernaliaNot = paraphernaliaFound ? '' : 'not ';
   const narcoticsStatement = `SFPD Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
@@ -76,29 +81,28 @@ export default function Form647f ({ data = {} }) {
         <table className='form-table'>
           <tbody>
             <SectionHeader title='Subject Information' />
-            <Row label='Subject Last Name' value={subjectLastName} required />
-            <Row label='Subject First Name' value={subjectFirstName} required />
+            <Row label='Subject Last Name' value={subjectLastName} />
+            <Row label='Subject First Name' value={subjectFirstName} />
             <Row label='Subject Middle Initial' value={subjectMiddleInitial} />
-            <Row label='Race' value={titleCase(subjectRace)} required />
-            <Row label='Sex' value={titleCase(subjectSex)} required />
-            <Row label='Date of Birth (DOB)' value={formatDateOnly(subjectDOB)} required />
+            <Row label='Race' value={titleCase(subjectRace)} />
+            <Row label='Sex' value={titleCase(subjectSex)} />
+            <Row label='Date of Birth (DOB)' value={formatDateOnly(subjectDOB)} />
             <Row label='Address' value={subjectAddress} />
             <Row label="Driver's License" value={subjectDL} />
             <Row label='Local ID / SF #' value={subjectLocalId} />
 
             <SectionHeader title='Arrest Information' />
-            <Row label='Date/Time Arrested' value={formatDateTime24(arrestedAt)} required />
-            <Row label='Location Arrested' value={arrestLocation} required />
-            <Row label='Charge' value={charge || '647(f) RWS'} required />
-            <Row label='CAD Number' value={cadNumber} required />
+            <Row label='Date/Time Arrested' value={formatDateTime24(arrestedAt)} />
+            <Row label='Location Arrested' value={arrestLocation} />
+            <Row label='Charge' value={charge || '647(f) RWS'} />
+            <Row label='CAD Number' value={cadNumber} />
 
             <SectionHeader title='Officer Information' />
-            <Row label='Arresting Officer' value={officerName} required />
-            <Row label='Badge Number / Star Number' value={officerBadge} required />
-            <Row label='Unit' value={officerUnit} required />
-            <Row label='Agency' value={agency} required />
-            <Row label="Supervising Sergeant's Star Number" value={supervisorBadgeNumber} required />
-            <Row label='Officer Present at Custody Transfer' value={transferOfficerName} />
+            <Row label='Arresting Officer' value={arrestingOfficer} />
+            <Row label='Unit' value={officerUnit} />
+            <Row label='Agency' value={officerAgency} />
+            <Row label="Supervising Sergeant's Star Number" value={supervisorBadgeNumber} />
+            <Row label='Officer Present at Custody Transfer' value={transferOfficer} />
 
             <SectionHeader title='Additional Information' />
             <Row label='Hold ID' value={String(deflectionId)} />
@@ -109,12 +113,10 @@ export default function Form647f ({ data = {} }) {
 
         <div className='narrative-section'>
           <div className='narrative-label'>
-            647(f) RWS Justification / Narrative<span style={{ color: '#c00' }}>*</span>
+            647(f) RWS Justification / Narrative
           </div>
           <div className='narrative-text'>{narrative}</div>
         </div>
-
-        <div className='footer-note'>* Required field</div>
 
         <footer>
           <span>

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -1,43 +1,33 @@
 import { metadata } from './metadata.js';
 import { getHospitalCancellationReleaseNarrative, HOSPITAL_CANCEL_REASON_ID } from '#lib/hospitalCancellation647f.js';
 import i18n from '#lib/i18n.js';
+import { firstLastName, streetCityState, streetCityStateZip } from '#lib/forms/shared/formUtils.js';
 
 export function transformData (deflection) {
   const subject = deflection.subject;
   const incident = deflection.incident;
 
-  const subjectAddress = [subject?.addressLine1, subject?.city, subject?.state]
-    .filter(Boolean)
-    .join(', ');
+  const subjectAddress = streetCityState(subject);
+  const arrestLocation = streetCityState(incident);
 
-  const arrestLocation = [incident?.addressLine1, incident?.city, incident?.state]
-    .filter(Boolean)
-    .join(', ');
-
-  const officer = incident?.createdBy || deflection.createdBy;
-  const officerRank = incident?.createdByTitle?.name || officer?.title?.name || '';
-  const officerName = officer
-    ? `${officer.firstName} ${officer.lastName}`
-    : '';
-  const officerBadge = incident?.createdByBadgeNumber || officer?.badgeNumber || '';
-  const officerUnit = incident?.createdByUnit?.name || officer?.unit?.name || '';
-  const officerAgency = incident?.createdByOrganization?.name || officer?.organization?.name || '';
+  const arrestingOfficer = incident?.createdBy || deflection.createdBy;
+  const arrestingOfficerRank = incident?.createdByTitle?.name || arrestingOfficer?.title?.name || '';
+  const arrestingOfficerName = firstLastName(arrestingOfficer);
+  const arrestingOfficerBadge = incident?.createdByBadgeNumber || arrestingOfficer?.badgeNumber || '';
+  const arrestingOfficerUnit = incident?.createdByUnit?.name || arrestingOfficer?.unit?.name || '';
+  const arrestingOfficerAgency = incident?.createdByOrganization?.name || arrestingOfficer?.organization?.name || '';
 
   // find the field officer who handed the subject to RESET:
   // use toOfficer from the most recent Handoff, or fall back to the deflection creator
   const mostRecentHandoff = deflection.handoffs?.toSorted((a, b) => new Date(b.timestamp) - new Date(a.timestamp))[0];
-  const transferOfficer = mostRecentHandoff?.toOfficer || incident?.createdBy || deflection.createdBy;
-  const transferOfficerRank = transferOfficer?.title?.name || '';
-  const transferOfficerName = transferOfficer
-    ? `${transferOfficer.firstName} ${transferOfficer.lastName}`
-    : '';
-  const transferOfficerBadge = transferOfficer?.badgeNumber || '';
-  const transferOfficerUnit = transferOfficer?.unit?.name || '';
+  const custodyReleaseOfficer = mostRecentHandoff?.toOfficer || arrestingOfficer;
+  const custodyReleaseOfficerRank = custodyReleaseOfficer?.title?.name || '';
+  const custodyReleaseOfficerName = firstLastName(custodyReleaseOfficer);
+  const custodyReleaseOfficerBadge = custodyReleaseOfficer?.badgeNumber || '';
+  const custodyReleaseOfficerUnit = custodyReleaseOfficer?.unit?.name || '';
 
   const facility = deflection.facility;
-  const facilityAddress = [facility?.addressLine1, facility?.city, facility?.state, facility?.postalCode]
-    .filter(Boolean)
-    .join(', ');
+  const facilityAddress = streetCityStateZip(facility);
 
   return {
     deflectionId: deflection.id,
@@ -54,16 +44,16 @@ export function transformData (deflection) {
     arrestLocation,
     charge: i18n.t(`chargeType.${deflection.chargeType || 'RWS_647F'}`),
     cadNumber: incident?.cadNumber || '',
-    officerRank,
-    officerName,
-    officerBadge,
-    officerUnit,
-    officerAgency,
+    arrestingOfficerRank,
+    arrestingOfficerName,
+    arrestingOfficerBadge,
+    arrestingOfficerUnit,
+    arrestingOfficerAgency,
     supervisorBadgeNumber: incident?.supervisorBadgeNumber || '',
-    transferOfficerRank,
-    transferOfficerName,
-    transferOfficerBadge,
-    transferOfficerUnit,
+    custodyReleaseOfficerRank,
+    custodyReleaseOfficerName,
+    custodyReleaseOfficerBadge,
+    custodyReleaseOfficerUnit,
     justification: deflection.behavior || '',
     hospitalCancellationReleaseNarrative: deflection.cancelReasonId === HOSPITAL_CANCEL_REASON_ID
       ? getHospitalCancellationReleaseNarrative(deflection.cancelledAt)

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -14,23 +14,25 @@ export function transformData (deflection) {
     .filter(Boolean)
     .join(', ');
 
-  const arrestingOfficerRecord = incident?.incidentOfficers?.find(record => record.role === 'ARRESTING');
-  const officer = arrestingOfficerRecord?.officer || incident?.createdBy || deflection.createdBy;
-  const officerRank = arrestingOfficerRecord?.title?.name || officer?.title?.name || '';
+  const officer = incident?.createdBy || deflection.createdBy;
+  const officerRank = incident?.createdByTitle?.name || officer?.title?.name || '';
   const officerName = officer
     ? `${officer.firstName} ${officer.lastName}`
     : '';
-  const officerBadge = arrestingOfficerRecord?.badgeNumber || incident?.createdByBadgeNumber || officer?.badgeNumber || '';
-  const officerUnit = arrestingOfficerRecord?.unit?.name || incident?.createdByUnit?.name || officer?.unit?.name || '';
-  const officerAgency = arrestingOfficerRecord?.organization?.name || officer?.organization?.name || '';
+  const officerBadge = incident?.createdByBadgeNumber || officer?.badgeNumber || '';
+  const officerUnit = incident?.createdByUnit?.name || officer?.unit?.name || '';
+  const officerAgency = incident?.createdByOrganization?.name || officer?.organization?.name || '';
 
-  const transferOfficer = deflection.transferredBy;
-  const transferOfficerRank = deflection.transferredByTitle?.name || transferOfficer?.title?.name || '';
+  // find the field officer who handed the subject to RESET:
+  // use toOfficer from the most recent Handoff, or fall back to the deflection creator
+  const mostRecentHandoff = deflection.handoffs?.toSorted((a, b) => new Date(b.timestamp) - new Date(a.timestamp))[0];
+  const transferOfficer = mostRecentHandoff?.toOfficer || incident?.createdBy || deflection.createdBy;
+  const transferOfficerRank = transferOfficer?.title?.name || '';
   const transferOfficerName = transferOfficer
     ? `${transferOfficer.firstName} ${transferOfficer.lastName}`
     : '';
-  const transferOfficerBadge = deflection.transferredByBadgeNumber || transferOfficer?.badgeNumber || '';
-  const transferOfficerUnit = deflection.transferredByUnit?.name || transferOfficer?.unit?.name || '';
+  const transferOfficerBadge = transferOfficer?.badgeNumber || '';
+  const transferOfficerUnit = transferOfficer?.unit?.name || '';
 
   const facility = deflection.facility;
   const facilityAddress = [facility?.addressLine1, facility?.city, facility?.state, facility?.postalCode]
@@ -50,7 +52,7 @@ export function transformData (deflection) {
     subjectLocalId: subject?.localId || '',
     arrestedAt: incident?.arrestedAt?.toISOString() || null,
     arrestLocation,
-    charge: '647(f) RWS',
+    charge: i18n.t(`chargeType.${deflection.chargeType || 'RWS_647F'}`),
     cadNumber: incident?.cadNumber || '',
     officerRank,
     officerName,
@@ -58,8 +60,8 @@ export function transformData (deflection) {
     officerUnit,
     officerAgency,
     supervisorBadgeNumber: incident?.supervisorBadgeNumber || '',
-    agency,
-    charge: i18n.t(`chargeType.${deflection.chargeType || 'RWS_647F'}`),
+    transferOfficerRank,
+    transferOfficerName,
     transferOfficerBadge,
     transferOfficerUnit,
     justification: deflection.behavior || '',

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -5,7 +5,6 @@ import i18n from '#lib/i18n.js';
 export function transformData (deflection) {
   const subject = deflection.subject;
   const incident = deflection.incident;
-  const officer = incident?.createdBy || deflection.createdBy;
 
   const subjectAddress = [subject?.addressLine1, subject?.city, subject?.state]
     .filter(Boolean)
@@ -15,12 +14,19 @@ export function transformData (deflection) {
     .filter(Boolean)
     .join(', ');
 
+  const arrestingOfficerRecord = incident?.incidentOfficers?.find(record => record.role === 'ARRESTING');
+  const officer = arrestingOfficerRecord?.officer || incident?.createdBy || deflection.createdBy;
   const officerName = officer
     ? `${officer.firstName} ${officer.lastName}`
     : '';
   const officerBadge = incident?.createdByBadgeNumber || officer?.badgeNumber || '';
   const officerUnit = incident?.createdByUnit?.name || officer?.unit?.name || '';
   const agency = officer?.organization?.name || '';
+
+  const transferOfficer = deflection.transferredBy;
+  const transferOfficerName = transferOfficer
+    ? `${transferOfficer.firstName} ${transferOfficer.lastName}`
+    : '';
 
   const facility = deflection.facility;
   const facilityAddress = [facility?.addressLine1, facility?.city, facility?.state, facility?.postalCode]
@@ -38,12 +44,14 @@ export function transformData (deflection) {
     subjectAddress,
     subjectDL: subject?.driverLicense || '',
     subjectLocalId: subject?.localId || '',
-    cadNumber: incident?.cadNumber || '',
     arrestedAt: incident?.arrestedAt?.toISOString() || null,
-    officerName,
     arrestLocation,
-    officerUnit,
+    charge: '647(f) RWS',
+    cadNumber: incident?.cadNumber || '',
+    officerName,
     officerBadge,
+    officerUnit,
+    agency,
     supervisorBadgeNumber: incident?.supervisorBadgeNumber || '',
     agency,
     charge: i18n.t(`chargeType.${deflection.chargeType || 'RWS_647F'}`),

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -16,17 +16,21 @@ export function transformData (deflection) {
 
   const arrestingOfficerRecord = incident?.incidentOfficers?.find(record => record.role === 'ARRESTING');
   const officer = arrestingOfficerRecord?.officer || incident?.createdBy || deflection.createdBy;
+  const officerRank = arrestingOfficerRecord?.title?.name || officer?.title?.name || '';
   const officerName = officer
     ? `${officer.firstName} ${officer.lastName}`
     : '';
-  const officerBadge = incident?.createdByBadgeNumber || officer?.badgeNumber || '';
-  const officerUnit = incident?.createdByUnit?.name || officer?.unit?.name || '';
-  const agency = officer?.organization?.name || '';
+  const officerBadge = arrestingOfficerRecord?.badgeNumber || incident?.createdByBadgeNumber || officer?.badgeNumber || '';
+  const officerUnit = arrestingOfficerRecord?.unit?.name || incident?.createdByUnit?.name || officer?.unit?.name || '';
+  const officerAgency = arrestingOfficerRecord?.organization?.name || officer?.organization?.name || '';
 
   const transferOfficer = deflection.transferredBy;
+  const transferOfficerRank = deflection.transferredByTitle?.name || transferOfficer?.title?.name || '';
   const transferOfficerName = transferOfficer
     ? `${transferOfficer.firstName} ${transferOfficer.lastName}`
     : '';
+  const transferOfficerBadge = deflection.transferredByBadgeNumber || transferOfficer?.badgeNumber || '';
+  const transferOfficerUnit = deflection.transferredByUnit?.name || transferOfficer?.unit?.name || '';
 
   const facility = deflection.facility;
   const facilityAddress = [facility?.addressLine1, facility?.city, facility?.state, facility?.postalCode]
@@ -48,13 +52,16 @@ export function transformData (deflection) {
     arrestLocation,
     charge: '647(f) RWS',
     cadNumber: incident?.cadNumber || '',
+    officerRank,
     officerName,
     officerBadge,
     officerUnit,
-    agency,
+    officerAgency,
     supervisorBadgeNumber: incident?.supervisorBadgeNumber || '',
     agency,
     charge: i18n.t(`chargeType.${deflection.chargeType || 'RWS_647F'}`),
+    transferOfficerBadge,
+    transferOfficerUnit,
     justification: deflection.behavior || '',
     hospitalCancellationReleaseNarrative: deflection.cancelReasonId === HOSPITAL_CANCEL_REASON_ID
       ? getHospitalCancellationReleaseNarrative(deflection.cancelledAt)

--- a/server/lib/forms/647f/metadata.js
+++ b/server/lib/forms/647f/metadata.js
@@ -31,6 +31,7 @@ export const metadata = {
       include: {
         organization: true,
         unit: true,
+        title: true,
       },
     },
   },

--- a/server/lib/forms/647f/metadata.js
+++ b/server/lib/forms/647f/metadata.js
@@ -27,6 +27,8 @@ export const metadata = {
         title: true,
       },
     },
+    transferredByTitle: true,
+    transferredByUnit: true,
     createdBy: {
       include: {
         organization: true,

--- a/server/lib/forms/647f/metadata.js
+++ b/server/lib/forms/647f/metadata.js
@@ -18,17 +18,23 @@ export const metadata = {
             title: true,
           },
         },
+        createdByTitle: true,
+        createdByUnit: true,
+        createdByOrganization: true,
       },
     },
     facility: true,
-    transferredBy: {
+    handoffs: {
       include: {
-        unit: true,
-        title: true,
+        toOfficer: {
+          include: {
+            organization: true,
+            unit: true,
+            title: true,
+          },
+        },
       },
     },
-    transferredByTitle: true,
-    transferredByUnit: true,
     createdBy: {
       include: {
         organization: true,

--- a/server/lib/forms/647f/metadata.js
+++ b/server/lib/forms/647f/metadata.js
@@ -20,6 +20,7 @@ export const metadata = {
       },
     },
     facility: true,
+    transferredBy: true,
     createdBy: {
       include: {
         organization: true,

--- a/server/lib/forms/647f/metadata.js
+++ b/server/lib/forms/647f/metadata.js
@@ -15,12 +15,18 @@ export const metadata = {
           include: {
             organization: true,
             unit: true,
+            title: true,
           },
         },
       },
     },
     facility: true,
-    transferredBy: true,
+    transferredBy: {
+      include: {
+        unit: true,
+        title: true,
+      },
+    },
     createdBy: {
       include: {
         organization: true,

--- a/server/lib/forms/shared/formUtils.js
+++ b/server/lib/forms/shared/formUtils.js
@@ -41,3 +41,7 @@ export function titleCase (str) {
   if (!str) return '';
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 }
+
+export function joinWords (...words) {
+  return words.filter(Boolean).join(' ');
+}

--- a/server/lib/forms/shared/formUtils.js
+++ b/server/lib/forms/shared/formUtils.js
@@ -45,3 +45,15 @@ export function titleCase (str) {
 export function joinWords (...words) {
   return words.filter(Boolean).join(' ');
 }
+
+export function firstLastName (obj) {
+  return [obj?.firstName, obj?.lastName].filter(Boolean).join(' ');
+}
+
+export function streetCityState (obj) {
+  return [obj?.addressLine1, obj?.city, obj?.state].filter(Boolean).join(', ');
+}
+
+export function streetCityStateZip (obj) {
+  return [streetCityState(obj), obj?.postalCode].filter(Boolean).join(' ');
+}

--- a/server/lib/forms/shared/pdf-forms.css
+++ b/server/lib/forms/shared/pdf-forms.css
@@ -100,6 +100,7 @@
 			.required {
 				color: #c00;
 				margin-left: 2pt;
+				display: none;
 			}
 
 			.section-header {

--- a/server/lib/forms/shared/pdf-forms.css
+++ b/server/lib/forms/shared/pdf-forms.css
@@ -100,7 +100,6 @@
 			.required {
 				color: #c00;
 				margin-left: 2pt;
-				display: none;
 			}
 
 			.section-header {

--- a/server/test/lib/forms/647f.test.js
+++ b/server/test/lib/forms/647f.test.js
@@ -3,6 +3,65 @@ import assert from 'node:assert/strict';
 
 import { transformData } from '#lib/forms/647f/generate.js';
 
+const baseDeflection = {
+  id: 1,
+  behavior: null,
+  narcoticsSubstance: null,
+  narcoticsParaphernalia: null,
+  cancelReasonId: null,
+  cancelledAt: null,
+  subject: null,
+  incident: null,
+  facility: null,
+  createdBy: null,
+  handoffs: [],
+};
+
+test('647f transferOfficer: no handoffs — falls back to incident.createdBy', () => {
+  const incidentCreator = { firstName: 'Jane', lastName: 'Smith', badgeNumber: 'B001', title: { name: 'Officer' }, unit: { name: 'Unit 1' } };
+  const deflectionCreator = { firstName: 'Other', lastName: 'Person', badgeNumber: 'B999', title: { name: 'Sergeant' }, unit: { name: 'Other Unit' } };
+  const data = transformData({
+    ...baseDeflection,
+    createdBy: deflectionCreator,
+    incident: { createdBy: incidentCreator },
+  });
+
+  assert.equal(data.transferOfficerName, 'Jane Smith');
+  assert.equal(data.transferOfficerBadge, 'B001');
+  assert.equal(data.transferOfficerRank, 'Officer');
+  assert.equal(data.transferOfficerUnit, 'Unit 1');
+});
+
+test('647f transferOfficer: no handoffs and no incident — falls back to deflection.createdBy', () => {
+  const creator = { firstName: 'Jane', lastName: 'Smith', badgeNumber: 'B001', title: { name: 'Officer' }, unit: { name: 'Unit 1' } };
+  const data = transformData({
+    ...baseDeflection,
+    createdBy: creator,
+  });
+
+  assert.equal(data.transferOfficerName, 'Jane Smith');
+});
+
+test('647f transferOfficer: handoff exists — uses toOfficer from the most recent Handoff', () => {
+  const fieldOfficer = { firstName: 'Al', lastName: 'Vega', badgeNumber: 'F100', title: { name: 'Deputy' }, unit: { name: 'Field Unit' } };
+  const olderFieldOfficer = { firstName: 'Old', lastName: 'Guy', badgeNumber: 'F099', title: { name: 'Sergeant' }, unit: { name: 'Old Unit' } };
+  const creator = { firstName: 'Jane', lastName: 'Smith', badgeNumber: 'B001', title: { name: 'Officer' }, unit: { name: 'Unit 1' } };
+
+  const data = transformData({
+    ...baseDeflection,
+    createdBy: creator,
+    handoffs: [
+      { timestamp: new Date('2025-01-01T10:00:00Z'), toOfficer: olderFieldOfficer },
+      { timestamp: new Date('2025-01-01T11:00:00Z'), toOfficer: fieldOfficer },
+    ],
+  });
+
+  assert.equal(data.transferOfficerName, 'Al Vega');
+  assert.equal(data.transferOfficerBadge, 'F100');
+  assert.equal(data.transferOfficerRank, 'Deputy');
+  assert.equal(data.transferOfficerUnit, 'Field Unit');
+});
+
 test('647f hospital cancellation appends the release narrative', () => {
   const data = transformData({
     id: 42,

--- a/server/test/lib/forms/647f.test.js
+++ b/server/test/lib/forms/647f.test.js
@@ -26,10 +26,10 @@ test('647f transferOfficer: no handoffs — falls back to incident.createdBy', (
     incident: { createdBy: incidentCreator },
   });
 
-  assert.equal(data.transferOfficerName, 'Jane Smith');
-  assert.equal(data.transferOfficerBadge, 'B001');
-  assert.equal(data.transferOfficerRank, 'Officer');
-  assert.equal(data.transferOfficerUnit, 'Unit 1');
+  assert.equal(data.custodyReleaseOfficerName, 'Jane Smith');
+  assert.equal(data.custodyReleaseOfficerBadge, 'B001');
+  assert.equal(data.custodyReleaseOfficerRank, 'Officer');
+  assert.equal(data.custodyReleaseOfficerUnit, 'Unit 1');
 });
 
 test('647f transferOfficer: no handoffs and no incident — falls back to deflection.createdBy', () => {
@@ -39,7 +39,7 @@ test('647f transferOfficer: no handoffs and no incident — falls back to deflec
     createdBy: creator,
   });
 
-  assert.equal(data.transferOfficerName, 'Jane Smith');
+  assert.equal(data.custodyReleaseOfficerName, 'Jane Smith');
 });
 
 test('647f transferOfficer: handoff exists — uses toOfficer from the most recent Handoff', () => {
@@ -56,10 +56,10 @@ test('647f transferOfficer: handoff exists — uses toOfficer from the most rece
     ],
   });
 
-  assert.equal(data.transferOfficerName, 'Al Vega');
-  assert.equal(data.transferOfficerBadge, 'F100');
-  assert.equal(data.transferOfficerRank, 'Deputy');
-  assert.equal(data.transferOfficerUnit, 'Field Unit');
+  assert.equal(data.custodyReleaseOfficerName, 'Al Vega');
+  assert.equal(data.custodyReleaseOfficerBadge, 'F100');
+  assert.equal(data.custodyReleaseOfficerRank, 'Deputy');
+  assert.equal(data.custodyReleaseOfficerUnit, 'Field Unit');
 });
 
 test('647f hospital cancellation appends the release narrative', () => {


### PR DESCRIPTION
Fixes #691

- Rename 'Transporting Officer' to 'Arresting Officer'
- Add new 'Officer Information' section
- Add 'Officer Present at Custody Transfer' row sourced from Handoff table: use `toOfficer` from the most recent Handoff by timestamp, falling back to `incident.createdBy` then `deflection.createdBy`
- Include `handoffs` in `deflectionInclude` for Prisma query
- Include the officer rank and badge number for the arresting and transfer officers
- Reorder fields to better match other forms
- Remove `required` flags from the 647(f) field, since it's strange to have required fields in a non-fillable form
- Add utils for generating strings from first/last names and addresses, with appropriate filtering for undefined values
 
<img width="710" height="693" alt="image" src="https://github.com/user-attachments/assets/7cb31d5a-af8b-40bd-bb8e-816f500af7df" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sfbrigade/care-connect/pull/697" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
