### PR TITLE
Updates release reasons per SFSO request (#731)

### DIFF
--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -212,7 +212,8 @@ function LegalReleaseQuestions () {
                     <Chip.Group value={releaseReasonId} onChange={setReleaseReasonId}>
                       <Stack gap='sm' align='flex-start'>
                         <Chip data-testid='release-reason-sobered' value='sobered'>Can care for themselves</Chip>
-                        <Chip value='medical_issue'>Medical issue</Chip>
+                        <Chip value='medical_issue'>Medical issue (physical)</Chip>
+                        <Chip value='behavioral_health_evaluation'>Behavioral health evaluation</Chip>
                         <Chip value='other'>Other (please specify)</Chip>
                       </Stack>
                     </Chip.Group>
@@ -221,7 +222,7 @@ function LegalReleaseQuestions () {
                 {isMedicalRelease && (
                   <>
                     <Text size='md' c='dimmed'>
-                      This &lsquo;Medical issue&rsquo; release will also mark the person as exited from RESET
+                      This &lsquo;Medical issue (physical)&rsquo; release will also mark the person as exited from RESET
                     </Text>
                     <Input.Wrapper label='Exit destination' required>
                       <Chip.Group value={exitDestinationId} onChange={setExitDestinationId}>
@@ -283,7 +284,10 @@ function LegalReleaseQuestions () {
                     !releaseReasonId ||
                     (releaseReasonId === 'medical_issue' && !exitDestinationId) ||
                     (releaseReasonId === 'other' && (!otherReason.trim() || !otherDestination.trim())) ||
-                    (releaseReasonId !== 'sobered' && releaseReasonId !== 'medical_issue' && releaseReasonId !== 'other')
+                    (releaseReasonId !== 'sobered' &&
+                      releaseReasonId !== 'medical_issue' &&
+                      releaseReasonId !== 'behavioral_health_evaluation' &&
+                      releaseReasonId !== 'other')
                   }
                 >
                   {isExitRelease ? 'Confirm release and exit' : 'Confirm release'}

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MantineProvider } from '@mantine/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -134,5 +134,28 @@ describe('LegalReleaseQuestions', () => {
     expect(screen.queryByRole('button', { name: 'Undo review' })).not.toBeInTheDocument();
     expect(screen.queryByText('Release reason')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Confirm release' })).not.toBeInTheDocument();
+  });
+
+  it('renders the updated release reason labels', async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+
+    expect(screen.getByRole('radio', { name: 'Medical issue (physical)' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Behavioral health evaluation' })).toBeInTheDocument();
+  });
+
+  it('submits behavioral health evaluation as the selected release reason', async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+    fireEvent.click(screen.getByRole('radio', { name: 'Behavioral health evaluation' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm release' }));
+
+    await waitFor(() => {
+      expect(mockDeflectionRelease).toHaveBeenCalledWith('123', {
+        releaseReasonId: 'behavioral_health_evaluation',
+      });
+    });
   });
 });

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.test.js
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.test.js
@@ -28,6 +28,18 @@ describe('getPrefilledLegalReleaseState', () => {
     });
   });
 
+  it('accepts behavioral health evaluation as a valid preset without an exit destination', () => {
+    const params = new URLSearchParams({
+      releaseReasonId: 'behavioral_health_evaluation',
+      exitDestinationId: 'hospital',
+    });
+
+    expect(getPrefilledLegalReleaseState(params)).toEqual({
+      releaseReasonId: 'behavioral_health_evaluation',
+      exitDestinationId: null,
+    });
+  });
+
   it('drops invalid preset values', () => {
     const params = new URLSearchParams({
       releaseReasonId: 'not-real',

--- a/client/src/lesc/components/custody/legalReleasePresets.js
+++ b/client/src/lesc/components/custody/legalReleasePresets.js
@@ -1,4 +1,4 @@
-const VALID_RELEASE_REASON_IDS = new Set(['sobered', 'medical_issue', 'other']);
+const VALID_RELEASE_REASON_IDS = new Set(['sobered', 'medical_issue', 'behavioral_health_evaluation', 'other']);
 const VALID_MEDICAL_EXIT_DESTINATION_IDS = new Set(['hospital', 'other']);
 
 export function getPrefilledLegalReleaseState (searchParams) {

--- a/server/prisma/seeds/deflectionReleaseReasons.js
+++ b/server/prisma/seeds/deflectionReleaseReasons.js
@@ -18,7 +18,13 @@ export default async function main (prisma) {
     },
     {
       id: 'medical_issue',
-      name: 'Medical issue',
+      name: 'Medical issue (physical)',
+      createdById: adminUser.id,
+      updatedById: adminUser.id,
+    },
+    {
+      id: 'behavioral_health_evaluation',
+      name: 'Behavioral health evaluation',
       createdById: adminUser.id,
       updatedById: adminUser.id,
     },

--- a/server/test/fixtures/db/deflectionReleaseReasons.yml
+++ b/server/test/fixtures/db/deflectionReleaseReasons.yml
@@ -8,7 +8,12 @@ items:
     updatedBy: '@user1'
   deflection_release_reason_medical_issue:
     id: 'medical_issue'
-    name: 'Medical issue'
+    name: 'Medical issue (physical)'
+    createdBy: '@user1'
+    updatedBy: '@user1'
+  deflection_release_reason_behavioral_health_evaluation:
+    id: 'behavioral_health_evaluation'
+    name: 'Behavioral health evaluation'
     createdBy: '@user1'
     updatedBy: '@user1'
   deflection_release_reason_other:

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -1655,6 +1655,49 @@ test('/api/deflections', async (t) => {
       assert.ok(dbDeflection.exitedAt);
     });
 
+    await t.test('marks a subject as legally released (behavioral health evaluation)', async () => {
+      await prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'ADMITTED',
+          status: 'ACTIVE',
+          completedAt: null,
+          releasedAt: null,
+          releasedById: null,
+          releaseReasonId: null,
+          exitedAt: null,
+          exitedById: null,
+          exitDestinationId: null,
+        },
+      });
+
+      const response = await app.inject()
+        .post('/api/deflections/6/release')
+        .headers(custodyUserHeaders)
+        .payload({
+          releaseReasonId: 'behavioral_health_evaluation',
+        });
+
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+
+      assert.strictEqual(data.subjectStatus, 'RELEASED');
+      assert.strictEqual(data.status, 'ACTIVE');
+      assert.strictEqual(data.releaseReasonId, 'behavioral_health_evaluation');
+      assert.strictEqual(data.exitDestinationId, null);
+      assert.ok(data.releasedAt);
+      assert.strictEqual(data.completedAt, null);
+      assert.strictEqual(data.exitedAt, null);
+
+      const dbDeflection = await prisma.deflection.findUnique({ where: { id: 6 } });
+      assert.strictEqual(dbDeflection.subjectStatus, 'RELEASED');
+      assert.strictEqual(dbDeflection.status, 'ACTIVE');
+      assert.strictEqual(dbDeflection.releaseReasonId, 'behavioral_health_evaluation');
+      assert.strictEqual(dbDeflection.exitDestinationId, null);
+      assert.strictEqual(dbDeflection.completedAt, null);
+      assert.strictEqual(dbDeflection.exitedAt, null);
+    });
+
     await t.test('marks a subject as legally released (other)', async () => {
       // Setup: reset deflection 6 status
       await prisma.deflection.update({


### PR DESCRIPTION
## Summary

Updates the custody legal release reason options to support the new release workflow.

## Changes

- Renames `Medical issue` to `Medical issue (physical)` in the custody legal release UI
- Adds `Behavioral health evaluation` as a new selectable release reason chip
- Updates release reason seed data and test fixtures so the new option persists via `releaseReasonId` - these are very targeted; decided not to make them cover just the rendering of the changes and not all the options, but can easily change that if needed
- Extends client and server tests to cover the renamed label and new behavioral health release path

Closes #731 