### PR TITLE
[Bugfix] SFPD: Automatically use location when creating a new Incident

### DIFF
--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -110,6 +110,7 @@ function IncidentForm () {
   const [isInitialized, setInitialized] = useState(false);
   const [showAddressForm, setShowAddressForm] = useState(false);
   const addressRef = useRef();
+  const autoGeolocationRequestedRef = useRef(false);
   const isEditing = !!incidentId;
 
   const form = useForm({
@@ -140,6 +141,16 @@ function IncidentForm () {
           form.setErrors(validateIncident(data));
         }
         setInitialized(true);
+        // If this is a brand-new incident, and the incident doesn't already have an address,
+        // then try using device location to fill in the address/location data
+        if (isConfirmIncidentFlow && !data.addressLine1 && !autoGeolocationRequestedRef.current) {
+          autoGeolocationRequestedRef.current = true;
+          getCurrentLocationAddress().then((address) => {
+            if (address) {
+              form.setValues(address);
+            }
+          });
+        }
       }
     } else {
       const now = DateTime.now().toISO({


### PR DESCRIPTION
Closes #750 , which is a recent regression from the intended functionality.

In this PR:
- In the IncidentDetails form, if this our first time presenting a fresh new Incident, and if the address is not already populated (as an extra precaution), then we attempt to fill in the address automatically from the device location
- This used to be the behavior until recently. I believe it regressed in https://github.com/sfbrigade/care-connect/pull/676.

