### PR TITLE
[Dev] Update test users so they look distinct

### DIFF
--- a/server/prisma/seeds/users.js
+++ b/server/prisma/seeds/users.js
@@ -6,8 +6,8 @@ export default async function main (prisma) {
   const users = [
     {
       email: 'sfpd@careconnectsf.org',
-      firstName: 'SFPD',
-      lastName: 'User',
+      firstName: 'Test',
+      lastName: 'SFPD1',
       isAdmin: false,
       organizationId: 'sfpd',
       roles: ['FIELD'],
@@ -16,8 +16,8 @@ export default async function main (prisma) {
     },
     {
       email: 'sfpd2@careconnectsf.org',
-      firstName: 'SFPD2',
-      lastName: 'User',
+      firstName: 'Test',
+      lastName: 'SFPD2',
       isAdmin: false,
       organizationId: 'sfpd',
       roles: ['FIELD'],
@@ -26,8 +26,8 @@ export default async function main (prisma) {
     },
     {
       email: 'sfso@careconnectsf.org',
-      firstName: 'SFSO',
-      lastName: 'User',
+      firstName: 'Test',
+      lastName: 'SFSO',
       isAdmin: false,
       organizationId: 'sfso',
       roles: ['FIELD', 'CUSTODY', 'ORG_ADMIN'],
@@ -36,8 +36,8 @@ export default async function main (prisma) {
     },
     {
       email: 'sfso2@careconnectsf.org',
-      firstName: 'SFSO2',
-      lastName: 'User',
+      firstName: 'Test',
+      lastName: 'SFSO2',
       isAdmin: false,
       organizationId: 'sfso',
       roles: ['FIELD', 'CUSTODY'],
@@ -46,8 +46,8 @@ export default async function main (prisma) {
     },
     {
       email: 'care@careconnectsf.org',
-      firstName: 'Care',
-      lastName: 'User',
+      firstName: 'Test',
+      lastName: 'Care',
       isAdmin: false,
       organizationId: 'connections',
       roles: ['CARE', 'FACILITY_ADMIN'],


### PR DESCRIPTION
Closes #752.

Before:
<img width="359" height="80" alt="Image" src="https://github.com/user-attachments/assets/6bc809ec-9b33-4493-b763-94451233a752" />

After:
<img width="347" height="89" alt="Image" src="https://github.com/user-attachments/assets/b669f395-d860-4b99-87a9-efc5f2d6b3ba" />

In this PR:

- Update the seed files to change the display names for the test account. This way, the test accounts (used by developers) will actually look distinct from each other. Currently they all look exactly the same (`S. User`). This happened after we changed the app header to only display the first initial rather than the full first name. (We apparently did this in order to make room for the role badge that we sometimes need to show.)
- The usernames and passwords are all unchanged. Only the display `firstName` and `lastName` are changed here.

Deployment notes:

- Nothing to do in prod, since (I assume) we do not run this seed on Prod.
- Developers will need to re-seed their local DB in order to see the change.