### PR TITLE
Allow valid emails with apostrophe

### DIFF
--- a/client/src/Admin/Invites/AdminInviteForm.jsx
+++ b/client/src/Admin/Invites/AdminInviteForm.jsx
@@ -1,6 +1,8 @@
 import { useNavigate } from 'react-router';
 import { Alert, Button, Checkbox, Container, Fieldset, Group, Stack, Select, Textarea, TextInput, Title } from '@mantine/core';
-import { isEmail, isNotEmpty, useForm } from '@mantine/form';
+import { isNotEmpty, useForm } from '@mantine/form';
+
+import { isEmail } from '@/utils/email';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { Head } from '@unhead/react';
 

--- a/client/src/Admin/Invites/util.js
+++ b/client/src/Admin/Invites/util.js
@@ -1,4 +1,4 @@
-import { isEmail } from '@mantine/form';
+import { isEmail } from '../../utils/email';
 const emailValidator = isEmail('Please enter a valid email address.');
 
 function parseCsvLine (line) {

--- a/client/src/Admin/Users/AdminUserForm.jsx
+++ b/client/src/Admin/Users/AdminUserForm.jsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router';
 import { Alert, Button, Checkbox, Container, Fieldset, Group, Select, Stack, TextInput, Title } from '@mantine/core';
-import { hasLength, isEmail, isNotEmpty, useForm } from '@mantine/form';
+import { hasLength, isNotEmpty, useForm } from '@mantine/form';
+
+import { isEmail } from '@/utils/email';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Head } from '@unhead/react';
 

--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useNavigate, Link, useLocation, useSearchParams } from 'react-router';
 import { Alert, Button, Container, Fieldset, Input, PinInput, Stack, Text, TextInput, Title } from '@mantine/core';
-import { isEmail, useForm } from '@mantine/form';
+import { useForm } from '@mantine/form';
+
+import { isEmail } from '@/utils/email';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Head } from '@unhead/react';
 import { IconMail, IconLock, IconArrowLeft } from '@tabler/icons-react';

--- a/client/src/ManageUsers/InviteUserModal.jsx
+++ b/client/src/ManageUsers/InviteUserModal.jsx
@@ -1,5 +1,7 @@
 import { Alert, Button, Stack, TextInput } from '@mantine/core';
-import { isEmail, isNotEmpty, useForm } from '@mantine/form';
+import { isNotEmpty, useForm } from '@mantine/form';
+
+import { isEmail } from '@/utils/email';
 import { useMutation } from '@tanstack/react-query';
 
 import Api from '@/Api';

--- a/client/src/Passwords/ForgotPassword.jsx
+++ b/client/src/Passwords/ForgotPassword.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
 import { Alert, Button, Container, Fieldset, Group, Stack, TextInput, Text, Title } from '@mantine/core';
-import { isEmail, useForm } from '@mantine/form';
+import { useForm } from '@mantine/form';
+
+import { isEmail } from '@/utils/email';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import { Head } from '@unhead/react';

--- a/client/src/RegistrationForm.jsx
+++ b/client/src/RegistrationForm.jsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { Alert, Anchor, Button, Fieldset, Stack, Text, TextInput } from '@mantine/core';
-import { isEmail, isNotEmpty, hasLength, useForm } from '@mantine/form';
+import { isNotEmpty, hasLength, useForm } from '@mantine/form';
+
+import { isEmail } from '@/utils/email';
 import { Link } from 'react-router';
 import { IconMail, IconLock } from '@tabler/icons-react';
 

--- a/client/src/utils/email.js
+++ b/client/src/utils/email.js
@@ -3,7 +3,7 @@ import { matches } from '@mantine/form';
 // Copied from zod 4's default email regex (`node_modules/zod/v4/core/regexes.js`)
 // so client-side validation matches the server's `z.string().email()` check.
 // Notably permits apostrophes in the local part — see issue #754.
-const EMAIL_REGEX = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/;
+const EMAIL_REGEX = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9-]*\.)+[A-Za-z]{2,}$/;
 
 export function isEmail (error) {
   return matches(EMAIL_REGEX, error);

--- a/client/src/utils/email.js
+++ b/client/src/utils/email.js
@@ -1,0 +1,10 @@
+import { matches } from '@mantine/form';
+
+// Copied from zod 4's default email regex (`node_modules/zod/v4/core/regexes.js`)
+// so client-side validation matches the server's `z.string().email()` check.
+// Notably permits apostrophes in the local part — see issue #754.
+const EMAIL_REGEX = /^(?!\.)(?!.*\.\.)([A-Za-z0-9_'+\-\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\-]*\.)+[A-Za-z]{2,}$/;
+
+export function isEmail (error) {
+  return matches(EMAIL_REGEX, error);
+}

--- a/client/src/utils/email.test.js
+++ b/client/src/utils/email.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { isEmail } from './email.js';
+
+const validate = isEmail('Please enter a valid email address.');
+
+describe('isEmail', () => {
+  describe('accepts', () => {
+    it.each([
+      ['user@example.com'],
+      ['user@sub.example.com'],
+      ['user.name@example.com'],
+      ['first+last@example.com'],
+      ['first-last@example.com'],
+      ['first_last@example.com'],
+      // Apostrophe in local part — the case from issue #754.
+      ["po'rourke@example.gov"],
+      ["o'connor@example.com"],
+    ])('%s', (email) => {
+      expect(validate(email)).toBeNull();
+    });
+  });
+
+  describe('rejects', () => {
+    it.each([
+      [''],
+      ['no-at-sign'],
+      ['user@'],
+      ['user@nodomain'],
+      ['@example.com'],
+      // Leading dot in local part.
+      ['.user@example.com'],
+      // Consecutive dots in local part.
+      ['us..er@example.com'],
+      // Apostrophe immediately before @ (zod regex's last-char class excludes it).
+      ["bad'@example.com"],
+      // TLD too short.
+      ['user@example.c'],
+    ])('%s', (email) => {
+      expect(validate(email)).toBe('Please enter a valid email address.');
+    });
+  });
+});


### PR DESCRIPTION
Closes #754 

The client and server both use regexes to validate email addresses. 
Client version is built-in to Mantine. 
Server version is built-in to Zod.

The two regexes disagree. Zod allows apostrophe in the name portion of an email address, which is [technically correct](https://www.reddit.com/r/techsupport/comments/1nhn6r/comment/cciojxw/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button). Mantine does not.

In this PR:
- Create a new shared util for email validation
- Have all clients use that util function instead of Mantine's built-in validation
- Add a test which covers this case (and a bunch of other common accept/reject cases for email validation)

The relevant context I was solving for was the `Invites` page (`/admin/invites/new`) in the Admin UI, but this change coversa bunch of other client forms (registration, login, etc)


Note: I originally intended to _exactly_ copy the regex used by Zod into the client-side email util. Unfortunately our linter doesn't like it (it has a few unnecessary escape chars). The hope is that while they are no longer literally identical, the client and server email validation still  have the same behaviors.