### PR TITLE
SFPD: Prevent Transfer if Incident incomplete; improve 'Finish Details' behavior

### DIFF
--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -364,6 +364,8 @@ const Api = {
             throw { _form: 'This transfer code is not valid. Check the number and try again.' };
           case StatusCodes.CONFLICT:
             throw { _form: 'This transfer code was already used. Confirm chair status or contact staff.' };
+          case StatusCodes.UNPROCESSABLE_ENTITY:
+            throw { _form: 'Some required details are missing. Ask the officer to finish them before transferring.' };
           default:
             throw { _form: error.message };
         }

--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -197,7 +197,7 @@ function Deflection () {
               </Group>
             )}
           </Stack>
-          <Accordion variant='section' defaultValue={['substance', 'deflection', 'property', 'incident']}>
+          <Accordion variant='section' defaultValue={['substance', 'drug-use', 'deflection', 'property', 'incident']}>
             <Divider />
             <Accordion.Item value='substance'>
               <Accordion.Control>

--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -407,12 +407,33 @@ function Deflection () {
           {showFinishDetailsFooter && (
             <Button
               onClick={() => {
-                const subjectPath = `/holds/${deflection?.id}/subject`;
+                const detailPath = `/holds/${deflection?.id}`;
                 if (!isValidIncident(incident)) {
-                  navigate(`/incident/${deflection?.incidentId}?next=${encodeURIComponent(subjectPath)}&revisit=true`);
+                  navigate(`/incident/${deflection?.incidentId}?next=${encodeURIComponent(detailPath)}&revisit=true`);
                   return;
                 }
-                navigate(subjectPath);
+                if (!isValidSubject(deflection.subject)) {
+                  navigate(`${detailPath}/subject`);
+                  return;
+                }
+                if (!isValidSubstance({
+                  narcoticsSubstance: deflection.narcoticsSubstance,
+                  narcoticsParaphernalia: deflection.narcoticsParaphernalia,
+                  drugUseEvidence: deflection.drugUseEvidence,
+                  drugType: deflection.drugType ?? null,
+                })) {
+                  navigate(`${detailPath}/substance`);
+                  return;
+                }
+                if (!isValidBehavior(deflection)) {
+                  navigate(`${detailPath}/deflection`);
+                  return;
+                }
+                if (!isValidProperty(deflection)) {
+                  navigate(`${detailPath}/property`);
+                  return;
+                }
+                navigate(detailPath);
               }}
             >
               Finish details

--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -39,7 +39,7 @@ function Deflection () {
   const address = formatAddress(deflection?.subject ?? {});
   const incident = deflection?.incident;
   const incidentAddress = formatAddress(incident ?? {});
-  const detailsComplete = deflection ? isValidDeflection(deflection) : false;
+  const allDetailsComplete = deflection ? isValidDeflection(deflection) && isValidIncident(incident) : false;
   const subjectDetailsComplete = deflection ? isValidSubject(deflection.subject) : false;
   const substanceComplete = deflection
     ? isValidSubstance({
@@ -63,8 +63,8 @@ function Deflection () {
   const isExpiredAutoCancelled = isExpiredBeforeTransfer(deflection, DateTime.now());
   const isOwner = !!deflection && deflection.currentOfficerId === user?.id;
   const isActionableActiveHold = isOwner && !!deflection && deflection.status === 'ACTIVE' && !isExpiredAutoCancelled && !isCustodyTransferred;
-  const showFinishDetailsFooter = isActionableActiveHold && !detailsComplete;
-  const showCancelOnlyFooter = isActionableActiveHold && detailsComplete;
+  const showFinishDetailsFooter = isActionableActiveHold && !allDetailsComplete;
+  const showCancelOnlyFooter = isActionableActiveHold && allDetailsComplete;
   const showActionFooter = showFinishDetailsFooter || showCancelOnlyFooter;
   const statusChip = getSfpdDeflectionStatusChip({ deflection, incident });
 
@@ -406,7 +406,14 @@ function Deflection () {
           </Button>
           {showFinishDetailsFooter && (
             <Button
-              onClick={() => navigate(`/holds/${deflection?.id}/subject`)}
+              onClick={() => {
+                const subjectPath = `/holds/${deflection?.id}/subject`;
+                if (!isValidIncident(incident)) {
+                  navigate(`/incident/${deflection?.incidentId}?next=${encodeURIComponent(subjectPath)}`);
+                  return;
+                }
+                navigate(subjectPath);
+              }}
             >
               Finish details
             </Button>

--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -409,7 +409,7 @@ function Deflection () {
               onClick={() => {
                 const subjectPath = `/holds/${deflection?.id}/subject`;
                 if (!isValidIncident(incident)) {
-                  navigate(`/incident/${deflection?.incidentId}?next=${encodeURIComponent(subjectPath)}`);
+                  navigate(`/incident/${deflection?.incidentId}?next=${encodeURIComponent(subjectPath)}&revisit=true`);
                   return;
                 }
                 navigate(subjectPath);

--- a/client/src/lesc/components/DeflectionForm.jsx
+++ b/client/src/lesc/components/DeflectionForm.jsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { Head } from '@unhead/react';
 import { IconArrowLeft } from '@tabler/icons-react';
-import { Badge, Button, Chip, Container, Fieldset, Group, Input, Stack, Text, Textarea, Title } from '@mantine/core';
+import { Badge, Button, Container, Fieldset, Group, Stack, Text, Textarea, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next';
 import Api from '@/Api';
 import { useFacilityContext } from '@/FacilityContext';
 import AudioRecorder from '@/components/AudioRecorder';
+import ChipInput from '@/components/ChipInput';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { buildDeflectionNarrative } from '@/utils/deflectionNarrative';
@@ -207,22 +208,15 @@ function DeflectionForm () {
                   />
                   <Text size='sm' c='dimmed'>Used on 647(f) and 849(b) forms</Text>
                 </Stack>
-                <Input.Wrapper
-                  label='Select a charge type'
-                  withAsterisk
-                  error={form.errors.chargeType}
-                >
-                  <Chip.Group
-                    key={form.key('chargeType')}
-                    {...form.getInputProps('chargeType')}
-                  >
-                    <Group gap='sm' mt='md'>
-                      {CHARGE_TYPE_OPTIONS.map((chargeType) => (
-                        <Chip key={chargeType} value={chargeType}>{t(`chargeType.${chargeType}`)}</Chip>
-                      ))}
-                    </Group>
-                  </Chip.Group>
-                </Input.Wrapper>
+                <ChipInput
+                  key={form.key('chargeType')}
+                  {...form.getInputProps('chargeType')}
+                  label={<>Select a charge type<span>*</span></>}
+                  options={CHARGE_TYPE_OPTIONS.map((chargeType) => ({
+                    value: chargeType,
+                    label: t(`chargeType.${chargeType}`),
+                  }))}
+                />
               </Stack>
               <Button type='submit' mb='xl' disabled={recorderBusy}>
                 {isNew ? 'Next: Personal property' : 'Save behavioral observations'}

--- a/client/src/lesc/components/DeflectionForm.jsx
+++ b/client/src/lesc/components/DeflectionForm.jsx
@@ -14,6 +14,7 @@ import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { buildDeflectionNarrative } from '@/utils/deflectionNarrative';
 import { buildDeflectionUpdatePayload } from '@/utils/deflectionBehavior';
+import { validateBehavior } from '@/utils/validators';
 import { CHARGE_TYPE_OPTIONS } from '@/lesc/constants/chargeTypeOptions';
 
 const initialValues = {
@@ -73,6 +74,12 @@ function DeflectionForm () {
           drugUseEvidence: normalized.drugUseEvidence,
         });
         form.initialize(normalized);
+        if (!isNew) {
+          form.setErrors(validateBehavior({
+            ...normalized,
+            behavior: deflection.behavior ?? '',
+          }));
+        }
       }
     }
   }, [isLoading, deflection, form.initialized]);

--- a/client/src/lesc/components/Hold.jsx
+++ b/client/src/lesc/components/Hold.jsx
@@ -4,7 +4,7 @@ import LockedQRCode from '@/components/LockedQRCode';
 import useNow from '@/hooks/useNow';
 import useSubjectDetails from '@/hooks/useSubjectDetails';
 import { formatTime, formatTimeRemaining } from '@/utils/format';
-import { isValidDeflection } from '@/utils/validators';
+import { isValidDeflection, isValidIncident } from '@/utils/validators';
 import checkerboardEmptyState from '@/assets/icons/checkerboard-empty-state.svg';
 
 import { isCustodyTransferredStatus, isExpiredBeforeTransfer } from './deflectionStatusChipUtils';
@@ -106,7 +106,7 @@ function Hold ({ incident, deflection, highlighted, onCancelClick, onDetailsClic
         )}
         {isActive && isArrived && !isHistory && (
           <Stack align='center' gap='xs'>
-            <LockedQRCode value={transferUrl} variant={!isValid ? 'locked' : undefined} />
+            <LockedQRCode value={transferUrl} variant={isValid && isValidIncident(incident) ? undefined : 'locked'} />
             <Text size='sm' c='dimmed'>Transfer code: {deflection.id}</Text>
           </Stack>
         )}

--- a/client/src/lesc/components/IncidentForm.jsx
+++ b/client/src/lesc/components/IncidentForm.jsx
@@ -103,6 +103,7 @@ function IncidentForm () {
   const initialNextPathRef = useRef(searchParams.get('next'));
   const nextPath = initialNextPathRef.current;
   const isConfirmIncidentFlow = !!nextPath;
+  const isRevisit = searchParams.get('revisit') === 'true';
   const queryClient = useQueryClient();
   const { showToast } = useToast();
   const { facility } = useFacilityContext();
@@ -137,7 +138,7 @@ function IncidentForm () {
           ...data,
           arrestedAt,
         }));
-        if (!isConfirmIncidentFlow) {
+        if (!isConfirmIncidentFlow || isRevisit) {
           form.setErrors(validateIncident(data));
         }
         setInitialized(true);

--- a/client/src/lesc/components/SubstanceForm.jsx
+++ b/client/src/lesc/components/SubstanceForm.jsx
@@ -2,13 +2,14 @@ import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams, useSearchParams } from 'react-router';
 import { Head } from '@unhead/react';
 import { IconArrowLeft } from '@tabler/icons-react';
-import { Badge, Button, Chip, Container, Fieldset, Group, Input, Stack, Text, Title } from '@mantine/core';
+import { Badge, Button, Container, Fieldset, Group, Stack, Text, Title } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 
 import Api from '@/Api';
 import BooleanInput from '@/components/BooleanInput';
+import ChipInput from '@/components/ChipInput';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useFacilityContext } from '@/FacilityContext';
@@ -174,18 +175,15 @@ function SubstanceForm () {
                 label={<>Signs of substance use<span>*</span></>}
               />
               {showDrugTypeQuestion && (
-                <Input.Wrapper label={<>Substance used<span>*</span></>}>
-                  <Chip.Group
-                    key={form.key('drugType')}
-                    {...form.getInputProps('drugType')}
-                  >
-                    <Group gap='sm' mt='md'>
-                      {DRUG_TYPE_OPTIONS.map((drugType) => (
-                        <Chip key={drugType} value={drugType}>{t(`drugType.${drugType}`)}</Chip>
-                      ))}
-                    </Group>
-                  </Chip.Group>
-                </Input.Wrapper>
+                <ChipInput
+                  key={form.key('drugType')}
+                  {...form.getInputProps('drugType')}
+                  label={<>Substance used<span>*</span></>}
+                  options={DRUG_TYPE_OPTIONS.map((drugType) => ({
+                    value: drugType,
+                    label: t(`drugType.${drugType}`),
+                  }))}
+                />
               )}
               <Button type='submit' mb='xl'>
                 {isNew ? 'Next: Behavioral observations' : 'Save substance details'}

--- a/client/src/utils/validators.js
+++ b/client/src/utils/validators.js
@@ -88,7 +88,7 @@ export const isValidNarcotics = (obj) => {
   return !!NarcoticsSchema.safeParse(obj)?.success;
 };
 
-const SubstanceSchema = z.union([
+const SubstanceSchema = z.discriminatedUnion('drugUseEvidence', [
   z.object({
     narcoticsSubstance: z.boolean(ERROR_SELECT_ONE),
     narcoticsParaphernalia: z.boolean(ERROR_SELECT_ONE),

--- a/client/src/utils/validators.test.js
+++ b/client/src/utils/validators.test.js
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateSubstance } from './validators';
+
+describe('validateSubstance', () => {
+  it('returns no errors when all fields are valid (drugUseEvidence false branch)', () => {
+    const errors = validateSubstance({
+      narcoticsSubstance: false,
+      narcoticsParaphernalia: false,
+      drugUseEvidence: false,
+      drugType: null,
+    });
+    expect(errors).toEqual({});
+  });
+
+  it('returns no errors when all fields are valid (drugUseEvidence true branch)', () => {
+    const errors = validateSubstance({
+      narcoticsSubstance: false,
+      narcoticsParaphernalia: false,
+      drugUseEvidence: true,
+      drugType: 'FENTANYL',
+    });
+    expect(errors).toEqual({});
+  });
+
+  it('returns a field-level error on narcoticsSubstance when unanswered', () => {
+    const errors = validateSubstance({
+      narcoticsSubstance: null,
+      narcoticsParaphernalia: false,
+      drugUseEvidence: false,
+      drugType: null,
+    });
+    expect(errors).toHaveProperty('narcoticsSubstance');
+  });
+
+  it('returns a field-level error on drugUseEvidence when unanswered', () => {
+    const errors = validateSubstance({
+      narcoticsSubstance: false,
+      narcoticsParaphernalia: false,
+      drugUseEvidence: null,
+      drugType: null,
+    });
+    expect(errors).toHaveProperty('drugUseEvidence');
+  });
+
+  it('returns a field-level error on drugType when drugUseEvidence is true but drugType is missing', () => {
+    const errors = validateSubstance({
+      narcoticsSubstance: false,
+      narcoticsParaphernalia: false,
+      drugUseEvidence: true,
+      drugType: null,
+    });
+    expect(errors).toHaveProperty('drugType');
+  });
+});

--- a/server/lib/incidentPermissions.js
+++ b/server/lib/incidentPermissions.js
@@ -2,6 +2,7 @@
  * Centralized helpers for incident and deflection permissions.
  *
  *   isIncidentDetailsComplete — are all required incident fields filled in?
+ *   isDeflectionDetailsComplete — are all required deflection fields filled in?
  *   canModifyDeflection       — can this user modify a deflection?
  */
 
@@ -18,6 +19,31 @@ export function isIncidentDetailsComplete (incident) {
     incident.cadNumber &&
     incident.caseNumber &&
     incident.supervisorBadgeNumber
+  );
+}
+
+/**
+ * Are all required deflection fields filled in? Mirrors the client-side
+ * DeflectionSchema in `client/src/utils/validators.js`. Expects the deflection
+ * to be loaded with its `subject` relation included.
+ */
+export function isDeflectionDetailsComplete (deflection) {
+  if (!deflection?.subject) return false;
+  const { subject } = deflection;
+  return !!(
+    subject.firstName &&
+    subject.lastName &&
+    subject.dateOfBirth &&
+    subject.sex &&
+    subject.race &&
+    typeof deflection.narcoticsSubstance === 'boolean' &&
+    typeof deflection.narcoticsParaphernalia === 'boolean' &&
+    typeof deflection.drugUseEvidence === 'boolean' &&
+    (deflection.drugUseEvidence === false || deflection.drugType) &&
+    deflection.behavior &&
+    deflection.behaviorNarrative &&
+    deflection.chargeType &&
+    deflection.property
   );
 }
 

--- a/server/routes/api/deflections/transfer.js
+++ b/server/routes/api/deflections/transfer.js
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
+import { isIncidentDetailsComplete, isDeflectionDetailsComplete } from '#lib/incidentPermissions.js';
 import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
 
 export default async function (fastify, opts) {
@@ -20,6 +21,12 @@ export default async function (fastify, opts) {
           [StatusCodes.NOT_FOUND]: z.null(),
           [StatusCodes.FORBIDDEN]: z.null(),
           [StatusCodes.CONFLICT]: z.null(),
+          [StatusCodes.UNPROCESSABLE_ENTITY]: z.object({
+            errors: z.array(z.object({
+              path: z.string(),
+              message: z.string(),
+            })),
+          }),
         },
       },
     },
@@ -45,6 +52,7 @@ export default async function (fastify, opts) {
         deflection = await tx.deflection.findUnique({
           where: { id },
           include: {
+            incident: true,
             subject: true,
             propertyPhotos: true,
           },
@@ -52,6 +60,12 @@ export default async function (fastify, opts) {
 
         if (deflection.status !== Deflection.HoldStatus.ACTIVE || deflection.subjectStatus !== Deflection.SubjectStatus.ONSITE_AWAITING_TRANSFER) {
           return reply.code(StatusCodes.CONFLICT).send();
+        }
+
+        if (!isIncidentDetailsComplete(deflection.incident) || !isDeflectionDetailsComplete(deflection)) {
+          return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({
+            errors: [{ path: '_form', message: 'Hold details must be complete before custody transfer.' }],
+          });
         }
 
         const now = new Date();

--- a/server/routes/api/deflections/transfer.js
+++ b/server/routes/api/deflections/transfer.js
@@ -64,7 +64,7 @@ export default async function (fastify, opts) {
 
         if (!isIncidentDetailsComplete(deflection.incident) || !isDeflectionDetailsComplete(deflection)) {
           return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({
-            errors: [{ path: '_form', message: 'Hold details must be complete before custody transfer.' }],
+            errors: [{ path: '_form', message: 'Some required details are missing. Ask the officer to finish them before transferring.' }],
           });
         }
 

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -23,6 +23,36 @@ test('/api/deflections', async (t) => {
   const custodyUserHeaders = await authenticate(app, 'sfsouser1@test.com', 'test');
   const careUserHeaders = await authenticate(app, 'careuser1@test.com', 'test');
 
+  // Fixtures are intentionally incomplete (see fixtures/db/incidents.yml,
+  // deflections.yml). Tests opt into completeness when they exercise endpoints
+  // that gate on isIncidentDetailsComplete / isDeflectionDetailsComplete.
+  async function makeIncidentComplete (incidentId) {
+    await prisma.incident.updateMany({
+      where: { id: incidentId },
+      data: {
+        addressLine1: '123 Test St',
+        city: 'San Francisco',
+        state: 'CA',
+        supervisorBadgeNumber: '1234',
+      },
+    });
+  }
+
+  async function makeDeflectionComplete (deflectionId) {
+    await prisma.deflection.updateMany({
+      where: { id: deflectionId },
+      data: {
+        narcoticsSubstance: false,
+        narcoticsParaphernalia: false,
+        drugUseEvidence: false,
+        behavior: 'Cooperative',
+        behaviorNarrative: 'Test narrative',
+        chargeType: 'RWS_647F',
+        property: 'NONE',
+      },
+    });
+  }
+
   await t.test('POST /', async (t) => {
     await t.test('creates a new deflection', async () => {
       await prisma.deflection.expire();
@@ -245,6 +275,8 @@ test('/api/deflections', async (t) => {
   await t.test('POST /:id/transfer', async (t) => {
     await t.test('transfers custody of a deflection', async () => {
       await prisma.deflection.expire();
+      await makeIncidentComplete(1);
+      await makeDeflectionComplete(5);
       await prisma.deflection.update({
         where: { id: 5 },
         data: {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -317,6 +317,46 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(bedType.inTransit, 2); // in-transit decrements
       assert.deepStrictEqual(bedType.available, 4);
     });
+
+    await t.test('rejects with 422 when incident details are incomplete', async () => {
+      await prisma.deflection.expire();
+      // hold details complete, incident details intentionally not
+      await makeDeflectionComplete(5);
+      await prisma.deflection.update({
+        where: { id: 5 },
+        data: { subjectStatus: 'ONSITE_AWAITING_TRANSFER' },
+      });
+
+      const response = await app.inject().post('/api/deflections/5/transfer').headers(custodyUserHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.UNPROCESSABLE_ENTITY);
+      const body = JSON.parse(response.body);
+      assert.deepStrictEqual(body.errors.length, 1);
+      assert.deepStrictEqual(body.errors[0].path, '_form');
+
+      const deflection = await prisma.deflection.findUnique({ where: { id: 5 } });
+      assert.deepStrictEqual(deflection.subjectStatus, 'ONSITE_AWAITING_TRANSFER');
+      assert.deepStrictEqual(deflection.transferredAt, null);
+    });
+
+    await t.test('rejects with 422 when hold details are incomplete', async () => {
+      await prisma.deflection.expire();
+      // incident details complete, hold details intentionally not
+      await makeIncidentComplete(1);
+      await prisma.deflection.update({
+        where: { id: 5 },
+        data: { subjectStatus: 'ONSITE_AWAITING_TRANSFER' },
+      });
+
+      const response = await app.inject().post('/api/deflections/5/transfer').headers(custodyUserHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.UNPROCESSABLE_ENTITY);
+      const body = JSON.parse(response.body);
+      assert.deepStrictEqual(body.errors.length, 1);
+      assert.deepStrictEqual(body.errors[0].path, '_form');
+
+      const deflection = await prisma.deflection.findUnique({ where: { id: 5 } });
+      assert.deepStrictEqual(deflection.subjectStatus, 'ONSITE_AWAITING_TRANSFER');
+      assert.deepStrictEqual(deflection.transferredAt, null);
+    });
   });
 
   await t.test('POST /:id/admit', async (t) => {

--- a/server/test/routes/api/facilities/arrived.test.js
+++ b/server/test/routes/api/facilities/arrived.test.js
@@ -191,8 +191,22 @@ test('POST /api/facilities/:facilityId/arrived', async (t) => {
         encounteredVia: 'DISPATCHED',
         cadNumber: `CAD-ARR-TRANSFER-${Date.now()}`,
         caseNumber: `CASE-ARR-TRANSFER-${Date.now()}`,
+        addressLine1: '123 Test St',
+        city: 'San Francisco',
+        state: 'CA',
+        arrestedAt: new Date('2024-01-01T07:00:00.000Z'),
+        supervisorBadgeNumber: '1234',
         createdById: USER2_ID,
         updatedById: USER2_ID,
+      },
+    });
+    const subject = await prisma.subject.create({
+      data: {
+        firstName: 'Test',
+        lastName: 'Transfer',
+        dateOfBirth: new Date('2000-01-01T00:00:00.000Z'),
+        sex: 'MALE',
+        race: 'WHITE',
       },
     });
     const deflection = await prisma.deflection.create({
@@ -200,9 +214,17 @@ test('POST /api/facilities/:facilityId/arrived', async (t) => {
         facilityId: OTHER_FACILITY_ID,
         incidentId: incident.id,
         bedTypeId: bedType.id,
+        subjectId: subject.id,
         currentOfficerId: USER2_ID,
         subjectStatus: 'ONSITE_AWAITING_TRANSFER',
         arrivedAt: originalArrivedAt,
+        narcoticsSubstance: false,
+        narcoticsParaphernalia: false,
+        drugUseEvidence: false,
+        behavior: 'Cooperative',
+        behaviorNarrative: 'Test narrative',
+        chargeType: 'RWS_647F',
+        property: 'NONE',
         createdById: USER2_ID,
       },
     });

--- a/server/test/routes/api/facilities/left.test.js
+++ b/server/test/routes/api/facilities/left.test.js
@@ -121,6 +121,29 @@ test('POST /api/facilities/:facilityId/left', async (t) => {
       .post(`/api/facilities/${FACILITY_ID}/arrived`)
       .headers(userHeaders);
 
+    // Make incident and deflection details complete so transfer doesn't 422.
+    await prisma.incident.updateMany({
+      where: { id: 1 },
+      data: {
+        addressLine1: '123 Test St',
+        city: 'San Francisco',
+        state: 'CA',
+        supervisorBadgeNumber: '1234',
+      },
+    });
+    await prisma.deflection.update({
+      where: { id: 4 },
+      data: {
+        narcoticsSubstance: false,
+        narcoticsParaphernalia: false,
+        drugUseEvidence: false,
+        behavior: 'Cooperative',
+        behaviorNarrative: 'Test narrative',
+        chargeType: 'RWS_647F',
+        property: 'NONE',
+      },
+    });
+
     const [leftResponse, transferResponse] = await Promise.all([
       app.inject()
         .post(`/api/facilities/${FACILITY_ID}/left`)


### PR DESCRIPTION
Closes #773, and makes a few other small improvements to the "finish details" flow.

In this PR:
- In the `FIELD` home screen, keep the QR code locked for any Hold whose Incident details are incomplete
- On the backend, reject a Transfer attempt if the incident details are incomplete (and make sure client can handle that rejection and display an appropriate error.)
- On the Deflection details screen (`/holds/{id}`), treat missing Incident details like missing Hold details: show the "Finish details" button in the footer, and when clicked, take user directly to the relevant page with the missing information.
- I noticed a few things about the existing `Finish details` flow that seemed incomplete and could obviously be improved, so I also did this:
  - **Before this PR**: When you clicked `Finish details`, it always took you to the first page of the Subject form (regardless of which page needs your attention.)
  - **In this PR**: When you click `Finish details`, it automatically takes you to the first page of the flow that has invalid or incomplete required form fields (including the Incident form or any of the deflection forms)
  -  **Before this PR**: not every form page displayed visible highlights during this experience, to show you which fields need your attention
  -  **In this PR**: When you click 'Finish details' and revisit a form, we the red validation warnings to show you which fields need attention.  

If Incident details are incomplete, lock the QRs on the associated Holds:
<img width="582" height="612" alt="image" src="https://github.com/user-attachments/assets/e509c749-3fbb-45ca-be1b-4dcfb6b70c9b" />

On the details page for the hold, the `Finish details` button will appear, and take you directly to the Incident form (if you're missing Incident details):

https://github.com/user-attachments/assets/19bc114f-cd86-47e8-acb2-766b7e5f4c22

All required fields will, upon _revisit_, show their validation warnings when applicable. Here's what it looks like if you fail to choose a Charge Type on the first time through the form. When you revisit the form by clicking "finish details", it takes you directly to the Arrest details page, and highlights the missing required field:

https://github.com/user-attachments/assets/20fe8041-d642-4b39-90f8-910edd0e61b5





