### PR TITLE
Replaces 5150 with Behavioral health eval label (#730)

### DIFF
--- a/server/prisma/migrations/20260429120000_rename_5150_cancel_reason/migration.sql
+++ b/server/prisma/migrations/20260429120000_rename_5150_cancel_reason/migration.sql
@@ -1,0 +1,5 @@
+UPDATE "DeflectionCancelReason"
+SET
+  "name" = 'Behavioral health evaluation',
+  "updatedAt" = CURRENT_TIMESTAMP
+WHERE "id" = '5150';

--- a/server/prisma/seeds/deflectionCancelReasons.js
+++ b/server/prisma/seeds/deflectionCancelReasons.js
@@ -12,7 +12,7 @@ export default async function main (prisma) {
   const deflectionCancelReasons = [
     {
       id: '5150',
-      name: '5150',
+      name: 'Behavioral health evaluation',
       createdById: adminUser.id,
       updatedById: adminUser.id,
     },
@@ -53,7 +53,16 @@ export default async function main (prisma) {
       where: { id: dcr.id },
     });
 
-    if (existing) {
+    if (existing && dcr.id === '5150' && existing.name !== dcr.name) {
+      const updated = await prisma.deflectionCancelReason.update({
+        where: { id: dcr.id },
+        data: {
+          name: dcr.name,
+          updatedById: dcr.updatedById,
+        },
+      });
+      console.log(`Updated deflection cancel reason: ${updated.id} - ${updated.name}`);
+    } else if (existing) {
       console.log(`Deflection cancel reason ${dcr.id} already exists, skipping...`);
     } else {
       const created = await prisma.deflectionCancelReason.create({

--- a/server/test/fixtures/db/deflectionCancelReasons.yml
+++ b/server/test/fixtures/db/deflectionCancelReasons.yml
@@ -3,7 +3,7 @@ connectedFields: ['createdBy', 'updatedBy']
 items:
   '5150':
     id: '5150'
-    name: '5150'
+    name: 'Behavioral health evaluation'
     createdBy: '@user1'
     updatedBy: '@user1'  
   jail:

--- a/server/test/routes/api/deflections/cancel-reasons.test.js
+++ b/server/test/routes/api/deflections/cancel-reasons.test.js
@@ -29,6 +29,10 @@ test('/api/deflections/cancel-reasons', async (t) => {
       assert.ok(ids.includes('no_chairs_available'));
       assert.ok(ids.includes('release_on_scene'));
       assert.ok(ids.includes('staffing_shortage'));
+      assert.strictEqual(
+        reasons.find(r => r.id === '5150')?.name,
+        'Behavioral health evaluation'
+      );
 
       // Check sorting by name
       const names = reasons.map(r => r.name);


### PR DESCRIPTION
## Summary

- Replace the `5150` cancel-reason display label with `Behavioral health evaluation`
- Add a migration so existing databases update the cancel-reason name
- Update seed data, test fixtures, and API test expectations

Closes #730 