### PR TITLE
Fix/755 resend code button shift

### DIFF
--- a/client/src/Login.jsx
+++ b/client/src/Login.jsx
@@ -211,21 +211,21 @@ function Login () {
 
                   <Stack mt='md' gap='sm' align='flex-start'>
                     <Button
-                      variant={resendCooldown > 0 ? 'default' : 'secondary'}
+                      type='submit'
+                      loading={verifyMutation.isPending}
+                      disabled={verifyForm.getValues().code.length !== 6}
+                    >
+                      Verify and continue
+                    </Button>
+
+                    <Button
+                      variant='white'
                       onClick={handleResend}
                       disabled={resendCooldown > 0 || resendMutation.isPending}
                     >
                       {resendCooldown > 0
                         ? `Resend code in ${String(Math.floor(resendCooldown / 60)).padStart(2, '0')}:${String(resendCooldown % 60).padStart(2, '0')}`
                         : 'Resend code'}
-                    </Button>
-
-                    <Button
-                      type='submit'
-                      loading={verifyMutation.isPending}
-                      disabled={verifyForm.getValues().code.length !== 6}
-                    >
-                      Verify and continue
                     </Button>
                   </Stack>
                 </Stack>


### PR DESCRIPTION
## Summary

- Reordered the MFA verification actions so `Verify and continue` appears above `Resend code`
- Updated the `Resend code` button to use the white button variant

Closes #755 
