### PR TITLE
Hides observations from medical staff (#799)

### DIFF
--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -43,7 +43,6 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   const [exitToJailModalOpened, setExitToJailModalOpened] = useState(false);
   const [recordDeathModalOpened, setRecordDeathModalOpened] = useState(false);
   const [custodyAccordionValues, setCustodyAccordionValues] = useState(['substance', 'deflection', 'property', 'incident', 'release-narrative']);
-  const [careAccordionValues, setCareAccordionValues] = useState(['substance', 'deflection']);
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { t } = useTranslation();
@@ -79,7 +78,6 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   const releaseTimingChip = releaseTiming(deflection);
   const propertyReturnStatusText = getPropertyReturnStatusText(deflection);
   const hasDrugUseEvidence = deflection?.drugUseEvidence !== null && deflection?.drugUseEvidence !== undefined;
-  const hasBehavioralObservations = Boolean(deflection?.behavior);
 
   function navigateToHospitalReleaseFlow () {
     navigate(`/custody/${deflection.id}/legal-release?from=detail&releaseReasonId=medical_issue&exitDestinationId=hospital`);
@@ -350,56 +348,23 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
               </Group>
             )}
           </Stack>
-          {isCareView && (hasDrugUseEvidence || hasBehavioralObservations) && (
-            <Accordion
-              variant='section'
-              multiple
-              value={careAccordionValues}
-              onChange={setCareAccordionValues}
-            >
-              {hasDrugUseEvidence && (
-                <>
-                  <Divider />
-                  <Accordion.Item value='substance'>
-                    <Accordion.Control>
-                      <Title order={3}>Substance-related details</Title>
-                    </Accordion.Control>
-                    <Accordion.Panel>
-                      <Stack gap='sm'>
-                        <Box>
-                          <Text c='dimmed'>Signs of substance use</Text>
-                          <Text>{deflection.drugUseEvidence ? 'Yes' : 'No'}</Text>
-                        </Box>
-                        {deflection.drugUseEvidence === true && deflection?.drugType && (
-                          <Box>
-                            <Text c='dimmed'>Substance used (suspected)</Text>
-                            <Text>{t(`drugType.${deflection.drugType}`)}</Text>
-                          </Box>
-                        )}
-                      </Stack>
-                    </Accordion.Panel>
-                  </Accordion.Item>
-                </>
-              )}
-              {hasBehavioralObservations && (
-                <>
-                  <Divider />
-                  <Accordion.Item value='deflection'>
-                    <Accordion.Control>
-                      <Title order={3}>Behavioral observations</Title>
-                    </Accordion.Control>
-                    <Accordion.Panel>
-                      <Stack gap='sm'>
-                        <Box>
-                          <Text c='dimmed'>Arrestable behavior</Text>
-                          <Text>{deflection.behavior}</Text>
-                        </Box>
-                      </Stack>
-                    </Accordion.Panel>
-                  </Accordion.Item>
-                </>
-              )}
-            </Accordion>
+          {isCareView && hasDrugUseEvidence && (
+            <>
+              <Divider />
+              <Stack gap='sm'>
+                <Title order={3}>Substance-related details</Title>
+                <Box>
+                  <Text c='dimmed'>Signs of substance use</Text>
+                  <Text>{deflection.drugUseEvidence ? 'Yes' : 'No'}</Text>
+                </Box>
+                {deflection.drugUseEvidence === true && deflection?.drugType && (
+                  <Box>
+                    <Text c='dimmed'>Substance used (suspected)</Text>
+                    <Text>{t(`drugType.${deflection.drugType}`)}</Text>
+                  </Box>
+                )}
+              </Stack>
+            </>
           )}
           {!isCareView && (
             <>

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -297,7 +297,7 @@ describe('CustodyDetailContent', () => {
     expect(html).toContain('drugType.ALCOHOL');
   });
 
-  it('shows behavioral observations after substance-related details in care personal details', () => {
+  it('hides behavioral observations in care personal details', () => {
     const html = render(
       {
         subjectStatus: 'ADMITTED',
@@ -309,10 +309,9 @@ describe('CustodyDetailContent', () => {
     );
 
     expect(html).toContain('Substance-related details');
-    expect(html).toContain('Behavioral observations');
-    expect(html).toContain('Arrestable behavior');
-    expect(html).toContain('Person was stumbling into traffic.');
-    expect(html.indexOf('Substance-related details')).toBeLessThan(html.indexOf('Behavioral observations'));
+    expect(html).not.toContain('Behavioral observations');
+    expect(html).not.toContain('Arrestable behavior');
+    expect(html).not.toContain('Person was stumbling into traffic.');
   });
 
   it('shows no drug use status without a drug type in care personal details', () => {
@@ -327,12 +326,18 @@ describe('CustodyDetailContent', () => {
     expect(html).not.toContain('Substance used (suspected)');
   });
 
-  it('hides care behavioral observations when no arrestable behavior was recorded', () => {
+  it('does not show care behavioral observations without substance-related details', () => {
     const html = render(
-      { subjectStatus: 'ADMITTED', behavior: null },
+      {
+        subjectStatus: 'ADMITTED',
+        drugUseEvidence: null,
+        behavior: 'Person was stumbling into traffic.',
+      },
       { viewerMode: 'care' }
     );
 
+    expect(html).not.toContain('Behavioral observations');
     expect(html).not.toContain('Arrestable behavior');
+    expect(html).not.toContain('Person was stumbling into traffic.');
   });
 });


### PR DESCRIPTION
## Summary

- Removes behavioral observations from the care/medical person details view
- Updates `CustodyDetailContent` tests to assert care users cannot see behavioral observation text, even when it exists on the deflection

## Context

This undoes the care-view portion of the earlier change for #682 / #701. The codebase has moved on since that PR, so this is not a blind revert. The current shared `CustodyDetailContent` component now conditionally preserves substance-related details for care users while no longer rendering behavioral observations in `viewerMode="care"`.

Closes #799 