### PR TITLE
[Draft] Fix occupied[] array in API

### DIFF
--- a/server/prisma/seeds/testDeflections.js
+++ b/server/prisma/seeds/testDeflections.js
@@ -19,10 +19,11 @@ const TEST_SUBJECTS = [
 ];
 
 // Holds = chair reserved, person not yet formally in a chair (DETAINED through ADMITTED)
-// Occupied = person formally in a chair (IN_CHAIR, RELEASED)
+// Occupied = person formally in a chair (IN_CHAIR), or legally released and still
+// onsite (RELEASED) — they continue to occupy the chair until exited.
 // The hold → occupied transition happens at intake-complete (ADMITTED → IN_CHAIR)
 const HOLD_STATUSES = ['DETAINED', 'ONSITE_AWAITING_TRANSFER', 'AWAITING_INTAKE', 'READY_FOR_INTAKE', 'ADMITTED', 'FAILED_INTAKE'];
-const OCCUPIED_STATUSES = ['IN_CHAIR'];
+const OCCUPIED_STATUSES = ['IN_CHAIR', 'RELEASED'];
 
 const TEST_STATUSES = [
   'AWAITING_INTAKE',

--- a/server/routes/api/status/capacity.js
+++ b/server/routes/api/status/capacity.js
@@ -33,11 +33,18 @@ async function computeCapacity (fastify, request) {
     inTransit: acc.inTransit + bt.inTransit,
   }), { total: 0, unavailable: 0, occupied: 0, inTransit: 0 });
 
+  // Match the bedType.occupied counter: IN_CHAIR plus RELEASED-but-still-onsite
+  // (Path A — the person was admitted to a chair, then legally released, and
+  // is still physically taking the chair until exit). Path B (released without
+  // ever sitting in a chair, no admittedAt) is excluded.
   const occupiedRows = await fastify.prisma.deflection.findMany({
     where: {
       facilityId: facility.id,
       status: 'ACTIVE',
-      subjectStatus: 'IN_CHAIR',
+      OR: [
+        { subjectStatus: 'IN_CHAIR' },
+        { subjectStatus: 'RELEASED', admittedAt: { not: null } },
+      ],
     },
     select: { admittedAt: true, drugType: true },
     orderBy: { admittedAt: 'asc' },


### PR DESCRIPTION
In the main app, if a person in-chair is legally released, but not yet exited, they will still show up as occupying a chair.

In the API, we don't return those people. This updates the API to respect the definition of 'occupying a chair'.
Also updates the seed fixtures (for local dev) because the fixtures contained rows that were bucketed into `RELEASED` without being counted in either `holds` or `occupied`.