### PR TITLE
[1] Enable PostHog client-side exception auto-capture

### DIFF
--- a/client/src/Admin/AdminRoutes.jsx
+++ b/client/src/Admin/AdminRoutes.jsx
@@ -5,6 +5,7 @@ import AdminUsersRoutes from './Users/AdminUsersRoutes';
 import AdminOrganizationsRoutes from './Organizations/AdminOrganizationsRoutes';
 import AdminFacilitiesRoutes from './Facilities/AdminFacilitiesRoutes';
 import AdminEnumsRoutes from './Enums/AdminEnumRoutes';
+import AdminCanaryPage from './Canary/AdminCanaryPage';
 
 function AdminRoutes () {
   return (
@@ -14,6 +15,7 @@ function AdminRoutes () {
       <Route path='organizations/*' element={<AdminOrganizationsRoutes />} />
       <Route path='facilities/*' element={<AdminFacilitiesRoutes />} />
       <Route path='enums/*' element={<AdminEnumsRoutes />} />
+      <Route path='canary' element={<AdminCanaryPage />} />
       <Route path='' element={<Navigate to='users' />} />
     </Routes>
   );

--- a/client/src/Admin/Canary/AdminCanaryPage.jsx
+++ b/client/src/Admin/Canary/AdminCanaryPage.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { Button, Card, Container, Stack, Text, Title } from '@mantine/core';
+
+import Api from '@/Api';
+
+function ExplodingChild () {
+  throw new Error('Canary: FE render');
+}
+
+function AdminCanaryPage () {
+  const [renderExplode, setRenderExplode] = useState(false);
+
+  function triggerRenderError () {
+    setRenderExplode(true);
+  }
+
+  function triggerUnhandledRejection () {
+    Promise.reject(new Error('Canary: FE unhandled rejection'));
+  }
+
+  async function triggerApiError () {
+    try {
+      await Api.canary.error();
+    } catch (err) {
+      // Expected: server returns 500. We swallow here so the error lands in PostHog
+      // via the server-side capture, not the client's network-failure path.
+    }
+  }
+
+  async function triggerJobError () {
+    await Api.canary.job();
+  }
+
+  return (
+    <Container>
+      <Stack gap='md'>
+        <Title order={2}>Canary errors</Title>
+        <Text c='dimmed'>
+          Each button triggers a known error on one surface. Verify it appears in PostHog &gt; Error Tracking
+          with the matching <code>Canary:</code> prefix.
+        </Text>
+
+        <Card bg='white' p='xl' withBorder>
+          <Stack gap='sm'>
+            <Title order={4}>Browser</Title>
+            <Button color='red' variant='light' onClick={triggerRenderError}>
+              Throw FE render error
+            </Button>
+            <Button color='red' variant='light' onClick={triggerUnhandledRejection}>
+              Throw FE unhandled rejection
+            </Button>
+          </Stack>
+        </Card>
+
+        <Card bg='white' p='xl' withBorder>
+          <Stack gap='sm'>
+            <Title order={4}>Server</Title>
+            <Button color='red' variant='light' onClick={triggerApiError}>
+              Throw API error (500)
+            </Button>
+            <Button color='red' variant='light' onClick={triggerJobError}>
+              Throw worker job error
+            </Button>
+          </Stack>
+        </Card>
+
+        {renderExplode && <ExplodingChild />}
+      </Stack>
+    </Container>
+  );
+}
+
+export default AdminCanaryPage;

--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -473,6 +473,14 @@ const Api = {
       return instance.post('/api/service-types', data).catch(handleError);
     },
   },
+  canary: {
+    error () {
+      return instance.post('/api/canary/error');
+    },
+    job () {
+      return instance.post('/api/canary/job');
+    },
+  },
   feedback: {
     create (data) {
       return instance.post('/api/feedback', data).catch(handleError);

--- a/client/src/Header.jsx
+++ b/client/src/Header.jsx
@@ -223,6 +223,7 @@ function Header ({ opened, close, toggle, logout }) {
                   <>
                     <Menu.Divider />
                     <Menu.Label>Admin</Menu.Label>
+                    <Menu.Item component={Link} to='/admin/canary' onClick={close}>Canary</Menu.Item>
                     <Menu.Item component={Link} to='/admin/enums' onClick={close}>Enums</Menu.Item>
                     <Menu.Item component={Link} to='/admin/facilities' onClick={close}>Facilities</Menu.Item>
                     <Menu.Item component={Link} to='/admin/invites' onClick={close}>Invites</Menu.Item>

--- a/client/src/analytics/PosthogProvider.jsx
+++ b/client/src/analytics/PosthogProvider.jsx
@@ -5,6 +5,26 @@ import { useStaticContext } from '@/StaticContext';
 
 const DEFAULT_API_HOST = 'https://app.posthog.com';
 
+// Drop known-noise exceptions before they reach PostHog Error Tracking. These are
+// either browser-internal warnings (ResizeObserver), cross-origin script errors
+// the browser intentionally hides, or errors from user-installed extensions —
+// none are actionable for us and they drown real signal.
+const NOISE_PATTERNS = [
+  /ResizeObserver loop/i,
+  /^Script error\.?$/i,
+  /Non-Error promise rejection captured/i,
+];
+const EXTENSION_FILENAME = /^(?:chrome-extension|moz-extension|safari-(?:web-)?extension|webkit-masked-url):/i;
+
+function isNoiseException (event) {
+  if (event?.event !== '$exception') return false;
+  const list = event.properties?.$exception_list ?? [];
+  const messages = list.map((e) => e?.value).filter(Boolean);
+  if (messages.some((m) => NOISE_PATTERNS.some((re) => re.test(m)))) return true;
+  const frames = list.flatMap((e) => e?.stacktrace?.frames ?? []);
+  return frames.some((f) => EXTENSION_FILENAME.test(f?.filename ?? ''));
+}
+
 function PosthogProvider () {
   const staticContext = useStaticContext();
   const { user } = useAuthContext();
@@ -30,9 +50,11 @@ function PosthogProvider () {
       posthog.init(apiKey, {
         api_host: apiHost || DEFAULT_API_HOST,
         capture_pageview: true,
+        capture_exceptions: true,
         // We can't store ANY PII of people brought to a facility (not of the app users themselves) for >72 hrs,
         // Disable Posthog session recording entirely until we have a way to anonymize or wipe it within the time limit.
         disable_session_recording: true,
+        before_send: (event) => (isNoiseException(event) ? null : event),
       });
       posthogRef.current = posthog;
 

--- a/server/jobs/canary.js
+++ b/server/jobs/canary.js
@@ -1,0 +1,3 @@
+export default async function canary () {
+  throw new Error('Canary: job exception');
+}

--- a/server/lib/jobQueue/queueConfig.js
+++ b/server/lib/jobQueue/queueConfig.js
@@ -3,7 +3,8 @@ import expireHolds from '../../jobs/expireHolds.js';
 import generateForms from '../../jobs/generateForms.js';
 import formsEmail from '../../jobs/formsEmail.js';
 import anonymizeSubjects from '../../jobs/anonymizeSubjects.js';
-import { QUEUE_INVITE_EMAIL, QUEUE_EXPIRE_HOLDS, QUEUE_GENERATE_FORMS, QUEUE_FORMS_EMAIL, QUEUE_ANONYMIZE_SUBJECTS } from './queueNames.js';
+import canary from '../../jobs/canary.js';
+import { QUEUE_INVITE_EMAIL, QUEUE_EXPIRE_HOLDS, QUEUE_GENERATE_FORMS, QUEUE_FORMS_EMAIL, QUEUE_ANONYMIZE_SUBJECTS, QUEUE_CANARY } from './queueNames.js';
 
 const queues = [
   {
@@ -48,6 +49,11 @@ const queues = [
     options: { retryLimit: 1 },
     handler: async ([job]) => anonymizeSubjects(job.data),
     cron: '0 * * * *',
+  },
+  {
+    name: QUEUE_CANARY,
+    options: { retryLimit: 0 },
+    handler: async ([job]) => canary(job.data),
   },
 ];
 export default queues;

--- a/server/lib/jobQueue/queueNames.js
+++ b/server/lib/jobQueue/queueNames.js
@@ -4,3 +4,4 @@ export const QUEUE_EXPIRE_HOLDS = 'expire-holds';
 export const QUEUE_GENERATE_FORMS = 'generate-forms';
 export const QUEUE_FORMS_EMAIL = 'forms-email';
 export const QUEUE_ANONYMIZE_SUBJECTS = 'anonymize-subjects';
+export const QUEUE_CANARY = 'canary';

--- a/server/routes/api/canary/error.js
+++ b/server/routes/api/canary/error.js
@@ -1,0 +1,12 @@
+export default async function (fastify, opts) {
+  fastify.post('/error',
+    {
+      onRequest: fastify.requireAdmin,
+      schema: {
+        description: 'Throws a canary error to verify PostHog Error Tracking captures Fastify exceptions (admin only).',
+      },
+    },
+    async function (request, reply) {
+      throw new Error('Canary: API exception');
+    });
+}

--- a/server/routes/api/canary/job.js
+++ b/server/routes/api/canary/job.js
@@ -1,0 +1,17 @@
+import { StatusCodes } from 'http-status-codes';
+
+import { QUEUE_CANARY } from '#lib/jobQueue/queueNames.js';
+
+export default async function (fastify, opts) {
+  fastify.post('/job',
+    {
+      onRequest: fastify.requireAdmin,
+      schema: {
+        description: 'Enqueues a canary pg-boss job that throws, to verify PostHog captures worker exceptions (admin only).',
+      },
+    },
+    async function (request, reply) {
+      await fastify.backgroundJobs.send(QUEUE_CANARY, {});
+      return reply.code(StatusCodes.ACCEPTED).send({ enqueued: true });
+    });
+}

--- a/server/worker.js
+++ b/server/worker.js
@@ -2,7 +2,7 @@ import './config.js';
 
 import { createBoss } from '#lib/jobQueue/pgBoss.js';
 import queues from '#lib/jobQueue/queueConfig.js';
-import { captureEvent, shutdown as shutdownPosthog } from '#lib/posthog.js';
+import { captureEvent, captureException, shutdown as shutdownPosthog } from '#lib/posthog.js';
 
 const boss = createBoss();
 
@@ -27,7 +27,16 @@ for (const queue of queues) {
 
   await boss.work(queue.name, async ([job]) => {
     const send = (name, data, opts) => boss.send(name, data, opts);
-    return queue.handler([job], { send });
+    try {
+      return await queue.handler([job], { send });
+    } catch (err) {
+      captureException(err, 'care-connect-worker', {
+        queue: queue.name,
+        jobId: job.id,
+        attempt: job.retrycount ?? 0,
+      });
+      throw err;
+    }
   });
 
   await boss.work(deadLetter, async ([job]) => {


### PR DESCRIPTION
Closes: https://github.com/sfbrigade/care-connect/issues/812

Sets `capture_exceptions: true` on the `posthog-js` init so unhandled errors and promise rejections are auto-reported to PostHog Error Tracking.