### PR TITLE
Filter known-noise exceptions before PostHog ingest

### DIFF
--- a/client/src/analytics/PosthogProvider.jsx
+++ b/client/src/analytics/PosthogProvider.jsx
@@ -5,6 +5,26 @@ import { useStaticContext } from '@/StaticContext';
 
 const DEFAULT_API_HOST = 'https://app.posthog.com';
 
+// Drop known-noise exceptions before they reach PostHog Error Tracking. These are
+// either browser-internal warnings (ResizeObserver), cross-origin script errors
+// the browser intentionally hides, or errors from user-installed extensions —
+// none are actionable for us and they drown real signal.
+const NOISE_PATTERNS = [
+  /ResizeObserver loop/i,
+  /^Script error\.?$/i,
+  /Non-Error promise rejection captured/i,
+];
+const EXTENSION_FILENAME = /^(?:chrome-extension|moz-extension|safari-(?:web-)?extension|webkit-masked-url):/i;
+
+function isNoiseException (event) {
+  if (event?.event !== '$exception') return false;
+  const list = event.properties?.$exception_list ?? [];
+  const messages = list.map((e) => e?.value).filter(Boolean);
+  if (messages.some((m) => NOISE_PATTERNS.some((re) => re.test(m)))) return true;
+  const frames = list.flatMap((e) => e?.stacktrace?.frames ?? []);
+  return frames.some((f) => EXTENSION_FILENAME.test(f?.filename ?? ''));
+}
+
 function PosthogProvider () {
   const staticContext = useStaticContext();
   const { user } = useAuthContext();
@@ -33,6 +53,7 @@ function PosthogProvider () {
         // We can't store ANY PII of people brought to a facility (not of the app users themselves) for >72 hrs,
         // Disable Posthog session recording entirely until we have a way to anonymize or wipe it within the time limit.
         disable_session_recording: true,
+        before_send: (event) => (isNoiseException(event) ? null : event),
       });
       posthogRef.current = posthog;
 


### PR DESCRIPTION
Adds a `before_send` hook to `posthog-js` init that drops three categories of known-useless exceptions before they reach Error Tracking:

- **`ResizeObserver loop` warnings** — browser-internal, never actionable.
- **`Script error.` / `Non-Error promise rejection captured`** — cross-origin script errors the browser intentionally redacts; nothing we can debug.
- **Errors originating from `chrome-extension://` / `moz-extension://` / `safari-web-extension://` / `webkit-masked-url://`** — user-installed extensions throwing in our page context.

Helper is module-scoped; can be expanded by adding to `NOISE_PATTERNS` or `EXTENSION_FILENAME` as more noise shows up in the dashboard.