### PR TITLE
Makes 849b org-generic (#847)

### DIFF
--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -265,7 +265,7 @@ describe('CustodyDetailContent', () => {
 
     expect(html).toContain('Incident number: CASE-456');
     expect(html).toContain('Cad number: CAD-123');
-    expect(html).toContain('The SFPD Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:');
+    expect(html).toContain('The Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:');
     expect(html).toContain('Behavior details');
   });
 

--- a/client/src/utils/releaseNarrative.js
+++ b/client/src/utils/releaseNarrative.js
@@ -18,7 +18,7 @@ export function build849bReleaseNarrative ({ incident, behavior } = {}) {
     `Cad number: ${cadNumber}`,
     'Subject was brought to RESET because they were found to be under the influence of a controlled substance or alcohol in a public location. Upon being able to care for themselves, they were released from their detention.',
     '',
-    'The SFPD Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
+    'The Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
     behaviorNarrative,
   ].join('\n');
 }

--- a/client/src/utils/releaseNarrative.test.js
+++ b/client/src/utils/releaseNarrative.test.js
@@ -15,7 +15,7 @@ describe('releaseNarrative', () => {
       'Cad number: CAD-456',
       'Subject was brought to RESET because they were found to be under the influence of a controlled substance or alcohol in a public location. Upon being able to care for themselves, they were released from their detention.',
       '',
-      'The SFPD Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
+      'The Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
       'Subject was unsteady on their feet.',
     ].join('\n'));
   });
@@ -29,7 +29,7 @@ describe('releaseNarrative', () => {
       'Cad number: SEE ABOVE',
       'Subject was brought to RESET because they were found to be under the influence of a controlled substance or alcohol in a public location. Upon being able to care for themselves, they were released from their detention.',
       '',
-      'The SFPD Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
+      'The Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
       'SEE ABOVE',
     ].join('\n'));
   });

--- a/server/lib/forms/849b/releaseNarrative.js
+++ b/server/lib/forms/849b/releaseNarrative.js
@@ -18,7 +18,7 @@ export function build849bReleaseNarrative ({ caseNumber, cadNumber, behavior } =
     `Cad number: ${normalizedCadNumber}`,
     'Subject was brought to RESET because they were found to be under the influence of a controlled substance or alcohol in a public location. Upon being able to care for themselves, they were released from their detention.',
     '',
-    'The SFPD Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
+    'The Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
     behaviorNarrative,
   ].join('\n');
 }


### PR DESCRIPTION
## Summary
- update the 849(b) release narrative copy to remove the hard-coded `SFPD` reference
- apply the same wording change in both the client-side default narrative builder and the server-side PDF narrative builder
- update affected tests to match the new narrative text

Closes #847 