### PR TITLE
Fixes in-transit list issues (#857, #851, #852, #853)

### DIFF
--- a/client/src/lesc/components/ManageCapacity/ManageCapacity.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageCapacity.jsx
@@ -3,19 +3,30 @@ import { useQuery } from '@tanstack/react-query';
 import { Chip, Container, Stack, Text, Title } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { Head } from '@unhead/react';
+import { DateTime } from 'luxon';
 
 import Api from '@/Api';
 import { useFacilityContext } from '@/FacilityContext';
 import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
+import useNow from '@/hooks/useNow';
 import IconButtonLink from '@/components/IconButtonLink';
 
 import AdjustAvailability from './AdjustAvailability';
 import ChangeStatus from './ChangeStatus';
 import ManageHolds from './ManageHolds';
 
+function isCurrentlyActiveHold (hold, now) {
+  if (!hold || hold.status !== 'ACTIVE') return false;
+  if (!hold.expiresAt) return true;
+
+  const expiresAt = DateTime.fromISO(hold.expiresAt);
+  return !expiresAt.isValid || expiresAt >= now;
+}
+
 function ManageCapacity () {
   const { facility } = useFacilityContext();
   const [selectedAction, setSelectedAction] = useState(null);
+  const now = useNow(1000, true);
 
   const { data: freshFacility } = useQuery({
     queryKey: ['facilities', facility.id],
@@ -29,8 +40,25 @@ function ManageCapacity () {
     ...facilityLiveQueryOptions,
   });
 
+  const { data: awaitingCustodyTransferHolds } = useQuery({
+    queryKey: ['deflections', facility.id, 'awaiting-custody-transfer'],
+    queryFn: () => Api.deflections.list({
+      facilityId: facility.id,
+      active: 'true',
+      subjectStatus: 'ONSITE_AWAITING_TRANSFER',
+      perPage: 1000,
+    }).then(response => response.data),
+    ...facilityLiveQueryOptions,
+  });
+
   const currentFacility = freshFacility || facility;
   const bedType = bedTypes?.[0];
+  const awaitingCustodyTransferCount = (awaitingCustodyTransferHolds ?? []).filter(
+    hold => isCurrentlyActiveHold(hold, now) && hold.subjectStatus === 'ONSITE_AWAITING_TRANSFER'
+  ).length;
+  const heldInCustodyOnSiteCount = bedType
+    ? Math.max(0, bedType.holds - bedType.inTransit - awaitingCustodyTransferCount)
+    : 0;
 
   return (
     <Container size='xs' px='xl'>
@@ -49,7 +77,8 @@ function ManageCapacity () {
           <Stack gap='xs'>
             <Text>Available now – <Text span fw={700}>{bedType.available}</Text>/{bedType.capacity}</Text>
             <Text>Held (in transit) – <Text span fw={700}>{bedType.inTransit}</Text></Text>
-            <Text>Held (in custody on site) – <Text span fw={700}>{bedType.holds - bedType.inTransit}</Text></Text>
+            <Text>Held (awaiting custody transfer) – <Text span fw={700}>{awaitingCustodyTransferCount}</Text></Text>
+            <Text>Held (in custody on site) – <Text span fw={700}>{heldInCustodyOnSiteCount}</Text></Text>
             <Text>Occupied – <Text span fw={700}>{bedType.occupied}</Text></Text>
             <Text>Unavailable – <Text span fw={700}>{bedType.unavailableUnoccupied}</Text></Text>
           </Stack>

--- a/client/src/lesc/components/ManageCapacity/ManageCapacity.test.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageCapacity.test.jsx
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MantineProvider } from '@mantine/core';
+import { MemoryRouter } from 'react-router';
+
+import ManageCapacity from './ManageCapacity';
+
+const {
+  mockFacilityGet,
+  mockBedTypesIndex,
+  mockDeflectionsList,
+} = vi.hoisted(() => ({
+  mockFacilityGet: vi.fn(),
+  mockBedTypesIndex: vi.fn(),
+  mockDeflectionsList: vi.fn(),
+}));
+
+vi.mock('@unhead/react', () => ({
+  Head: ({ children }) => <>{children}</>,
+}));
+
+vi.mock('@/Api', () => ({
+  default: {
+    facilities: {
+      get: mockFacilityGet,
+      bedTypes: {
+        index: mockBedTypesIndex,
+      },
+    },
+    deflections: {
+      list: mockDeflectionsList,
+    },
+  },
+}));
+
+vi.mock('@/FacilityContext', () => ({
+  useFacilityContext: () => ({
+    facility: {
+      id: 1,
+      name: 'RESET',
+      status: 'OPEN_ACCEPTING',
+      bedTypes: [{ id: 99, available: 16, capacity: 25, holds: 6, inTransit: 2, occupied: 2, unavailableUnoccupied: 0, type: 'CHAIR' }],
+    },
+  }),
+}));
+
+function renderManageCapacity () {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ManageCapacity />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}
+
+function hasExactTextContent (text) {
+  return (_, node) => node?.textContent === text;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockFacilityGet.mockResolvedValue({
+    data: {
+      id: 1,
+      name: 'RESET',
+      status: 'OPEN_ACCEPTING',
+    },
+  });
+  mockBedTypesIndex.mockResolvedValue({
+    data: [{
+      id: 99,
+      available: 16,
+      capacity: 25,
+      holds: 6,
+      inTransit: 2,
+      occupied: 2,
+      unavailableUnoccupied: 0,
+      type: 'CHAIR',
+    }],
+  });
+  mockDeflectionsList.mockResolvedValue({
+    data: [
+      { id: 5, status: 'ACTIVE', subjectStatus: 'ONSITE_AWAITING_TRANSFER', expiresAt: '3026-05-03T12:00:00.000Z' },
+      { id: 6, status: 'ACTIVE', subjectStatus: 'ONSITE_AWAITING_TRANSFER', expiresAt: '3026-05-03T12:00:00.000Z' },
+      { id: 7, status: 'ACTIVE', subjectStatus: 'ONSITE_AWAITING_TRANSFER', expiresAt: '2020-05-03T12:00:00.000Z' },
+    ],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ManageCapacity', () => {
+  it('shows awaiting-custody-transfer count and excludes it from held-in-custody-on-site', async () => {
+    renderManageCapacity();
+
+    expect(await screen.findByText(/Held \(in transit\) –/)).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('Held (in transit) – 2'))).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('Held (awaiting custody transfer) – 2'))).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('Held (in custody on site) – 2'))).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockDeflectionsList).toHaveBeenCalledWith({
+        facilityId: 1,
+        active: 'true',
+        subjectStatus: 'ONSITE_AWAITING_TRANSFER',
+        perPage: 1000,
+      });
+    });
+  });
+});

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
@@ -1,13 +1,23 @@
 import { useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Button, Card, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
+import { Accordion, Button, Card, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
+import { DateTime } from 'luxon';
 import { Link } from 'react-router';
 
 import Api from '@/Api';
 import { useToast } from '@/components/ToastContext';
+import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import useNow from '@/hooks/useNow';
 import useSubjectDetails from '@/hooks/useSubjectDetails';
 import { formatTimeRemaining } from '@/utils/format';
+
+function isCurrentlyActiveHold (hold, now) {
+  if (!hold || hold.status !== 'ACTIVE') return false;
+  if (!hold.expiresAt) return true;
+
+  const expiresAt = DateTime.fromISO(hold.expiresAt);
+  return !expiresAt.isValid || expiresAt >= now;
+}
 
 function HoldCard ({ deflection, facilityName, onCancelClick }) {
   const now = useNow(1000, deflection.status === 'ACTIVE' && !!deflection.expiresAt);
@@ -69,25 +79,31 @@ function ManageHolds ({ facility }) {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
   const [cancelTarget, setCancelTarget] = useState(null);
+  const now = useNow(1000, true);
 
   const { data: holds, isLoading } = useQuery({
     queryKey: ['deflections', facility.id, 'manage-holds'],
     queryFn: () => Api.deflections.list({
       facilityId: facility.id,
       active: 'true',
-      subjectStatus: 'DETAINED',
+      subjectStatus: 'DETAINED,ONSITE_AWAITING_TRANSFER',
+      perPage: 1000,
     }).then(r => r.data),
-    refetchOnMount: 'always',
+    ...facilityLiveQueryOptions,
   });
 
-  const activeHolds = (holds ?? []).filter(
-    hold => hold.status === 'ACTIVE' && hold.subjectStatus === 'DETAINED'
+  const inTransitHolds = (holds ?? []).filter(
+    hold => isCurrentlyActiveHold(hold, now) && hold.subjectStatus === 'DETAINED'
+  );
+  const awaitingCustodyTransferHolds = (holds ?? []).filter(
+    hold => isCurrentlyActiveHold(hold, now) && hold.subjectStatus === 'ONSITE_AWAITING_TRANSFER'
   );
 
   const cancelMutation = useMutation({
     mutationFn: (id) => Api.deflections.cancel(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['deflections', facility.id, 'in-transit'] });
+      queryClient.invalidateQueries({ queryKey: ['deflections', facility.id, 'manage-holds'] });
+      queryClient.invalidateQueries({ queryKey: ['deflections', facility.id, 'awaiting-custody-transfer'] });
       queryClient.invalidateQueries({ queryKey: ['facilities', facility.id, 'bed-types'] });
       showToast('Hold canceled', 'success', 4000, 'Officer notified.');
       setCancelTarget(null);
@@ -109,20 +125,56 @@ function ManageHolds ({ facility }) {
   return (
     <>
       <Stack>
-        <Title order={4}>Holds in transit</Title>
+        <Accordion
+          variant='contained'
+          chevronPosition='left'
+          multiple
+          defaultValue={['holds-in-transit', 'holds-awaiting-custody-transfer']}
+        >
+          <Accordion.Item value='holds-in-transit'>
+            <Accordion.Control>
+              <Title order={4}>Holds in transit</Title>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Stack gap='md'>
+                {inTransitHolds.length === 0 && (
+                  <Text c='dimmed'>No holds in transit.</Text>
+                )}
 
-        {activeHolds.length === 0 && (
-          <Text c='dimmed'>No holds in transit.</Text>
-        )}
+                {inTransitHolds.map((hold) => (
+                  <HoldCard
+                    key={hold.id}
+                    deflection={hold}
+                    facilityName={facility.name}
+                    onCancelClick={setCancelTarget}
+                  />
+                ))}
+              </Stack>
+            </Accordion.Panel>
+          </Accordion.Item>
 
-        {activeHolds.map((hold) => (
-          <HoldCard
-            key={hold.id}
-            deflection={hold}
-            facilityName={facility.name}
-            onCancelClick={setCancelTarget}
-          />
-        ))}
+          <Accordion.Item value='holds-awaiting-custody-transfer'>
+            <Accordion.Control>
+              <Title order={4}>Holds awaiting custody transfer</Title>
+            </Accordion.Control>
+            <Accordion.Panel>
+              <Stack gap='md'>
+                {awaitingCustodyTransferHolds.length === 0 && (
+                  <Text c='dimmed'>No holds awaiting custody transfer.</Text>
+                )}
+
+                {awaitingCustodyTransferHolds.map((hold) => (
+                  <HoldCard
+                    key={hold.id}
+                    deflection={hold}
+                    facilityName={facility.name}
+                    onCancelClick={setCancelTarget}
+                  />
+                ))}
+              </Stack>
+            </Accordion.Panel>
+          </Accordion.Item>
+        </Accordion>
       </Stack>
 
       <Modal

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
@@ -81,7 +81,7 @@ function ManageHolds ({ facility }) {
   const [cancelTarget, setCancelTarget] = useState(null);
   const now = useNow(1000, true);
 
-  const { data: holds, isLoading } = useQuery({
+  const { data: holds, isLoading, isFetching } = useQuery({
     queryKey: ['deflections', facility.id, 'manage-holds'],
     queryFn: () => Api.deflections.list({
       facilityId: facility.id,
@@ -98,6 +98,8 @@ function ManageHolds ({ facility }) {
   const awaitingCustodyTransferHolds = (holds ?? []).filter(
     hold => isCurrentlyActiveHold(hold, now) && hold.subjectStatus === 'ONSITE_AWAITING_TRANSFER'
   );
+  const showEmptyInTransit = !isLoading && !isFetching && inTransitHolds.length === 0;
+  const showEmptyAwaitingCustodyTransfer = !isLoading && !isFetching && awaitingCustodyTransferHolds.length === 0;
 
   const cancelMutation = useMutation({
     mutationFn: (id) => Api.deflections.cancel(id),
@@ -137,7 +139,7 @@ function ManageHolds ({ facility }) {
             </Accordion.Control>
             <Accordion.Panel>
               <Stack gap='md'>
-                {inTransitHolds.length === 0 && (
+                {showEmptyInTransit && (
                   <Text c='dimmed'>No holds in transit.</Text>
                 )}
 
@@ -159,7 +161,7 @@ function ManageHolds ({ facility }) {
             </Accordion.Control>
             <Accordion.Panel>
               <Stack gap='md'>
-                {awaitingCustodyTransferHolds.length === 0 && (
+                {showEmptyAwaitingCustodyTransfer && (
                   <Text c='dimmed'>No holds awaiting custody transfer.</Text>
                 )}
 

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
@@ -74,10 +74,15 @@ function ManageHolds ({ facility }) {
     queryKey: ['deflections', facility.id, 'manage-holds'],
     queryFn: () => Api.deflections.list({
       facilityId: facility.id,
-      subjectStatus: 'DETAINED,ONSITE_AWAITING_TRANSFER',
+      active: 'true',
+      subjectStatus: 'DETAINED',
     }).then(r => r.data),
     refetchOnMount: 'always',
   });
+
+  const activeHolds = (holds ?? []).filter(
+    hold => hold.status === 'ACTIVE' && hold.subjectStatus === 'DETAINED'
+  );
 
   const cancelMutation = useMutation({
     mutationFn: (id) => Api.deflections.cancel(id),
@@ -106,11 +111,11 @@ function ManageHolds ({ facility }) {
       <Stack>
         <Title order={4}>Holds in transit</Title>
 
-        {holds?.length === 0 && (
+        {activeHolds.length === 0 && (
           <Text c='dimmed'>No holds in transit.</Text>
         )}
 
-        {holds?.map((hold) => (
+        {activeHolds.map((hold) => (
           <HoldCard
             key={hold.id}
             deflection={hold}

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.test.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.test.jsx
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MantineProvider } from '@mantine/core';
+import { MemoryRouter } from 'react-router';
+
+import ManageHolds from './ManageHolds';
+
+const {
+  mockDeflectionsList,
+  mockDeflectionsCancel,
+  mockShowToast,
+} = vi.hoisted(() => ({
+  mockDeflectionsList: vi.fn(),
+  mockDeflectionsCancel: vi.fn(),
+  mockShowToast: vi.fn(),
+}));
+
+vi.mock('@/Api', () => ({
+  default: {
+    deflections: {
+      list: mockDeflectionsList,
+      cancel: mockDeflectionsCancel,
+    },
+  },
+}));
+
+vi.mock('@/components/ToastContext', () => ({
+  useToast: () => ({
+    showToast: mockShowToast,
+  }),
+}));
+
+function renderManageHolds (props = {}) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ManageHolds
+            facility={{ id: 1, name: 'RESET' }}
+            {...props}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDeflectionsList.mockResolvedValue({ data: [] });
+  mockDeflectionsCancel.mockResolvedValue({ data: {} });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ManageHolds', () => {
+  it('requests only active in-transit holds', async () => {
+    renderManageHolds();
+
+    await waitFor(() => {
+      expect(mockDeflectionsList).toHaveBeenCalledWith({
+        facilityId: 1,
+        active: 'true',
+        subjectStatus: 'DETAINED',
+      });
+    });
+  });
+
+  it('renders only active detained holds when other rows are returned', async () => {
+    mockDeflectionsList.mockResolvedValue({
+      data: [
+        {
+          id: 1,
+          status: 'ACTIVE',
+          expiresAt: '2026-05-03T12:00:00.000Z',
+          subjectStatus: 'DETAINED',
+          subject: { firstName: 'Active', lastName: 'Person' },
+          createdBy: { firstName: 'Officer', lastName: 'One' },
+        },
+        {
+          id: 2,
+          status: 'ACTIVE',
+          subjectStatus: 'ONSITE_AWAITING_TRANSFER',
+          expiresAt: '2026-05-03T11:00:00.000Z',
+          subject: { firstName: 'Onsite', lastName: 'Person' },
+          createdBy: { firstName: 'Officer', lastName: 'Two' },
+        },
+        {
+          id: 3,
+          status: 'CANCELLED',
+          cancelledAt: '2026-05-03T11:00:00.000Z',
+          subjectStatus: 'DETAINED',
+          subject: { firstName: 'Cancelled', lastName: 'Person' },
+          createdBy: { firstName: 'Officer', lastName: 'Three' },
+        },
+        {
+          id: 4,
+          status: 'EXPIRED',
+          expiresAt: '2026-05-03T10:00:00.000Z',
+          subjectStatus: 'DETAINED',
+          subject: { firstName: 'Expired', lastName: 'Person' },
+          createdBy: { firstName: 'Officer', lastName: 'Four' },
+        },
+      ],
+    });
+
+    renderManageHolds();
+
+    expect(await screen.findByText('Active Person')).toBeInTheDocument();
+    expect(screen.queryByText('Onsite Person')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cancelled Person')).not.toBeInTheDocument();
+    expect(screen.queryByText('Expired Person')).not.toBeInTheDocument();
+  });
+});

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.test.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.test.jsx
@@ -72,18 +72,19 @@ describe('ManageHolds', () => {
       expect(mockDeflectionsList).toHaveBeenCalledWith({
         facilityId: 1,
         active: 'true',
-        subjectStatus: 'DETAINED',
+        subjectStatus: 'DETAINED,ONSITE_AWAITING_TRANSFER',
+        perPage: 1000,
       });
     });
   });
 
-  it('renders only active detained holds when other rows are returned', async () => {
+  it('renders separate accordions for in-transit and awaiting-custody-transfer holds', async () => {
     mockDeflectionsList.mockResolvedValue({
       data: [
         {
           id: 1,
           status: 'ACTIVE',
-          expiresAt: '2026-05-03T12:00:00.000Z',
+          expiresAt: '3026-05-03T12:00:00.000Z',
           subjectStatus: 'DETAINED',
           subject: { firstName: 'Active', lastName: 'Person' },
           createdBy: { firstName: 'Officer', lastName: 'One' },
@@ -92,33 +93,44 @@ describe('ManageHolds', () => {
           id: 2,
           status: 'ACTIVE',
           subjectStatus: 'ONSITE_AWAITING_TRANSFER',
-          expiresAt: '2026-05-03T11:00:00.000Z',
+          expiresAt: '3026-05-03T11:00:00.000Z',
           subject: { firstName: 'Onsite', lastName: 'Person' },
           createdBy: { firstName: 'Officer', lastName: 'Two' },
         },
         {
           id: 3,
-          status: 'CANCELLED',
-          cancelledAt: '2026-05-03T11:00:00.000Z',
-          subjectStatus: 'DETAINED',
-          subject: { firstName: 'Cancelled', lastName: 'Person' },
+          status: 'ACTIVE',
+          subjectStatus: 'ONSITE_AWAITING_TRANSFER',
+          expiresAt: '2026-05-03T09:00:00.000Z',
+          subject: { firstName: 'Expired Onsite', lastName: 'Person' },
           createdBy: { firstName: 'Officer', lastName: 'Three' },
         },
         {
           id: 4,
+          status: 'CANCELLED',
+          cancelledAt: '2026-05-03T11:00:00.000Z',
+          subjectStatus: 'DETAINED',
+          subject: { firstName: 'Cancelled', lastName: 'Person' },
+          createdBy: { firstName: 'Officer', lastName: 'Four' },
+        },
+        {
+          id: 5,
           status: 'EXPIRED',
           expiresAt: '2026-05-03T10:00:00.000Z',
           subjectStatus: 'DETAINED',
           subject: { firstName: 'Expired', lastName: 'Person' },
-          createdBy: { firstName: 'Officer', lastName: 'Four' },
+          createdBy: { firstName: 'Officer', lastName: 'Five' },
         },
       ],
     });
 
     renderManageHolds();
 
+    expect(await screen.findByText('Holds in transit')).toBeInTheDocument();
+    expect(screen.getByText('Holds awaiting custody transfer')).toBeInTheDocument();
     expect(await screen.findByText('Active Person')).toBeInTheDocument();
-    expect(screen.queryByText('Onsite Person')).not.toBeInTheDocument();
+    expect(screen.getByText('Onsite Person')).toBeInTheDocument();
+    expect(screen.queryByText('Expired Onsite Person')).not.toBeInTheDocument();
     expect(screen.queryByText('Cancelled Person')).not.toBeInTheDocument();
     expect(screen.queryByText('Expired Person')).not.toBeInTheDocument();
   });

--- a/server/routes/api/deflections/cancel.js
+++ b/server/routes/api/deflections/cancel.js
@@ -48,7 +48,8 @@ export default async function (fastify, opts) {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      if (!canModifyDeflection(deflection, request.user)) {
+      const canCancelDeflection = canModifyDeflection(deflection, request.user) || request.user.isFacilityAdmin;
+      if (!canCancelDeflection) {
         return reply.code(StatusCodes.FORBIDDEN).send();
       }
 
@@ -110,7 +111,6 @@ export default async function (fastify, opts) {
           });
           const isInTransit = [
             Deflection.SubjectStatus.DETAINED,
-            Deflection.SubjectStatus.ONSITE_AWAITING_TRANSFER,
           ].includes(deflection.subjectStatus);
           const { capacity, unavailableUnoccupied, unavailableOccupied, occupied, holds, inTransit, available } = bedType;
           const updatedData = {

--- a/server/routes/api/deflections/reopen.js
+++ b/server/routes/api/deflections/reopen.js
@@ -75,7 +75,6 @@ export default async function (fastify, opts) {
       // check/update bed type availability
       const isInTransit = [
         Deflection.SubjectStatus.DETAINED,
-        Deflection.SubjectStatus.ONSITE_AWAITING_TRANSFER,
       ].includes(deflection.subjectStatus);
       const { capacity, unavailableUnoccupied, unavailableOccupied, occupied, holds, inTransit, available } = bedType;
       const updatedData = {

--- a/server/routes/api/deflections/transfer.js
+++ b/server/routes/api/deflections/transfer.js
@@ -95,8 +95,7 @@ export default async function (fastify, opts) {
           });
 
           // Person transitions from ONSITE_AWAITING_TRANSFER → AWAITING_INTAKE.
-          // Both are hold statuses, so holds/occupied/available don't change.
-          // But the person is no longer "in transit" (they've arrived at the facility).
+          // Both are onsite hold statuses, so bed-type counters do not change.
           const { capacity, unavailableUnoccupied, unavailableOccupied, occupied, holds, inTransit, available } = bedType;
           const updatedData = {
             capacity,
@@ -104,7 +103,7 @@ export default async function (fastify, opts) {
             unavailableOccupied,
             occupied,
             holds,
-            inTransit: Math.max(0, inTransit - 1),
+            inTransit,
             available,
             updateMethod: 'API',
             updatedById: request.user.id,

--- a/server/routes/api/facilities/_facilityId/arrived.js
+++ b/server/routes/api/facilities/_facilityId/arrived.js
@@ -37,6 +37,7 @@ export default async function (fastify) {
             throw notFoundError(`Facility ${facilityId} not found`);
           }
           const now = new Date();
+          let transitionedFromDetainedCount = 0;
 
           // Snapshot candidate pre-transfer holds for this officer under the facility lock.
           const candidateHolds = await tx.deflection.findMany({
@@ -48,6 +49,7 @@ export default async function (fastify) {
             },
             select: {
               id: true,
+              bedTypeId: true,
               arrivedAt: true,
               subjectStatus: true,
               incident: true,
@@ -93,6 +95,9 @@ export default async function (fastify) {
 
             if (updated.count === 1) {
               holdIds.push(hold.id);
+              if (hold.subjectStatus === 'DETAINED') {
+                transitionedFromDetainedCount++;
+              }
               if (hold.subjectStatus !== 'ONSITE_AWAITING_TRANSFER' || hold.arrivedAt === null) {
                 holdsNeedingArrivalUpdate.push(hold);
               }
@@ -112,6 +117,46 @@ export default async function (fastify) {
                 updatedAt: now,
               })),
             });
+          }
+
+          if (transitionedFromDetainedCount > 0) {
+            const decrementCounts = new Map();
+
+            for (const hold of candidateHolds) {
+              if (holdIds.includes(hold.id) && hold.subjectStatus === 'DETAINED') {
+                const current = decrementCounts.get(hold.bedTypeId) ?? 0;
+                decrementCounts.set(hold.bedTypeId, current + 1);
+              }
+            }
+
+            for (const [bedTypeId, decrementCount] of decrementCounts) {
+              const bedType = await tx.bedType.findByIdForUpdate(tx, bedTypeId);
+              if (!bedType) continue;
+
+              const updatedData = {
+                capacity: bedType.capacity,
+                unavailableUnoccupied: bedType.unavailableUnoccupied,
+                unavailableOccupied: bedType.unavailableOccupied,
+                occupied: bedType.occupied,
+                holds: bedType.holds,
+                inTransit: Math.max(0, bedType.inTransit - decrementCount),
+                available: bedType.available,
+                updateMethod: 'API',
+                updatedById: officerId,
+              };
+
+              await tx.bedTypeUpdate.create({
+                data: {
+                  ...updatedData,
+                  bedTypeId,
+                  facilityId,
+                },
+              });
+              await tx.bedType.update({
+                where: { id: bedTypeId },
+                data: updatedData,
+              });
+            }
           }
 
           // Record the facility check-in event for the holds that were still eligible at commit time.

--- a/server/routes/api/facilities/_facilityId/bed-types/get.js
+++ b/server/routes/api/facilities/_facilityId/bed-types/get.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
 import BedType from '#models/bedType.js';
+import Deflection from '#models/deflection.js';
 
 export default async function (fastify, opts) {
   fastify.get('/:bedTypeId',
@@ -32,6 +33,18 @@ export default async function (fastify, opts) {
         return reply.code(StatusCodes.NOT_FOUND).send({ error: 'Bed type record not found' });
       }
 
-      return reply.send(bedType);
+      const inTransit = await fastify.prisma.deflection.count({
+        where: {
+          facilityId,
+          bedTypeId,
+          status: Deflection.HoldStatus.ACTIVE,
+          subjectStatus: Deflection.SubjectStatus.DETAINED,
+        },
+      });
+
+      return reply.send({
+        ...bedType,
+        inTransit,
+      });
     });
 }

--- a/server/routes/api/facilities/_facilityId/bed-types/list.js
+++ b/server/routes/api/facilities/_facilityId/bed-types/list.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
 import BedType from '#models/bedType.js';
+import Deflection from '#models/deflection.js';
 
 export default async function (fastify, opts) {
   fastify.get('/',
@@ -34,6 +35,24 @@ export default async function (fastify, opts) {
       };
 
       const { records, total } = await fastify.prisma.bedType.paginate(options);
-      return reply.setPaginationHeaders(page, perPage, total).send(records);
+      const inTransitCounts = await fastify.prisma.deflection.groupBy({
+        by: ['bedTypeId'],
+        where: {
+          facilityId,
+          bedTypeId: { in: records.map(record => record.id) },
+          status: Deflection.HoldStatus.ACTIVE,
+          subjectStatus: Deflection.SubjectStatus.DETAINED,
+        },
+        _count: { _all: true },
+      });
+      const inTransitByBedTypeId = new Map(
+        inTransitCounts.map(row => [row.bedTypeId, row._count._all])
+      );
+      const hydratedRecords = records.map(record => ({
+        ...record,
+        inTransit: inTransitByBedTypeId.get(record.id) ?? 0,
+      }));
+
+      return reply.setPaginationHeaders(page, perPage, total).send(hydratedRecords);
     });
 }

--- a/server/routes/api/status/capacity.js
+++ b/server/routes/api/status/capacity.js
@@ -46,10 +46,11 @@ async function computeCapacity (fastify, request) {
   // they're physically still in the facility.
   //
   // Boundary:
-  //   - transferredAt is set: SFSO has handed custody to care staff. This
-  //     matches the inTransit counter's exit point (deflections/transfer.js
-  //     decrements bedType.inTransit at the same moment), so anyone the
-  //     system calls "in transit" is excluded.
+  //   - arrivedAt is set: the officer has checked in at the facility. This
+  //     matches the inTransit counter's exit point (facilities/:id/arrived
+  //     decrements bedType.inTransit when DETAINED becomes
+  //     ONSITE_AWAITING_TRANSFER), so anyone the system calls "in transit"
+  //     is excluded.
   //   - exitedAt is null: the subject hasn't physically left the facility
   //     (deflections/exit.js sets exitedAt when they leave).
   //
@@ -57,7 +58,7 @@ async function computeCapacity (fastify, request) {
   const occupied = await fastify.prisma.deflection.count({
     where: {
       facilityId: facility.id,
-      transferredAt: { not: null },
+      arrivedAt: { not: null },
       exitedAt: null,
     },
   });

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -317,7 +317,7 @@ test('/api/deflections', async (t) => {
       });
       assert.deepStrictEqual(bedType.occupied, 0);
       assert.deepStrictEqual(bedType.holds, 4);
-      assert.deepStrictEqual(bedType.inTransit, 2); // in-transit decrements
+      assert.deepStrictEqual(bedType.inTransit, 3);
       assert.deepStrictEqual(bedType.available, 4);
     });
 
@@ -1485,6 +1485,26 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(bedType.holds, 1);
       assert.deepStrictEqual(bedType.inTransit, 1); // deflection 6 is READY_FOR_INTAKE so is NOT considered in transit
       assert.deepStrictEqual(bedType.available, 7);
+    });
+
+    await t.test('allows facility admin to cancel an active hold', async () => {
+      await prisma.deflection.expire();
+
+      const response = await app.inject()
+        .delete('/api/deflections/4?cancelReason=BEHAVIORAL_HEALTH_EVALUATION')
+        .headers(facilityAdminHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.status, 'CANCELLED');
+      assert.deepStrictEqual(data.cancelledById, 'a1b2c3d4-e5f6-7890-abcd-fa1234567890');
+
+      const deflection = await prisma.deflection.findUnique({
+        where: { id: 4 },
+      });
+      assert.deepStrictEqual(deflection.status, 'CANCELLED');
+      assert.deepStrictEqual(deflection.cancelledById, 'a1b2c3d4-e5f6-7890-abcd-fa1234567890');
     });
 
     await t.test('returns 404 for non-existent deflection', async () => {

--- a/server/test/routes/api/facilities/arrived.test.js
+++ b/server/test/routes/api/facilities/arrived.test.js
@@ -65,6 +65,25 @@ test('POST /api/facilities/:facilityId/arrived', async (t) => {
     assert.ok(afterCount >= beforeCount + 2, 'expected an update row per pre-transfer hold');
   });
 
+  await t.test('decrements inTransit when detained holds become awaiting transfer', async () => {
+    await makeFixturePreTransferDetailsComplete(prisma);
+
+    const bedTypeBefore = await prisma.bedType.findUnique({
+      where: { id: '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76' },
+    });
+
+    const response = await app.inject()
+      .post(`/api/facilities/${FACILITY_ID}/arrived`)
+      .headers(userHeaders);
+
+    assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+
+    const bedTypeAfter = await prisma.bedType.findUnique({
+      where: { id: '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76' },
+    });
+    assert.deepStrictEqual(bedTypeAfter.inTransit, bedTypeBefore.inTransit - 2);
+  });
+
   await t.test('records an ARRIVAL FacilityCheckIn with the affected hold ids', async () => {
     await makeFixturePreTransferDetailsComplete(prisma);
 

--- a/server/test/routes/api/facilities/bed-types.test.js
+++ b/server/test/routes/api/facilities/bed-types.test.js
@@ -28,6 +28,26 @@ test('/api/facilities/:facilityId/bed-types', async (t) => {
       assert.deepStrictEqual(data.id, bedTypeId);
     });
 
+    await t.test('returns derived inTransit count instead of stale stored value', async () => {
+      await app.prisma.deflection.expire();
+      await app.prisma.deflection.update({
+        where: { id: 5 },
+        data: { subjectStatus: 'ONSITE_AWAITING_TRANSFER' },
+      });
+      await app.prisma.bedType.update({
+        where: { id: '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76' },
+        data: { inTransit: 99 },
+      });
+
+      const response = await app.inject()
+        .get(`/api/facilities/${facilityId}/bed-types/2347510d-5fd0-4c5c-8a14-82bfd3ef2c76`)
+        .headers(userHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.inTransit, 2);
+    });
+
     await t.test('returns 404 for non-existent bed type', async () => {
       const response = await app.inject()
         .get(`/api/facilities/${facilityId}/bed-types/00000000-0000-0000-0000-000000000000`)


### PR DESCRIPTION
## Summary

This PR fixes several hold-management regressions and inconsistencies across facility-admin and field-user workflows.

## Details

### Facility-admin hold cancellation
- Fixed a `403` when a facility admin cancels an active hold.
- Scoped the permission change to the cancel route only, without broadening general deflection-edit permissions.
- Added a regression test for facility-admin hold cancellation.

### Facility-admin "Holds in transit" panel
- Fixed the manage-capacity hold list to show only active in-transit holds.
- Updated the query to request only `ACTIVE` + `DETAINED` holds.
- Added a defensive client-side filter so cancelled, expired, and onsite-awaiting-transfer holds do not render in that panel.
- Added focused client regression coverage for the request shape and rendered list.

### Facility-admin "Holds awaiting custody transfer" panel
- Added awaiting transfer lists
- Moved awaiting transfer and in transit into accordion

### In-transit boundary normalization
- Changed the in-transit definition so it now includes only active holds in `DETAINED`.
- Moved the counter boundary from transfer-time to arrival-time:
  - `/facilities/:facilityId/arrived` now decrements `bedType.inTransit` when a hold transitions from `DETAINED` to `ONSITE_AWAITING_TRANSFER`
  - `/deflections/:id/transfer` no longer decrements `inTransit`
  - cancel/reopen logic now affects `inTransit` only for `DETAINED` holds
- Updated related server tests to match the new boundary.

### Bed-type API counter correctness
- Fixed facility bed-type read endpoints to derive `inTransit` from live deflection rows instead of trusting a possibly stale stored column. 
- `inTransit` is now computed from active `DETAINED` deflections on read.
- Added a regression test proving the API returns the derived value even if the stored `BedType.inTransit` field is stale.

This does not necessarily solve the problem of the past drift in the stale column, but making more aggressive changes seemed risky at this stage.

## Why

Before these changes:
- facility admins could not cancel holds they were expected to manage
- the manage-capacity UI could show cancelled/expired/on-site holds in the in-transit list
- the `inTransit` concept was inconsistent across UI, counters, and mutation flows
- the bed-type API could expose stale denormalized `inTransit` values

After these changes:
- facility-admin hold management matches intended permissions
- "Holds in transit" reflects only true in-transit holds
- the arrival boundary and the displayed counter semantics are aligned
- bed-type API consumers get a correct `inTransit` count even if stored counters drift

Closes #857, #851, #852, #853
