### PR TITLE
Set enableExceptionAutocapture to true for Posthog on the server

### DIFF
--- a/server/lib/posthog.js
+++ b/server/lib/posthog.js
@@ -7,7 +7,12 @@ const host = process.env.VITE_POSTHOG_HOST || 'https://app.posthog.com';
 let client = null;
 
 if (apiKey) {
-  client = new PostHog(apiKey, { host });
+  client = new PostHog(apiKey, {
+    host,
+    // on the server, we need to enable exception autocapture via code, while it's done
+    // on the Posthog site for the client
+    enableExceptionAutocapture: true
+  });
 }
 
 export function captureEvent (event, properties = {}) {


### PR DESCRIPTION
According to the docs, autocapture of unhandled exceptions needs to be done via the `PostHog` constructor: https://posthog.com/docs/error-tracking/installation/node#configure-exception-autocapture