### PR TITLE
Ignore expiresAt when deflection subjectStatus is ONSITE_AWAITING_TRANSFER

### DIFF
--- a/client/src/lesc/components/ManageCapacity/ManageCapacity.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageCapacity.jsx
@@ -17,7 +17,7 @@ import ManageHolds from './ManageHolds';
 
 function isCurrentlyActiveHold (hold, now) {
   if (!hold || hold.status !== 'ACTIVE') return false;
-  if (!hold.expiresAt) return true;
+  if (!hold.expiresAt || hold.subjectStatus === 'ONSITE_AWAITING_TRANSFER') return true;
 
   const expiresAt = DateTime.fromISO(hold.expiresAt);
   return !expiresAt.isValid || expiresAt >= now;

--- a/client/src/lesc/components/ManageCapacity/ManageCapacity.test.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageCapacity.test.jsx
@@ -109,8 +109,8 @@ describe('ManageCapacity', () => {
 
     expect(await screen.findByText(/Held \(in transit\) –/)).toBeInTheDocument();
     expect(screen.getByText(hasExactTextContent('Held (in transit) – 2'))).toBeInTheDocument();
-    expect(screen.getByText(hasExactTextContent('Held (awaiting custody transfer) – 2'))).toBeInTheDocument();
-    expect(screen.getByText(hasExactTextContent('Held (in custody on site) – 2'))).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('Held (awaiting custody transfer) – 3'))).toBeInTheDocument();
+    expect(screen.getByText(hasExactTextContent('Held (in custody on site) – 1'))).toBeInTheDocument();
 
     await waitFor(() => {
       expect(mockDeflectionsList).toHaveBeenCalledWith({

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.jsx
@@ -13,7 +13,7 @@ import { formatTimeRemaining } from '@/utils/format';
 
 function isCurrentlyActiveHold (hold, now) {
   if (!hold || hold.status !== 'ACTIVE') return false;
-  if (!hold.expiresAt) return true;
+  if (!hold.expiresAt || hold.subjectStatus === 'ONSITE_AWAITING_TRANSFER') return true;
 
   const expiresAt = DateTime.fromISO(hold.expiresAt);
   return !expiresAt.isValid || expiresAt >= now;

--- a/client/src/lesc/components/ManageCapacity/ManageHolds.test.jsx
+++ b/client/src/lesc/components/ManageCapacity/ManageHolds.test.jsx
@@ -102,7 +102,7 @@ describe('ManageHolds', () => {
           status: 'ACTIVE',
           subjectStatus: 'ONSITE_AWAITING_TRANSFER',
           expiresAt: '2026-05-03T09:00:00.000Z',
-          subject: { firstName: 'Expired Onsite', lastName: 'Person' },
+          subject: { firstName: 'Onsite Doesnt Expire', lastName: 'Person' },
           createdBy: { firstName: 'Officer', lastName: 'Three' },
         },
         {
@@ -130,7 +130,7 @@ describe('ManageHolds', () => {
     expect(screen.getByText('Holds awaiting custody transfer')).toBeInTheDocument();
     expect(await screen.findByText('Active Person')).toBeInTheDocument();
     expect(screen.getByText('Onsite Person')).toBeInTheDocument();
-    expect(screen.queryByText('Expired Onsite Person')).not.toBeInTheDocument();
+    expect(screen.queryByText('Onsite Doesnt Expire Person')).toBeInTheDocument();
     expect(screen.queryByText('Cancelled Person')).not.toBeInTheDocument();
     expect(screen.queryByText('Expired Person')).not.toBeInTheDocument();
   });


### PR DESCRIPTION
Only ACTIVE/DETAINED deflections get expired. ACTIVE/ONSITE_AWAITING_TRANSFER will remain indefinitely and hold a chair until cancelled or otherwise released.

Although PR #858 fixed the queries to fetch all of these states and calculate counts, the definition of isCurrentlyActiveHold was not updated, and as a result, they were still not being calculated nor displayed in the Manage screen.

Need to refactor ManageHolds/ManageCapacity so we're not repeating the same logic check code in multiple places. We should also update BedType and the counts to handle this so we're not dependent upon client-side iterating through records and counting.