### PR TITLE
prevent exception on active camera dismiss

### DIFF
--- a/client/src/components/QRScanner.jsx
+++ b/client/src/components/QRScanner.jsx
@@ -314,7 +314,10 @@ export default function QRScanner ({ onScanSuccess, onScanError, className = '',
           scanner.stop()
             .catch(() => {})
             .finally(() => {
-              scanner.clear().catch(() => {});
+              // html5-qrcode's clear() can return undefined after stop() has already
+              // torn down internal state; the optional chain + try wrap keeps cleanup
+              // best-effort regardless of what shape (or whether) clear() returns.
+              try { scanner.clear()?.catch?.(() => {}); } catch {}
             });
         } catch {
           // stop() threw synchronously (scanner not fully started)


### PR DESCRIPTION
## Problem

We are seeing errors in PostHog like:

```
TypeError: undefined is not an object (evaluating 'K.clear().catch')
URL: https://reset.careconnect.sf.gov/care
Handled: false
```

I was able to reproduce this by using the QR code scanner as care staff. If I let camera start, then dismiss it the error occurs.

## Priority

Low

## Fix

Catch errors when we reach scanner stop instead of letting them propagate. I think it is fine to just catch here and not log because in the finally step we are done and cleaning up the camera activity.