### PR TITLE
Updates custody copy for generic org (#846)

### DIFF
--- a/client/src/lesc/components/EmptyState.stories.jsx
+++ b/client/src/lesc/components/EmptyState.stories.jsx
@@ -17,7 +17,7 @@ export default {
 export const NoneInCustody = {
   args: {
     title: 'No persons In Custody',
-    description: "When you receive a person from SFPD, they'll appear here.",
+    description: "When you receive a person from an arresting officer, they'll appear here.",
   },
 };
 

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -283,7 +283,7 @@ function Custody () {
                 : (
                   <EmptyState
                     title='No persons In Custody'
-                    description="When you receive a person from SFPD, they'll appear here."
+                    description="When you receive a person from an arresting officer, they'll appear here."
                   />
                   )}
             </Stack>


### PR DESCRIPTION
## Summary

- Update the custody empty-state message to refer to “an arresting officer” instead of “SFPD”
- Align the matching Storybook empty-state example with the new copy

Closes #846 