### PR TITLE
Gives release unit precedence (#869)

### DIFF
--- a/server/lib/forms/cert/generate.js
+++ b/server/lib/forms/cert/generate.js
@@ -14,9 +14,7 @@ export function transformData (deflection) {
   const deputyTitle = deputy?.title?.name || '';
   const deputyName = deputy ? `${deputy.firstName} ${deputy.lastName}` : '';
   const deputyBadge = deputy?.badgeNumber || '';
-  const unitIdentifier = deflection.incident?.createdByUnit?.name ||
-    deputy?.unit?.name ||
-    '';
+  const unitIdentifier = deputy?.unit?.name || '';
 
   const detention = formatDateParts(deflection.createdAt?.toISOString());
   const release = formatDateParts(deflection.releasedAt.toISOString());

--- a/server/test/lib/forms/cert.test.js
+++ b/server/test/lib/forms/cert.test.js
@@ -1,0 +1,49 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { transformData } from '#lib/forms/cert/generate.js';
+
+const baseDeflection = {
+  subject: null,
+  createdAt: new Date('2026-05-01T10:00:00.000Z'),
+  releasedAt: new Date('2026-05-01T12:00:00.000Z'),
+  createdBy: null,
+  releasedBy: null,
+  incident: null,
+  narcoticsSubstance: null,
+  narcoticsParaphernalia: null,
+};
+
+test('cert unitIdentifier uses releasedBy.unit before incident.createdByUnit', () => {
+  const data = transformData({
+    ...baseDeflection,
+    releasedBy: {
+      firstName: 'Sam',
+      lastName: 'Deputy',
+      badgeNumber: '5678',
+      unit: { name: 'SFSO Intake' },
+    },
+    incident: {
+      createdByUnit: { name: 'SFPD Southern' },
+    },
+  });
+
+  assert.equal(data.unitIdentifier, 'SFSO Intake');
+});
+
+test('cert unitIdentifier is blank when releasedBy has no unit', () => {
+  const data = transformData({
+    ...baseDeflection,
+    releasedBy: {
+      firstName: 'Sam',
+      lastName: 'Deputy',
+      badgeNumber: '5678',
+      unit: null,
+    },
+    incident: {
+      createdByUnit: { name: 'SFPD Southern' },
+    },
+  });
+
+  assert.equal(data.unitIdentifier, '');
+});


### PR DESCRIPTION
## Summary

- Update Certificate of Release unit selection to use the releasing deputy’s unit rather than the incident unit.
- Remove fallback to the originating incident/SFPD unit for the Certificate of Release - blank is better than wrong.
- Add form unit tests covering the SFSO unit case and blank-unit fallback.

Closes #869 