### PR TITLE
tighter capacity count

### DIFF
--- a/server/routes/api/status/capacity.js
+++ b/server/routes/api/status/capacity.js
@@ -1,6 +1,8 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
+import Deflection from '#models/deflection.js';
+
 const CACHE_TTL_MS = 30_000;
 
 const OccupantSchema = z.object({
@@ -26,17 +28,23 @@ const CapacityResponseSchema = z.object({
 let cache = null;
 let inflight = null;
 
+export function _resetCacheForTests () {
+  cache = null;
+  inflight = null;
+}
+
 async function computeCapacity (fastify, request) {
   const { facility } = request;
 
-  // Bed totals: capacity, what's unavailable, and the inTransit count come
-  // straight from the denormalized bedType counters. occupied is computed
-  // separately below — see comment on the count query.
+  // Bed totals: capacity and what's unavailable come straight from the
+  // denormalized bedType counters (those track config, not lifecycle, so
+  // they don't drift). occupied and inTransit are computed live from row
+  // state below — the bedType.occupied / bedType.inTransit counters can
+  // drift from reality and are deliberately not used here.
   const totals = facility.bedTypes.reduce((acc, bt) => ({
     total: acc.total + bt.capacity,
     unavailable: acc.unavailable + bt.unavailableUnoccupied + bt.unavailableOccupied,
-    inTransit: acc.inTransit + bt.inTransit,
-  }), { total: 0, unavailable: 0, inTransit: 0 });
+  }), { total: 0, unavailable: 0 });
 
   // "Occupied" = people at the facility who are no longer in transit. We
   // compute this from deflection rows rather than summing bedType.occupied
@@ -46,6 +54,9 @@ async function computeCapacity (fastify, request) {
   // they're physically still in the facility.
   //
   // Boundary:
+  //   - status is ACTIVE: filters out cancelled-after-arrival rows and any
+  //     completed-but-no-exitedAt rows, so stale lifecycle artifacts don't
+  //     inflate the count.
   //   - arrivedAt is set: the officer has checked in at the facility. This
   //     matches the inTransit counter's exit point (facilities/:id/arrived
   //     decrements bedType.inTransit when DETAINED becomes
@@ -58,8 +69,23 @@ async function computeCapacity (fastify, request) {
   const occupied = await fastify.prisma.deflection.count({
     where: {
       facilityId: facility.id,
+      status: Deflection.HoldStatus.ACTIVE,
       arrivedAt: { not: null },
       exitedAt: null,
+    },
+  });
+
+  // "InTransit" = active holds where the officer hasn't yet arrived at the
+  // facility. Computed live from row state rather than summing
+  // bedType.inTransit — see bed-types/list.js for prior art applying the
+  // same workaround. The counter is incremented on create and decremented
+  // on arrived/cancel, but has been observed to drift when test data and
+  // edge-case lifecycle paths leave the counter and row state inconsistent.
+  const inTransit = await fastify.prisma.deflection.count({
+    where: {
+      facilityId: facility.id,
+      status: Deflection.HoldStatus.ACTIVE,
+      subjectStatus: Deflection.SubjectStatus.DETAINED,
     },
   });
 
@@ -88,7 +114,7 @@ async function computeCapacity (fastify, request) {
       total: totals.total,
       operational: totals.total - totals.unavailable,
       occupied,
-      inTransit: totals.inTransit,
+      inTransit,
     },
     occupants: occupants.map(d => ({
       medicalIntakeStartedAt: d.medicalIntakeStartedAt ? d.medicalIntakeStartedAt.toISOString() : null,

--- a/server/test/routes/api/status-capacity.test.js
+++ b/server/test/routes/api/status-capacity.test.js
@@ -3,6 +3,7 @@ import * as assert from 'node:assert';
 import { StatusCodes } from 'http-status-codes';
 
 import { build } from '#test/helper.js';
+import { _resetCacheForTests } from '../../../routes/api/status/capacity.js';
 
 const TEST_API_KEY = 'test-capacity-api-key-do-not-use-in-prod';
 
@@ -14,8 +15,11 @@ test('/api/status/capacity', async (t) => {
 
   // The shared test fixtures don't include a facility with subdomain='reset',
   // and the helper's afterEach recreates the DB from template1 after every
-  // subtest — so we re-seed per test that needs it.
+  // subtest — so we re-seed per test that needs it. Also reset the
+  // module-level capacity response cache so a previous subtest's snapshot
+  // doesn't leak into the next subtest's freshly-seeded DB.
   t.beforeEach(async () => {
+    _resetCacheForTests();
     const user = await prisma.user.findFirst();
     const serviceType = await prisma.serviceType.findFirst();
     await prisma.facility.create({
@@ -119,5 +123,70 @@ test('/api/status/capacity', async (t) => {
       .get('/api/status/capacity')
       .headers({ authorization: `Bearer ${TEST_API_KEY}`, host: 'reset.localhost' });
     assert.ok(response.headers['cache-control'].includes('max-age=30'));
+  });
+
+  await t.test('beds.inTransit is computed from live row state, not the BedType counter', async () => {
+    // beforeEach seeded the bedType with inTransit=2, but no actual
+    // ACTIVE+DETAINED deflection rows exist. The response should report 0,
+    // proving the denormalized counter is no longer the source of truth.
+    const response = await app.inject()
+      .get('/api/status/capacity')
+      .headers({ authorization: `Bearer ${TEST_API_KEY}`, host: 'reset.localhost' });
+
+    assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+    const body = JSON.parse(response.body);
+    assert.deepStrictEqual(body.beds.inTransit, 0);
+  });
+
+  await t.test('beds.occupied excludes cancelled-after-arrival rows', async () => {
+    const user = await prisma.user.findFirst();
+    const facility = await prisma.facility.findUnique({ where: { subdomain: 'reset' } });
+    const bedType = await prisma.bedType.findFirst({ where: { facilityId: facility.id } });
+
+    const incident = await prisma.incident.create({
+      data: {
+        facilityId: facility.id,
+        encounteredVia: 'ON_VIEW',
+        createdById: user.id,
+        updatedById: user.id,
+      },
+    });
+
+    // Stale row: arrived but never exited, then cancelled. Must not count.
+    await prisma.deflection.create({
+      data: {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        bedTypeId: bedType.id,
+        createdById: user.id,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        status: 'CANCELLED',
+        arrivedAt: new Date('2026-01-01T00:00:00Z'),
+        exitedAt: null,
+      },
+    });
+
+    // Real row: active, currently onsite. Must count.
+    await prisma.deflection.create({
+      data: {
+        incidentId: incident.id,
+        facilityId: facility.id,
+        bedTypeId: bedType.id,
+        createdById: user.id,
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+        status: 'ACTIVE',
+        subjectStatus: 'IN_CHAIR',
+        arrivedAt: new Date(),
+        exitedAt: null,
+      },
+    });
+
+    const response = await app.inject()
+      .get('/api/status/capacity')
+      .headers({ authorization: `Bearer ${TEST_API_KEY}`, host: 'reset.localhost' });
+
+    assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+    const body = JSON.parse(response.body);
+    assert.deepStrictEqual(body.beds.occupied, 1);
   });
 });


### PR DESCRIPTION
We are seeing old test data influence the capacity counts returned in the capacity api. Tighten up how this is calculated:


- `occupied` counted rows with \`arrivedAt != null AND exitedAt = null\` but had no \`status\` filter, so cancelled-after-arrival and stale pre-go-live test rows were counted forever.
- `inTransit` summed \`BedType.inTransit\`, which has drifted from the actual ACTIVE+DETAINED row count.


Mirror the pattern already in [bed-types/list.js](server/routes/api/facilities/_facilityId/bed-types/list.js): compute both counts live from row state and ignore the denormalized counters. The counters on \`BedType\` are unchanged — other endpoints behave identically.
