### PR TITLE
849b stingy regen

### DIFF
--- a/server/jobs/generateForms.js
+++ b/server/jobs/generateForms.js
@@ -11,8 +11,6 @@ export default async function generateForms (data, prismaClient = prisma) {
     ? Object.fromEntries(Object.entries(FORMS).filter(([id]) => formIds.includes(id)))
     : FORMS;
 
-  const user = await prismaClient.user.findUnique({ where: { id: userId }, include: { unit: true } });
-
   const skippedFormIds = [];
 
   for (const [formId, form] of Object.entries(forms)) {
@@ -38,7 +36,7 @@ export default async function generateForms (data, prismaClient = prisma) {
       continue;
     }
 
-    const pdfBuffer = await form.generatePdf(deflectionData, user);
+    const pdfBuffer = await form.generatePdf(deflectionData);
 
     const filename = form.downloadFilename(deflectionId);
 

--- a/server/lib/forms/849b/generate.js
+++ b/server/lib/forms/849b/generate.js
@@ -22,11 +22,16 @@ export function transformData (deflection) {
       .join(' ');
   }
 
-  const incidentCreator = incident?.createdBy;
-  const officerName = incidentCreator
-    ? `${incidentCreator.firstName} ${incidentCreator.lastName}`
+  // Reporting deputy = the user who performed the release or exit-to-jail,
+  // sourced from the deflection record so the form's attribution is stable
+  // regardless of who later requests the PDF.
+  const reportingDeputy = deflection.releasedBy || deflection.exitedBy;
+  const reportingDeputyName = reportingDeputy
+    ? `${reportingDeputy.firstName} ${reportingDeputy.lastName}`
     : '';
-  const officerBadge = incident?.createdByBadgeNumber || incidentCreator?.badgeNumber || '';
+  const reportingDeputyBadge = reportingDeputy?.badgeNumber || '';
+  const reportingDeputyUnit = reportingDeputy?.unit?.name || '';
+  const prop115Certified = reportingDeputy?.prop115Certified ?? false;
 
   const arrestLocation = [incident?.addressLine1, incident?.city, incident?.state]
     .filter(Boolean)
@@ -42,8 +47,10 @@ export function transformData (deflection) {
     arrestedAt: formatDateTime24(incident?.arrestedAt?.toISOString()),
     arrestLocation,
     locationSentTo: incident?.encounteredVia === 'ON_VIEW' ? 'Same/On View' : 'Other',
-    officerName,
-    officerBadge,
+    reportingDeputyName,
+    reportingDeputyBadge,
+    reportingDeputyUnit,
+    prop115Certified,
     subjectName,
     subjectFullName,
     subjectRace: subject?.race || '',
@@ -65,7 +72,7 @@ export function transformData (deflection) {
   };
 }
 
-export async function generatePdf (deflectionData, user) {
+export async function generatePdf (deflectionData) {
   const templatePath = join(process.cwd(), 'lib/forms/849b/template.pdf');
   const templateBytes = await readFile(templatePath);
   const isDrugTypeAlcohol = deflectionData.subjectDrugType === DrugTypeEnum.ALCOHOL;
@@ -92,13 +99,11 @@ export async function generatePdf (deflectionData, user) {
     prop115Years: '2',
     prop115Pages: '2',
 
-    // Prop 115 certified - from user profile
-    prop115Certified: user?.prop115Certified ?? false,
+    prop115Certified: deflectionData.prop115Certified,
 
-    // Deputy fields - from user profile (not incident creator)
-    reportingDeputy: user ? `${user.firstName} ${user.lastName}` : '',
-    star: user?.badgeNumber || '',
-    divisionUnit: user?.unit?.name || '',
+    reportingDeputy: deflectionData.reportingDeputyName,
+    star: deflectionData.reportingDeputyBadge,
+    divisionUnit: deflectionData.reportingDeputyUnit,
     supervisorApproval: '',
     watch: '',
     assignTo: '',

--- a/server/lib/forms/849b/metadata.js
+++ b/server/lib/forms/849b/metadata.js
@@ -11,16 +11,8 @@ export const metadata = {
 
   deflectionInclude: {
     subject: true,
-    incident: {
-      include: {
-        createdBy: {
-          include: {
-            organization: true,
-            unit: true,
-            title: true,
-          },
-        },
-      },
-    },
+    incident: true,
+    releasedBy: { include: { unit: true } },
+    exitedBy: { include: { unit: true } },
   },
 };

--- a/server/routes/api/forms/index.js
+++ b/server/routes/api/forms/index.js
@@ -1,6 +1,9 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 import { FORMS } from '#lib/forms/index.js';
+import DeflectionDocument from '#models/deflectionDocument.js';
+import s3 from '#lib/s3.js';
+import generateForms from '../../../jobs/generateForms.js';
 
 const RENDER_TIMEOUT_MS = 20_000;
 
@@ -11,73 +14,63 @@ const errorResponses = {
   [StatusCodes.UNPROCESSABLE_ENTITY]: z.object({ error: z.string() }),
 };
 
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-async function fetchDeflection (fastify, deflectionId, deflectionInclude) {
-  const deflection = await fastify.prisma.deflection.findUnique({
-    where: { id: deflectionId },
-    include: deflectionInclude,
-  });
-
-  if (!deflection) return { error: 'not_found' };
-
-  return { deflection };
-}
-
-function sendError (reply, result) {
-  if (result.error === 'not_found') {
-    return reply.code(StatusCodes.NOT_FOUND).send({ error: 'Deflection not found' });
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Route registration
-// ---------------------------------------------------------------------------
-
 export default async function (fastify, _opts) {
   for (const [formId, form] of Object.entries(FORMS)) {
-    // --- PDF generation endpoint ---
     fastify.get(
       `/${formId}/pdf/:deflectionId`,
       {
         onRequest: fastify.requireUser,
         schema: {
-          description: `Generate a ${form.title} PDF for a deflection`,
+          description: `Redirect to a signed URL for the stored ${form.title} PDF for a deflection. Generates and persists the PDF inline if no stored copy exists.`,
           params: paramsSchema,
-          response: {
-            [StatusCodes.OK]: z.any().describe('PDF file'),
-            ...errorResponses,
-          },
+          response: errorResponses,
         },
       },
       async function (request, reply) {
         const { deflectionId } = request.params;
-        const result = await fetchDeflection(fastify, deflectionId, form.deflectionInclude);
 
-        if (result.error) return sendError(reply, result);
+        const deflection = await fastify.prisma.deflection.findUnique({
+          where: { id: deflectionId },
+          include: form.deflectionInclude,
+        });
+        if (!deflection) {
+          return reply.code(StatusCodes.NOT_FOUND).send({ error: 'Deflection not found' });
+        }
 
-        const check = form.canGenerate(result.deflection);
+        const check = form.canGenerate(deflection);
         if (check !== true) {
           return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: check.message });
         }
 
-        // note: on timeout the generatePdf promise (and any Chromium process it
-        // launched) continues running in the background until it resolves or rejects.
-        const pdfBuffer = await Promise.race([
-          form.generatePdf(form.transformData(result.deflection), request.user),
-          new Promise((_resolve, reject) =>
-            setTimeout(() => reject(new Error('PDF generation timed out')), RENDER_TIMEOUT_MS)
-          ),
-        ]);
+        let docRow = await fastify.prisma.deflectionDocument.findUnique({
+          where: { deflectionId_formId: { deflectionId, formId } },
+        });
 
-        const filename = form.downloadFilename(deflectionId);
-        return reply
-          .code(StatusCodes.OK)
-          .header('Content-Type', 'application/pdf')
-          .header('Content-Disposition', `inline; filename=${filename}`)
-          .send(pdfBuffer);
+        if (!docRow?.file) {
+          // Recovery path: no stored doc yet (e.g. lifecycle job hasn't run, or
+          // a prior run was interrupted). Generate and persist inline so the
+          // next request — and this one — hit the canonical asset.
+          // note: on timeout the generation promise continues running in the
+          // background until it resolves or rejects.
+          await Promise.race([
+            generateForms({ deflectionId, userId: request.user.id, formIds: [formId] }, fastify.prisma),
+            new Promise((_resolve, reject) =>
+              setTimeout(() => reject(new Error('PDF generation timed out')), RENDER_TIMEOUT_MS)
+            ),
+          ]);
+          docRow = await fastify.prisma.deflectionDocument.findUnique({
+            where: { deflectionId_formId: { deflectionId, formId } },
+          });
+          if (!docRow?.file) {
+            return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: 'Failed to generate PDF' });
+          }
+        }
+
+        const doc = new DeflectionDocument(docRow);
+        const assetPath = `${doc.getAssetDirPath('file')}/${doc.file}`;
+        const url = await s3.getSignedAssetUrl(assetPath, 900);
+        reply.header('Cache-Control', 'public, max-age=845');
+        return reply.redirect(url);
       }
     );
   }

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -31,4 +31,51 @@ test('849b form generation eligibility', async (t) => {
       message: 'The SFSO 849(b) Report can only be generated after the subject has been released or exited to jail.',
     });
   });
+
+  await t.test('reporting deputy fields source from releasedBy', () => {
+    const releasedBy = {
+      firstName: 'Regular',
+      lastName: 'User',
+      badgeNumber: '12345',
+      prop115Certified: true,
+      unit: { name: 'Unit A' },
+    };
+    const data = form849b.transformData({
+      releasedAt: new Date('2026-04-29T12:34:56.000Z'),
+      exitedAt: null,
+      releasedBy,
+      exitedBy: null,
+      incident: {},
+      subject: null,
+      releaseReason: null,
+    });
+    assert.strictEqual(data.reportingDeputyName, 'Regular User');
+    assert.strictEqual(data.reportingDeputyBadge, '12345');
+    assert.strictEqual(data.reportingDeputyUnit, 'Unit A');
+    assert.strictEqual(data.prop115Certified, true);
+  });
+
+  await t.test('reporting deputy falls back to exitedBy when not released', () => {
+    const exitedBy = {
+      firstName: 'Exit',
+      lastName: 'Officer',
+      badgeNumber: '99',
+      prop115Certified: false,
+      unit: null,
+    };
+    const data = form849b.transformData({
+      releasedAt: null,
+      exitedAt: new Date('2026-04-29T12:34:56.000Z'),
+      exitDestination: 'JAIL',
+      releasedBy: null,
+      exitedBy,
+      incident: {},
+      subject: null,
+      releaseReason: null,
+    });
+    assert.strictEqual(data.reportingDeputyName, 'Exit Officer');
+    assert.strictEqual(data.reportingDeputyBadge, '99');
+    assert.strictEqual(data.reportingDeputyUnit, '');
+    assert.strictEqual(data.prop115Certified, false);
+  });
 });

--- a/server/test/routes/api/forms.test.js
+++ b/server/test/routes/api/forms.test.js
@@ -39,15 +39,14 @@ test('/api/forms', async (t) => {
   await t.test('GET /647f/pdf/:deflectionId', async (t) => {
     // canGenerate() always returns true for 647f — any deflection qualifies.
 
-    await t.test('returns a PDF with correct headers', async () => {
+    await t.test('redirects to a signed URL for the stored asset', async () => {
       const response = await app.inject()
         .get(`/api/forms/647f/pdf/${unreleasedDeflection.id}`)
         .headers(userHeaders);
-      assert.strictEqual(response.statusCode, StatusCodes.OK);
-      assert.strictEqual(response.headers['content-type'], 'application/pdf');
+      assert.strictEqual(response.statusCode, StatusCodes.MOVED_TEMPORARILY);
       assert.match(
-        response.headers['content-disposition'],
-        new RegExp(`647f-report-${unreleasedDeflection.id}\\.pdf`)
+        response.headers.location,
+        new RegExp(`deflection_documents/[a-f0-9-]+/file/647f-report-${unreleasedDeflection.id}\\.pdf`)
       );
     });
 
@@ -68,15 +67,14 @@ test('/api/forms', async (t) => {
   await t.test('GET /cert/pdf/:deflectionId', async (t) => {
     // canGenerate() requires releasedAt to be set.
 
-    await t.test('returns a PDF with correct headers for a released deflection', async () => {
+    await t.test('redirects to a signed URL for a released deflection', async () => {
       const response = await app.inject()
         .get(`/api/forms/cert/pdf/${releasedDeflection.id}`)
         .headers(userHeaders);
-      assert.strictEqual(response.statusCode, StatusCodes.OK);
-      assert.strictEqual(response.headers['content-type'], 'application/pdf');
+      assert.strictEqual(response.statusCode, StatusCodes.MOVED_TEMPORARILY);
       assert.match(
-        response.headers['content-disposition'],
-        new RegExp(`cert-${releasedDeflection.id}\\.pdf`)
+        response.headers.location,
+        new RegExp(`deflection_documents/[a-f0-9-]+/file/cert-${releasedDeflection.id}\\.pdf`)
       );
     });
 
@@ -97,15 +95,14 @@ test('/api/forms', async (t) => {
   await t.test('GET /849b/pdf/:deflectionId', async (t) => {
     // canGenerate() requires releasedAt to be set.
 
-    await t.test('returns a PDF with correct headers for a released deflection', async () => {
+    await t.test('redirects to a signed URL for a released deflection', async () => {
       const response = await app.inject()
         .get(`/api/forms/849b/pdf/${releasedDeflection.id}`)
         .headers(userHeaders);
-      assert.strictEqual(response.statusCode, StatusCodes.OK);
-      assert.strictEqual(response.headers['content-type'], 'application/pdf');
+      assert.strictEqual(response.statusCode, StatusCodes.MOVED_TEMPORARILY);
       assert.match(
-        response.headers['content-disposition'],
-        new RegExp(`849b-report-${releasedDeflection.id}\\.pdf`)
+        response.headers.location,
+        new RegExp(`deflection_documents/[a-f0-9-]+/file/849b-report-${releasedDeflection.id}\\.pdf`)
       );
     });
 
@@ -120,6 +117,31 @@ test('/api/forms', async (t) => {
       const response = await app.inject()
         .get(`/api/forms/849b/pdf/${releasedDeflection.id}`);
       assert.strictEqual(response.statusCode, StatusCodes.UNAUTHORIZED);
+    });
+
+    await t.test('redirects to the same stored asset regardless of requesting user', async () => {
+      // Attribution must come from the deflection record (releasedBy), not
+      // the session user. Verify by hitting the same URL as two different
+      // authenticated users and confirming both redirect to the same
+      // DeflectionDocument asset path.
+      const adminHeaders = await authenticate(app, 'admin.user@test.com', 'test');
+
+      const r1 = await app.inject()
+        .get(`/api/forms/849b/pdf/${releasedDeflection.id}`)
+        .headers(userHeaders);
+      const r2 = await app.inject()
+        .get(`/api/forms/849b/pdf/${releasedDeflection.id}`)
+        .headers(adminHeaders);
+
+      assert.strictEqual(r1.statusCode, StatusCodes.MOVED_TEMPORARILY);
+      assert.strictEqual(r2.statusCode, StatusCodes.MOVED_TEMPORARILY);
+
+      const assetPathRegex = new RegExp(`(deflection_documents/[a-f0-9-]+/file/849b-report-${releasedDeflection.id}\\.pdf)`);
+      const m1 = r1.headers.location.match(assetPathRegex);
+      const m2 = r2.headers.location.match(assetPathRegex);
+      assert.ok(m1, 'first response must include the asset path');
+      assert.ok(m2, 'second response must include the asset path');
+      assert.strictEqual(m1[1], m2[1]);
     });
   });
 });


### PR DESCRIPTION
## Problem

We were surprised when we attempted to retrieve an already generated 849 by visiting the api route with the id and it regenerated the form using the currently logged in user info. The form should not regenerate unless data changes. Other forms like 647 already work this way, no regeneration unless data changes.

## Testing

Before the fix we could go to the pdf route with a hold id when logged in as somebody other than the person who initiated the arrest and it would put your currently logged in account as the officer doing the arrest.

sample url: ```http://localhost:3333/api/forms/849b/pdf/120```

After the fix the pdf is not regenerated by visiting the API route with the hold id so the arresting officer stays static.