### PR TITLE
Fix/898 fixes to 849b fields

### DIFF
--- a/client/src/lesc/components/care/CareExitDetails.jsx
+++ b/client/src/lesc/components/care/CareExitDetails.jsx
@@ -47,7 +47,11 @@ function CareExitDetails () {
   const fromDetail = searchParams.get('from') === 'detail';
   const backTo = getCareExitBackTo({ fromDetail, id });
 
+  // Mirrors CARE_EXIT_DESTINATIONS in server/lib/careExitDestinations.js.
+  // Server rejects JAIL on /exit and /exit-details; this filter keeps the
+  // UI honest so users don't pick a destination that will 400.
   const exitDestinations = Object.entries(t('deflectionExitDestination', { returnObjects: true }))
+    .filter(([id]) => id !== 'JAIL')
     .map(([id, name]) => ({ id, name }));
   const exitHousingStatuses = Object.entries(t('deflectionExitHousingStatus', { returnObjects: true }))
     .map(([id, name]) => ({ id, name }));

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -215,7 +215,6 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
     incidentReady: !deflection?.incidentId || incidentQuery.isFetched,
   });
 
-  const doc849b = deflection?.deflectionDocuments?.find(d => d.formId === '849b');
   const docCert = deflection?.deflectionDocuments?.find(d => d.formId === 'cert');
   const showPostReleaseNarrativeActions = !isCareView && isCustody && isPostRelease;
 
@@ -230,8 +229,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   });
 
   function open849bPdf () {
-    const url = doc849b?.fileUrl || `/api/forms/849b/pdf/${deflection.id}`;
-    window.open(url, '_blank');
+    window.open(`/api/forms/849b/pdf/${deflection.id}`, '_blank');
   }
 
   return (

--- a/e2e/849b-pdf-fields.spec.js
+++ b/e2e/849b-pdf-fields.spec.js
@@ -110,6 +110,11 @@ test.describe('849(b) PDF field verification', () => {
     expect(dropdown.getSelected()).toContain('Same/On View');
   });
 
+  test('disposition code is detained and released', () => {
+    const dropdown = pdfForm.getDropdown('Dropdown4');
+    expect(dropdown.getSelected()).toContain('DET/REL');
+  });
+
   // ── Subject fields ──
 
   test('subject code is D', () => {
@@ -143,6 +148,34 @@ test.describe('849(b) PDF field verification', () => {
     expect(getFieldText('ID NO SOCSECOPLICFBICII')).toBe('D1234567');
   });
 
+  // ── Reporting party fields ──
+
+  test('reporting party code is R1', () => {
+    expect(getFieldText('CODE_2')).toBe('R1');
+  });
+
+  test('reporting party name uses releasing deputy', () => {
+    expect(getFieldText('NAME LAST FIRST MIDDLE_2')).toBe('SFSO, T, #5678');
+  });
+
+  test('reporting party contact phone number', () => {
+    expect(getFieldText('CONTACT PHONE NUMBER_2')).toBe('415-575-6461');
+  });
+
+  test('reporting party business address', () => {
+    expect(
+      getFieldText('BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO_2')
+    ).toBe('70 Oak Grove St');
+  });
+
+  test('reporting party business zipcode', () => {
+    expect(getFieldText('ZIP CODE_4')).toBe('94107');
+  });
+
+  test('citation area does not contain stray text', () => {
+    expect(getFieldText('Text4') || '').toBe('');
+  });
+
   // ── Narrative ──
 
   test('narrative uses release narrative', () => {
@@ -150,11 +183,5 @@ test.describe('849(b) PDF field verification', () => {
     expect(narrative).toContain('Incident number: CS849B');
     expect(narrative).toContain('Cad number: CAD849B');
     expect(narrative).toContain('Subject was brought to RESET');
-  });
-
-  // ── Prop 115 ──
-
-  test('prop 115 pages is 2', () => {
-    expect(getFieldText('Text4')).toBe('2');
   });
 });

--- a/e2e/849b-pdf-fields.spec.js
+++ b/e2e/849b-pdf-fields.spec.js
@@ -184,6 +184,10 @@ test.describe('849(b) PDF field verification', () => {
     expect(getCheckboxChecked('POST TRAINING')).toBe(true);
   });
 
+  test('prop 115 certification follows releasing deputy profile', () => {
+    expect(getCheckboxChecked('BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED')).toBe(false);
+  });
+
   // ── Narrative ──
 
   test('narrative uses release narrative', () => {

--- a/e2e/849b-pdf-fields.spec.js
+++ b/e2e/849b-pdf-fields.spec.js
@@ -169,7 +169,7 @@ test.describe('849(b) PDF field verification', () => {
   test('reporting party business address', () => {
     expect(
       getFieldText('BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO_2')
-    ).toBe('70 Oak Grove St');
+    ).toBe('70 Oak Grove St.');
   });
 
   test('reporting party business zipcode', () => {
@@ -178,6 +178,10 @@ test.describe('849(b) PDF field verification', () => {
 
   test('citation area does not contain stray text', () => {
     expect(getFieldText('Text4') || '').toBe('');
+  });
+
+  test('post training is checked', () => {
+    expect(getCheckboxChecked('POST TRAINING')).toBe(true);
   });
 
   // ── Narrative ──

--- a/server/jobs/formsEmail.js
+++ b/server/jobs/formsEmail.js
@@ -2,6 +2,7 @@ import prisma from '#prisma/client.js';
 import mailer from '#lib/mailer.js';
 import { generateLive849bPdf, storeLive849bPdf } from '#lib/forms/849b/livePdf.js';
 import DeflectionDocument from '#models/deflectionDocument.js';
+import { captureException } from '#lib/posthog.js';
 
 const EMAIL_RECIPIENT = 'careconnect@sfgov.org';
 const INCIDENT_REPORTS_RECIPIENT = 'Sfso-incidentreports@sfgov.org';
@@ -85,12 +86,27 @@ export default async function formsEmail (data, prismaClient = prisma) {
     });
 
     if (live849bAttachment && targetFormIds.includes('849b')) {
+      // Storage of the audit copy must not block delivery: the email has
+      // already gone out. Surface failures via logs + PostHog instead so
+      // missing audit records are noticeable.
       await storeLive849bPdf(prismaClient, {
         deflectionId,
         userId,
         content: live849bAttachment.content,
         filename: live849bAttachment.filename,
-      }).catch(() => {});
+      }).catch((error) => {
+        console.error(JSON.stringify({
+          event: '849b/store-failed',
+          deflectionId,
+          template,
+          error: error.message,
+        }));
+        captureException(error, 'care-connect-worker', {
+          event: '849b/store-failed',
+          deflectionId,
+          template,
+        });
+      });
     }
   }
 

--- a/server/jobs/formsEmail.js
+++ b/server/jobs/formsEmail.js
@@ -30,10 +30,11 @@ export default async function formsEmail (data, prismaClient = prisma) {
   const emailAttachments = [];
   if (formIds.includes('849b')) {
     const live849b = await generateLive849bPdf(prismaClient, deflectionId);
-    if (live849b.status === 'ok') {
-      live849bAttachment = live849b.attachment;
-      emailAttachments.push(live849bAttachment);
+    if (live849b.status !== 'ok') {
+      throw new Error(`Live 849(b) generation failed for deflection ${deflectionId}: ${live849b.status}${live849b.error ? ` (${live849b.error})` : ''}`);
     }
+    live849bAttachment = live849b.attachment;
+    emailAttachments.push(live849bAttachment);
   }
 
   for (const doc of deflection.deflectionDocuments) {

--- a/server/jobs/formsEmail.js
+++ b/server/jobs/formsEmail.js
@@ -1,5 +1,6 @@
 import prisma from '#prisma/client.js';
 import mailer from '#lib/mailer.js';
+import { generateLive849bPdf, storeLive849bPdf } from '#lib/forms/849b/livePdf.js';
 import DeflectionDocument from '#models/deflectionDocument.js';
 
 const EMAIL_RECIPIENT = 'careconnect@sfgov.org';
@@ -12,7 +13,8 @@ const TRANSFER_RECIPIENTS = [
 ];
 
 export default async function formsEmail (data, prismaClient = prisma) {
-  const { deflectionId, formIds, template, recipientEmail, userId } = data;
+  const { deflectionId, formIds, template, recipientEmail, userId, regeneratedFormIds = [] } = data;
+  let live849bAttachment = null;
 
   const deflection = await prismaClient.deflection.findUnique({
     where: { id: deflectionId },
@@ -26,7 +28,16 @@ export default async function formsEmail (data, prismaClient = prisma) {
   if (!deflection) return;
 
   const emailAttachments = [];
+  if (formIds.includes('849b')) {
+    const live849b = await generateLive849bPdf(prismaClient, deflectionId);
+    if (live849b.status === 'ok') {
+      live849bAttachment = live849b.attachment;
+      emailAttachments.push(live849bAttachment);
+    }
+  }
+
   for (const doc of deflection.deflectionDocuments) {
+    if (doc.formId === '849b') continue;
     const document = new DeflectionDocument(doc);
     const filePath = await document.getAsset('file');
     emailAttachments.push({
@@ -51,7 +62,10 @@ export default async function formsEmail (data, prismaClient = prisma) {
   async function sendFormsMessage ({ targetFormIds, to, cc = [] }) {
     const attachments = emailAttachments
       .filter((attachment) => targetFormIds.includes(attachment.formId))
-      .map(({ filename, path }) => ({ filename, path }));
+      .map(({ filename, path, content }) => ({
+        filename,
+        ...(path ? { path } : { content }),
+      }));
 
     if (attachments.length === 0) return;
 
@@ -68,18 +82,15 @@ export default async function formsEmail (data, prismaClient = prisma) {
         facilityName: deflection.facility.name,
       },
     });
-  }
 
-  function was647fRegeneratedSinceTransfer () {
-    const doc647f = deflection.deflectionDocuments.find((doc) => doc.formId === '647f');
-    if (!doc647f || !deflection.transferredAt) return false;
-
-    const baseline = Math.max(
-      new Date(deflection.transferredAt).getTime(),
-      new Date(doc647f.createdAt).getTime()
-    );
-
-    return new Date(doc647f.updatedAt).getTime() > baseline;
+    if (live849bAttachment && targetFormIds.includes('849b')) {
+      await storeLive849bPdf(prismaClient, {
+        deflectionId,
+        userId,
+        content: live849bAttachment.content,
+        filename: live849bAttachment.filename,
+      }).catch(() => {});
+    }
   }
 
   if (template === 'release-forms') {
@@ -91,7 +102,7 @@ export default async function formsEmail (data, prismaClient = prisma) {
       ].filter(Boolean),
     });
 
-    if (formIds.includes('647f') && was647fRegeneratedSinceTransfer()) {
+    if (formIds.includes('647f') && regeneratedFormIds.includes('647f')) {
       await mailer.send({
         template: 'transfer-form',
         message: {

--- a/server/jobs/generateForms.js
+++ b/server/jobs/generateForms.js
@@ -2,18 +2,25 @@ import { createHash } from 'node:crypto';
 
 import prisma from '#prisma/client.js';
 import { FORMS } from '#lib/forms/index.js';
-import DeflectionDocument from '#models/deflectionDocument.js';
+import { LIVE_EMAIL_FORM_IDS } from '#lib/forms/liveEmailForms.js';
+import { storeFormPdf } from '#lib/forms/storeFormPdf.js';
 
 export default async function generateForms (data, prismaClient = prisma) {
-  const { deflectionId, userId, formIds } = data;
+  const { deflectionId, userId, formIds, emailTemplate } = data;
 
   const forms = formIds
-    ? Object.fromEntries(Object.entries(FORMS).filter(([id]) => formIds.includes(id)))
+    ? Object.fromEntries(Object.entries(FORMS).filter(([id]) =>
+      formIds.includes(id) && !(emailTemplate && LIVE_EMAIL_FORM_IDS.has(id))
+    ))
     : FORMS;
 
   const user = await prismaClient.user.findUnique({ where: { id: userId }, include: { unit: true } });
 
-  const skippedFormIds = [];
+  const result = {
+    skippedFormIds: [],
+    generatedFormIds: [],
+    updatedSinceTransferFormIds: [],
+  };
 
   for (const [formId, form] of Object.entries(forms)) {
     const deflection = await prismaClient.deflection.findUnique({
@@ -24,7 +31,7 @@ export default async function generateForms (data, prismaClient = prisma) {
 
     const check = form.canGenerate(deflection);
     if (check !== true) {
-      skippedFormIds.push(formId);
+      result.skippedFormIds.push(formId);
       continue;
     }
 
@@ -33,39 +40,36 @@ export default async function generateForms (data, prismaClient = prisma) {
     const existing = await prismaClient.deflectionDocument.findUnique({
       where: { deflectionId_formId: { deflectionId, formId } },
     });
+    if (
+      formId === '647f' &&
+      existing?.createdAt &&
+      existing?.updatedAt &&
+      deflection.transferredAt &&
+      new Date(existing.updatedAt).getTime() > Math.max(
+        new Date(deflection.transferredAt).getTime(),
+        new Date(existing.createdAt).getTime()
+      )
+    ) {
+      result.updatedSinceTransferFormIds.push(formId);
+    }
     if (dataHash && existing?.sourceDataHash === dataHash) {
-      skippedFormIds.push(formId);
+      result.skippedFormIds.push(formId);
       continue;
     }
 
     const pdfBuffer = await form.generatePdf(deflectionData, user);
 
     const filename = form.downloadFilename(deflectionId);
-
-    if (existing) {
-      const doc = new DeflectionDocument(existing);
-      const assetHandler = doc.setAsset('file', filename, { buffer: pdfBuffer });
-      await prismaClient.deflectionDocument.update({
-        where: { id: existing.id },
-        data: { file: filename, updatedById: userId, ...(dataHash && { sourceDataHash: dataHash }) },
-      });
-      await assetHandler();
-    } else {
-      const doc = new DeflectionDocument({ formId, deflectionId });
-      const assetHandler = doc.setAsset('file', filename, { buffer: pdfBuffer });
-      const record = await prismaClient.deflectionDocument.create({
-        data: {
-          deflectionId,
-          formId,
-          file: filename,
-          createdById: userId,
-          updatedById: userId,
-          ...(dataHash && { sourceDataHash: dataHash }),
-        },
-      });
-      await assetHandler({ id: record.id });
-    }
+    await storeFormPdf(prismaClient, {
+      deflectionId,
+      formId,
+      filename,
+      content: pdfBuffer,
+      userId,
+      sourceDataHash: dataHash,
+    });
+    result.generatedFormIds.push(formId);
   }
 
-  return skippedFormIds;
+  return result;
 }

--- a/server/lib/careExitDestinations.js
+++ b/server/lib/careExitDestinations.js
@@ -1,0 +1,10 @@
+import prismaPkg from '@prisma/client';
+
+const { DeflectionExitDestinationEnum } = prismaPkg;
+
+// Care users record exits to non-jail destinations only. Jail outcomes are
+// recorded by custody via /exit-to-jail, which sets exitDestination: 'JAIL'
+// directly and generates the 849(b). Keep this list aligned with the chip
+// filter in client/src/lesc/components/care/CareExitDetails.jsx.
+export const CARE_EXIT_DESTINATIONS = Object.values(DeflectionExitDestinationEnum)
+  .filter((destination) => destination !== 'JAIL');

--- a/server/lib/forms/849b/fill849b.js
+++ b/server/lib/forms/849b/fill849b.js
@@ -222,7 +222,7 @@ function applyDobAge (form, pdfField, data, prefix) {
   if (dob && age) value = `${dob} / ${age}`;
   else value = dob || age;
 
-  form.getTextField(pdfField).setText(String(value));
+  setTextField(form, pdfField, value);
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -238,6 +238,13 @@ function get (obj, path) {
     cur = cur[p];
   }
   return cur;
+}
+
+function setTextField (form, pdfField, value) {
+  const field = form.getTextField(pdfField);
+  const text = String(value);
+  const maxLength = field.getMaxLength();
+  field.setText(maxLength == null ? text : text.slice(0, maxLength));
 }
 
 // ═══════════════════════════════════════════════════════════════════
@@ -259,15 +266,15 @@ export async function fill849b (pdfBytes, data) {
   for (const [key, pdfField] of Object.entries(TEXT)) {
     const val = get(data, key);
     if (val != null && val !== '') {
-      form.getTextField(pdfField).setText(String(val));
+      setTextField(form, pdfField, val);
     }
   }
 
   // ── Page numbers (always 1 and 2) and totalPages default ──
-  form.getTextField('Text1').setText('1');
-  form.getTextField('Text1_2').setText('2');
+  setTextField(form, 'Text1', '1');
+  setTextField(form, 'Text1_2', '2');
   if (get(data, 'totalPages') == null) {
-    form.getTextField('Text2').setText('2');
+    setTextField(form, 'Text2', '2');
   }
 
   // ── Checkboxes ──
@@ -318,7 +325,7 @@ export async function fill849b (pdfBytes, data) {
     for (let i = 0; i < pdfFields.length; i++) {
       const val = arr[i];
       if (val != null && val !== '') {
-        form.getTextField(pdfFields[i]).setText(String(val));
+        setTextField(form, pdfFields[i], val);
       }
     }
   }

--- a/server/lib/forms/849b/fill849b.js
+++ b/server/lib/forms/849b/fill849b.js
@@ -45,7 +45,6 @@ const TEXT = {
   assignTo:                'ASSIGN TO',
   assignedBy:              'ASSIGNED BY INITALSSTAR',
   copiesTo:                'COPIES TO DDL UNITSGENCIES',
-  prop115Pages:            'Text4',
 
   // Subject
   'subject.code':             'CODE',

--- a/server/lib/forms/849b/generate.js
+++ b/server/lib/forms/849b/generate.js
@@ -116,6 +116,7 @@ export async function generatePdf (deflectionData) {
     // performed the release or jail exit. If that persisted user is missing,
     // leave these fields blank/unchecked instead of using the current user.
     prop115Certified: reportingDeputy?.prop115Certified ?? false,
+    postTraining: true,
 
     // Deputy fields - from persisted reporting deputy (not incident creator or current user)
     reportingDeputy: firstInitialLastName(reportingDeputy),
@@ -163,7 +164,7 @@ export async function generatePdf (deflectionData) {
       code: 'R1',
       name: deflectionData.releasingDeputyReportingPartyName,
       contactPhone: '415-575-6461',
-      businessAddress: '70 Oak Grove St',
+      businessAddress: '70 Oak Grove St.',
       businessZip: '94107',
     },
 

--- a/server/lib/forms/849b/generate.js
+++ b/server/lib/forms/849b/generate.js
@@ -7,6 +7,23 @@ import { build849bReleaseNarrative } from './releaseNarrative.js';
 import i18n from '#lib/i18n.js';
 const { DrugTypeEnum } = prismaPkg;
 
+function formatDeputyNameForReportingParty (deputy) {
+  if (!deputy) return '';
+
+  const firstInitial = deputy.firstName?.trim()?.charAt(0)?.toUpperCase();
+  const lastName = deputy.lastName?.trim();
+  const star = deputy.badgeNumber?.trim();
+
+  const nameParts = [];
+  if (lastName) nameParts.push(lastName);
+  if (firstInitial) nameParts.push(firstInitial);
+  if (star) nameParts.push(`#${star}`);
+
+  if (nameParts.length > 0) return nameParts.join(', ');
+
+  return [deputy.firstName, deputy.lastName].filter(Boolean).join(' ');
+}
+
 export function transformData (deflection) {
   const incident = deflection.incident;
   const subject = deflection.subject;
@@ -35,6 +52,7 @@ export function transformData (deflection) {
   const subjectAddress = [subject?.addressLine1, subject?.city, subject?.state]
     .filter(Boolean)
     .join(', ');
+  const releasingDeputy = deflection.releasedBy || deflection.exitedBy || null;
 
   return {
     cadNumber: incident?.cadNumber || '',
@@ -60,6 +78,8 @@ export function transformData (deflection) {
     transferredAt: deflection.transferredAt?.toISOString() || null,
     releasedAt: (deflection.releasedAt || deflection.exitedAt).toISOString(),
     releaseReason: deflection.releaseReason ? i18n.t(`deflectionReleaseReason.${deflection.releaseReason}`) : '',
+    releasingDeputyReportingPartyName: formatDeputyNameForReportingParty(releasingDeputy),
+    releasingDeputyProp115Certified: releasingDeputy?.prop115Certified ?? false,
     behavior: deflection.behavior || null,
     releaseNarrative: deflection.releaseNarrative || null,
   };
@@ -86,14 +106,14 @@ export async function generatePdf (deflectionData, user) {
     location: deflectionData.arrestLocation,
     premiseType: '',
     locationSentTo: deflectionData.locationSentTo,
+    dispositionCode: 'DET/REL',
     reportedTo: '', // TBC
 
     // Page info
     prop115Years: '2',
-    prop115Pages: '2',
 
-    // Prop 115 certified - from user profile
-    prop115Certified: user?.prop115Certified ?? false,
+    // Prop 115 certified - from the original releasing deputy profile
+    prop115Certified: deflectionData.releasingDeputyProp115Certified,
 
     // Deputy fields - from user profile (not incident creator)
     reportingDeputy: user ? `${user.firstName} ${user.lastName}` : '',
@@ -136,6 +156,14 @@ export async function generatePdf (deflectionData, user) {
     incidentCodes: isDrugTypeAlcohol
       ? ['19090', '64085']
       : ['19095', '64085'],
+
+    reportingParty: {
+      code: 'R1',
+      name: deflectionData.releasingDeputyReportingPartyName,
+      contactPhone: '415-575-6461',
+      businessAddress: '70 Oak Grove St',
+      businessZip: '94107',
+    },
 
     narrative: deflectionData.releaseNarrative || build849bReleaseNarrative({
       caseNumber: deflectionData.caseNumber,

--- a/server/lib/forms/849b/generate.js
+++ b/server/lib/forms/849b/generate.js
@@ -116,7 +116,7 @@ export async function generatePdf (deflectionData) {
     // performed the release or jail exit. If that persisted user is missing,
     // leave these fields blank/unchecked instead of using the current user.
     prop115Certified: reportingDeputy?.prop115Certified ?? false,
-    postTraining: true,
+    postTraining: !(reportingDeputy?.prop115Certified ?? false),
 
     // Deputy fields - from persisted reporting deputy (not incident creator or current user)
     reportingDeputy: firstInitialLastName(reportingDeputy),

--- a/server/lib/forms/849b/livePdf.js
+++ b/server/lib/forms/849b/livePdf.js
@@ -1,0 +1,43 @@
+import { FORMS } from '#lib/forms/index.js';
+import { storeFormPdf } from '#lib/forms/storeFormPdf.js';
+
+export async function generateLive849bPdf (prismaClient, deflectionId) {
+  const form = FORMS['849b'];
+  const deflection = await prismaClient.deflection.findUnique({
+    where: { id: deflectionId },
+    include: {
+      ...form.deflectionInclude,
+      facility: true,
+    },
+  });
+
+  if (!deflection) {
+    return { status: 'not_found' };
+  }
+
+  const check = form.canGenerate(deflection);
+  if (check !== true) {
+    return { status: 'unprocessable', error: check.message, deflection };
+  }
+
+  const content = await form.generatePdf(form.transformData(deflection));
+  return {
+    status: 'ok',
+    deflection,
+    attachment: {
+      formId: '849b',
+      filename: form.downloadFilename(deflectionId),
+      content,
+    },
+  };
+}
+
+export async function storeLive849bPdf (prismaClient, { deflectionId, userId, content, filename }) {
+  await storeFormPdf(prismaClient, {
+    deflectionId,
+    formId: '849b',
+    filename,
+    content,
+    userId,
+  });
+}

--- a/server/lib/forms/849b/livePdf.js
+++ b/server/lib/forms/849b/livePdf.js
@@ -1,7 +1,7 @@
 import { FORMS } from '#lib/forms/index.js';
 import { storeFormPdf } from '#lib/forms/storeFormPdf.js';
 
-export async function generateLive849bPdf (prismaClient, deflectionId) {
+export async function validateLive849bPdf (prismaClient, deflectionId) {
   const form = FORMS['849b'];
   const deflection = await prismaClient.deflection.findUnique({
     where: { id: deflectionId },
@@ -20,10 +20,18 @@ export async function generateLive849bPdf (prismaClient, deflectionId) {
     return { status: 'unprocessable', error: check.message, deflection };
   }
 
-  const content = await form.generatePdf(form.transformData(deflection));
+  return { status: 'ok', deflection };
+}
+
+export async function generateLive849bPdf (prismaClient, deflectionId) {
+  const validation = await validateLive849bPdf(prismaClient, deflectionId);
+  if (validation.status !== 'ok') return validation;
+
+  const form = FORMS['849b'];
+  const content = await form.generatePdf(form.transformData(validation.deflection));
   return {
     status: 'ok',
-    deflection,
+    deflection: validation.deflection,
     attachment: {
       formId: '849b',
       filename: form.downloadFilename(deflectionId),

--- a/server/lib/forms/849b/metadata.js
+++ b/server/lib/forms/849b/metadata.js
@@ -11,8 +11,6 @@ export const metadata = {
 
   deflectionInclude: {
     subject: true,
-    releasedBy: true,
-    exitedBy: true,
     incident: {
       include: {
         createdBy: {

--- a/server/lib/forms/849b/metadata.js
+++ b/server/lib/forms/849b/metadata.js
@@ -11,6 +11,8 @@ export const metadata = {
 
   deflectionInclude: {
     subject: true,
+    releasedBy: true,
+    exitedBy: true,
     incident: {
       include: {
         createdBy: {

--- a/server/lib/forms/formEmailJobs.js
+++ b/server/lib/forms/formEmailJobs.js
@@ -1,0 +1,20 @@
+import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
+
+export async function queueReleaseFormsEmail (fastify, { deflectionId, userId }) {
+  await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
+    deflectionId,
+    userId,
+    formIds: ['647f', '849b', 'cert'],
+    emailTemplate: 'release-forms',
+  });
+}
+
+export async function queue849bIncidentEmail (fastify, { deflectionId, userId, recipientEmail }) {
+  await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
+    deflectionId,
+    userId,
+    formIds: ['849b'],
+    emailTemplate: 'incident-forms',
+    recipientEmail,
+  });
+}

--- a/server/lib/forms/liveEmailForms.js
+++ b/server/lib/forms/liveEmailForms.js
@@ -1,0 +1,1 @@
+export const LIVE_EMAIL_FORM_IDS = new Set(['849b']);

--- a/server/lib/forms/storeFormPdf.js
+++ b/server/lib/forms/storeFormPdf.js
@@ -1,0 +1,45 @@
+import DeflectionDocument from '#models/deflectionDocument.js';
+
+export async function storeFormPdf (prismaClient, {
+  deflectionId,
+  formId,
+  filename,
+  content,
+  userId,
+  sourceDataHash,
+}) {
+  if (!prismaClient.deflectionDocument || !userId) return;
+
+  const existing = await prismaClient.deflectionDocument.findUnique({
+    where: { deflectionId_formId: { deflectionId, formId } },
+  });
+
+  if (existing) {
+    const doc = new DeflectionDocument(existing);
+    const assetHandler = doc.setAsset('file', filename, { buffer: content });
+    await prismaClient.deflectionDocument.update({
+      where: { id: existing.id },
+      data: {
+        file: filename,
+        updatedById: userId,
+        ...(sourceDataHash && { sourceDataHash }),
+      },
+    });
+    await assetHandler();
+    return;
+  }
+
+  const doc = new DeflectionDocument({ formId, deflectionId });
+  const assetHandler = doc.setAsset('file', filename, { buffer: content });
+  const record = await prismaClient.deflectionDocument.create({
+    data: {
+      deflectionId,
+      formId,
+      file: filename,
+      createdById: userId,
+      updatedById: userId,
+      ...(sourceDataHash && { sourceDataHash }),
+    },
+  });
+  await assetHandler({ id: record.id });
+}

--- a/server/lib/jobQueue/queueConfig.js
+++ b/server/lib/jobQueue/queueConfig.js
@@ -5,6 +5,7 @@ import formsEmail from '../../jobs/formsEmail.js';
 import anonymizeSubjects from '../../jobs/anonymizeSubjects.js';
 import canary from '../../jobs/canary.js';
 import { LIVE_EMAIL_FORM_IDS } from '#lib/forms/liveEmailForms.js';
+import { captureException } from '#lib/posthog.js';
 import { QUEUE_INVITE_EMAIL, QUEUE_EXPIRE_HOLDS, QUEUE_GENERATE_FORMS, QUEUE_FORMS_EMAIL, QUEUE_ANONYMIZE_SUBJECTS, QUEUE_CANARY } from './queueNames.js';
 
 function normalizeGenerateFormsResult (result) {
@@ -54,6 +55,16 @@ const queues = [
           : normalizeGenerateFormsResult();
       } catch (error) {
         if (!job.data.emailTemplate) throw error;
+        // If there's a form generation error, don't block the whole email,
+        // but do log the issue to make it visible.
+        const context = {
+          event: 'generate-forms/failed',
+          deflectionId: job.data.deflectionId,
+          formIds: job.data.formIds,
+          emailTemplate: job.data.emailTemplate,
+        };
+        console.error(JSON.stringify({ ...context, error: error.message }));
+        captureException(error, 'care-connect-worker', context);
         generationFailed = true;
       }
       if (job.data.emailTemplate) {

--- a/server/lib/jobQueue/queueConfig.js
+++ b/server/lib/jobQueue/queueConfig.js
@@ -4,7 +4,23 @@ import generateForms from '../../jobs/generateForms.js';
 import formsEmail from '../../jobs/formsEmail.js';
 import anonymizeSubjects from '../../jobs/anonymizeSubjects.js';
 import canary from '../../jobs/canary.js';
+import { LIVE_EMAIL_FORM_IDS } from '#lib/forms/liveEmailForms.js';
 import { QUEUE_INVITE_EMAIL, QUEUE_EXPIRE_HOLDS, QUEUE_GENERATE_FORMS, QUEUE_FORMS_EMAIL, QUEUE_ANONYMIZE_SUBJECTS, QUEUE_CANARY } from './queueNames.js';
+
+function normalizeGenerateFormsResult (result) {
+  if (Array.isArray(result)) {
+    return {
+      skippedFormIds: result,
+      generatedFormIds: [],
+      updatedSinceTransferFormIds: [],
+    };
+  }
+  return {
+    skippedFormIds: result?.skippedFormIds || [],
+    generatedFormIds: result?.generatedFormIds || [],
+    updatedSinceTransferFormIds: result?.updatedSinceTransferFormIds || [],
+  };
+}
 
 const queues = [
   {
@@ -23,11 +39,35 @@ const queues = [
     name: QUEUE_GENERATE_FORMS,
     options: { retryLimit: 3, retryBackoff: true },
     handler: async ([job], { send }) => {
-      const skippedFormIds = await generateForms(job.data) || [];
+      const formIds = job.data.formIds || [];
+      // Some email attachments, currently 849(b), must be generated at send
+      // time so automatic emails cannot pick up stale DeflectionDocument assets.
+      const shouldUseLiveEmailForms = Boolean(job.data.emailTemplate);
+      const storedFormIds = shouldUseLiveEmailForms
+        ? formIds.filter((id) => !LIVE_EMAIL_FORM_IDS.has(id))
+        : formIds;
+      let generationResult = normalizeGenerateFormsResult();
+      let generationFailed = false;
+      try {
+        generationResult = storedFormIds.length > 0 || !job.data.formIds
+          ? normalizeGenerateFormsResult(await generateForms({ ...job.data, formIds: storedFormIds.length > 0 ? storedFormIds : job.data.formIds }))
+          : normalizeGenerateFormsResult();
+      } catch (error) {
+        if (!job.data.emailTemplate) throw error;
+        generationFailed = true;
+      }
       if (job.data.emailTemplate) {
+        const regeneratedFormIds = generationFailed
+          ? []
+          : [...new Set([
+              ...generationResult.generatedFormIds,
+              ...generationResult.updatedSinceTransferFormIds,
+            ])];
         const emailFormIds = job.data.emailTemplate === 'release-forms'
-          ? job.data.formIds
-          : job.data.formIds.filter((id) => !skippedFormIds.includes(id));
+          ? formIds
+          : formIds.filter((id) =>
+            LIVE_EMAIL_FORM_IDS.has(id) || (!generationFailed && !generationResult.skippedFormIds.includes(id))
+          );
         if (emailFormIds.length > 0) {
           await send(QUEUE_FORMS_EMAIL, {
             deflectionId: job.data.deflectionId,
@@ -35,6 +75,7 @@ const queues = [
             template: job.data.emailTemplate,
             recipientEmail: job.data.recipientEmail,
             userId: job.data.userId,
+            regeneratedFormIds,
           });
         }
       }

--- a/server/routes/api/deflections/849b-email.js
+++ b/server/routes/api/deflections/849b-email.js
@@ -1,8 +1,8 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
-import { FORMS } from '#lib/forms/index.js';
-import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
+import { generateLive849bPdf, storeLive849bPdf } from '#lib/forms/849b/livePdf.js';
+import mailer from '#lib/mailer.js';
 
 export default async function (fastify) {
   fastify.post('/:id/849b-email',
@@ -25,29 +25,43 @@ export default async function (fastify) {
     },
     async function (request, reply) {
       const { id } = request.params;
-      const form = FORMS['849b'];
-      const deflection = await fastify.prisma.deflection.findUnique({
-        where: { id },
-        include: form.deflectionInclude,
-      });
+      const live849b = await generateLive849bPdf(fastify.prisma, id);
 
-      if (!deflection) {
+      if (live849b.status === 'not_found') {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      const check = form.canGenerate(deflection);
-      if (check !== true) {
-        return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: check.message });
+      if (live849b.status !== 'ok') {
+        return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: live849b.error });
       }
 
-      await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
-        deflectionId: id,
-        userId: request.user.id,
-        formIds: ['849b'],
-        emailTemplate: 'self-849b',
-        recipientEmail: request.user.email,
+      const { deflection, attachment } = live849b;
+      const subjectName = deflection.subject
+        ? [deflection.subject.firstName, deflection.subject.lastName].filter(Boolean).join(' ')
+        : 'Person X';
+
+      await mailer.send({
+        template: 'self-849b',
+        message: {
+          to: request.user.email,
+          attachments: [{
+            filename: attachment.filename,
+            content: attachment.content,
+          }],
+        },
+        locals: {
+          subjectName,
+          facilityName: deflection.facility.name,
+        },
       });
 
-      return reply.send({ queued: true, email: request.user.email });
+      await storeLive849bPdf(fastify.prisma, {
+        deflectionId: id,
+        userId: request.user.id,
+        content: attachment.content,
+        filename: attachment.filename,
+      }).catch(() => {});
+
+      return reply.send({ queued: false, email: request.user.email });
     });
 }

--- a/server/routes/api/deflections/849b-email.js
+++ b/server/routes/api/deflections/849b-email.js
@@ -1,8 +1,8 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
-import { generateLive849bPdf, storeLive849bPdf } from '#lib/forms/849b/livePdf.js';
-import mailer from '#lib/mailer.js';
+import { validateLive849bPdf } from '#lib/forms/849b/livePdf.js';
+import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
 
 export default async function (fastify) {
   fastify.post('/:id/849b-email',
@@ -25,43 +25,24 @@ export default async function (fastify) {
     },
     async function (request, reply) {
       const { id } = request.params;
-      const live849b = await generateLive849bPdf(fastify.prisma, id);
+      const validation = await validateLive849bPdf(fastify.prisma, id);
 
-      if (live849b.status === 'not_found') {
+      if (validation.status === 'not_found') {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      if (live849b.status !== 'ok') {
-        return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: live849b.error });
+      if (validation.status !== 'ok') {
+        return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: validation.error });
       }
 
-      const { deflection, attachment } = live849b;
-      const subjectName = deflection.subject
-        ? [deflection.subject.firstName, deflection.subject.lastName].filter(Boolean).join(' ')
-        : 'Person X';
-
-      await mailer.send({
-        template: 'self-849b',
-        message: {
-          to: request.user.email,
-          attachments: [{
-            filename: attachment.filename,
-            content: attachment.content,
-          }],
-        },
-        locals: {
-          subjectName,
-          facilityName: deflection.facility.name,
-        },
-      });
-
-      await storeLive849bPdf(fastify.prisma, {
+      await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
         deflectionId: id,
         userId: request.user.id,
-        content: attachment.content,
-        filename: attachment.filename,
-      }).catch(() => {});
+        formIds: ['849b'],
+        emailTemplate: 'self-849b',
+        recipientEmail: request.user.email,
+      });
 
-      return reply.send({ queued: false, email: request.user.email });
+      return reply.send({ queued: true, email: request.user.email });
     });
 }

--- a/server/routes/api/deflections/exit-details.js
+++ b/server/routes/api/deflections/exit-details.js
@@ -5,11 +5,14 @@ import { z } from 'zod';
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
+import { CARE_EXIT_DESTINATIONS } from '#lib/careExitDestinations.js';
 const { SFResidentEnum, TernaryEnum } = prismaPkg;
 
 const ResidencyEnum = z.enum(Object.values(SFResidentEnum));
 
 const ConnectionToCareEnum = z.enum(Object.values(TernaryEnum));
+
+const CareExitDestinationEnum = z.enum(CARE_EXIT_DESTINATIONS);
 
 const EXIT_DETAIL_EDITABLE_STATUSES = [
   Deflection.SubjectStatus.IN_CHAIR,
@@ -26,7 +29,7 @@ export default async function (fastify, opts) {
           id: z.coerce.number(),
         }),
         body: z.object({
-          exitDestination: z.string(),
+          exitDestination: CareExitDestinationEnum,
           exitHousingStatus: z.string(),
           exitSFResident: ResidencyEnum,
           exitConnectedToCare: ConnectionToCareEnum,

--- a/server/routes/api/deflections/exit-to-jail.js
+++ b/server/routes/api/deflections/exit-to-jail.js
@@ -6,7 +6,7 @@ import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { refusalReasonFromExitDestination } from '#lib/refusalReasonFromExitDestination.js';
 import { conflictError } from '#lib/httpErrors.js';
-import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
+import { queue849bIncidentEmail } from '#lib/forms/formEmailJobs.js';
 
 const EXIT_TO_JAIL_ELIGIBLE_STATUSES = new Set([
   Deflection.SubjectStatus.AWAITING_INTAKE,
@@ -172,11 +172,9 @@ export default async function (fastify, opts) {
 
       deflection.propertyPhotos = deflection.propertyPhotos.map(photo => new PropertyPhoto(photo));
 
-      await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
+      await queue849bIncidentEmail(fastify, {
         deflectionId: deflection.id,
         userId: request.user.id,
-        formIds: ['849b'],
-        emailTemplate: 'incident-forms',
         recipientEmail: request.user.email,
       });
 

--- a/server/routes/api/deflections/exit.js
+++ b/server/routes/api/deflections/exit.js
@@ -6,12 +6,14 @@ import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { conflictError } from '#lib/httpErrors.js';
-import { queue849bIncidentEmail } from '#lib/forms/formEmailJobs.js';
+import { CARE_EXIT_DESTINATIONS } from '#lib/careExitDestinations.js';
 const { SFResidentEnum, TernaryEnum } = prismaPkg;
 
 const ResidencyEnum = z.enum(Object.values(SFResidentEnum));
 
 const ConnectionToCareEnum = z.enum(Object.values(TernaryEnum));
+
+const CareExitDestinationEnum = z.enum(CARE_EXIT_DESTINATIONS);
 
 const EXITABLE_STATUSES = [
   Deflection.SubjectStatus.IN_CHAIR,
@@ -28,7 +30,7 @@ export default async function (fastify, opts) {
           id: z.coerce.number(),
         }),
         body: z.object({
-          exitDestination: z.string(),
+          exitDestination: CareExitDestinationEnum,
           exitHousingStatus: z.string(),
           exitSFResident: ResidencyEnum,
           exitConnectedToCare: ConnectionToCareEnum,
@@ -137,14 +139,6 @@ export default async function (fastify, opts) {
       }
 
       deflection.propertyPhotos = deflection.propertyPhotos.map(photo => new PropertyPhoto(photo));
-
-      if (exitDestination === 'JAIL') {
-        await queue849bIncidentEmail(fastify, {
-          deflectionId: deflection.id,
-          userId: request.user.id,
-          recipientEmail: request.user.email,
-        });
-      }
 
       return reply.send(redactDeflectionForUser(deflection, request.user));
     }

--- a/server/routes/api/deflections/exit.js
+++ b/server/routes/api/deflections/exit.js
@@ -6,6 +6,7 @@ import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { conflictError } from '#lib/httpErrors.js';
+import { queue849bIncidentEmail } from '#lib/forms/formEmailJobs.js';
 const { SFResidentEnum, TernaryEnum } = prismaPkg;
 
 const ResidencyEnum = z.enum(Object.values(SFResidentEnum));
@@ -136,6 +137,14 @@ export default async function (fastify, opts) {
       }
 
       deflection.propertyPhotos = deflection.propertyPhotos.map(photo => new PropertyPhoto(photo));
+
+      if (exitDestination === 'JAIL') {
+        await queue849bIncidentEmail(fastify, {
+          deflectionId: deflection.id,
+          userId: request.user.id,
+          recipientEmail: request.user.email,
+        });
+      }
 
       return reply.send(redactDeflectionForUser(deflection, request.user));
     }

--- a/server/routes/api/deflections/release.js
+++ b/server/routes/api/deflections/release.js
@@ -4,8 +4,8 @@ import { z } from 'zod';
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
-import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
 import { conflictError } from '#lib/httpErrors.js';
+import { queueReleaseFormsEmail } from '#lib/forms/formEmailJobs.js';
 
 const RELEASABLE_STATUSES = [
   Deflection.SubjectStatus.AWAITING_INTAKE,
@@ -229,11 +229,9 @@ export default async function (fastify, opts) {
 
       deflection.propertyPhotos = deflection.propertyPhotos.map(photo => new PropertyPhoto(photo));
 
-      await fastify.backgroundJobs.send(QUEUE_GENERATE_FORMS, {
+      await queueReleaseFormsEmail(fastify, {
         deflectionId: deflection.id,
         userId: request.user.id,
-        formIds: ['647f', '849b', 'cert'],
-        emailTemplate: 'release-forms',
       });
 
       return reply.send(redactDeflectionForUser(deflection, request.user));

--- a/server/test/jobs/formsEmail.test.js
+++ b/server/test/jobs/formsEmail.test.js
@@ -1,6 +1,7 @@
 import { test } from 'node:test';
 import * as assert from 'node:assert';
 import * as nodemailerMock from 'nodemailer-mock';
+import { PDFDocument } from 'pdf-lib';
 import { configureMailer } from '#lib/mailer.js';
 import DeflectionDocument from '#models/deflectionDocument.js';
 
@@ -25,45 +26,65 @@ test('formsEmail job handler', async (t) => {
     nodemailerMock.mock.reset();
   });
 
+  const mockDeflection = {
+    id: 4,
+    transferredAt: new Date('2026-05-01T12:00:00.000Z'),
+    releasedAt: new Date('2026-05-02T08:00:00.000Z'),
+    exitedAt: null,
+    exitDestination: null,
+    releaseReason: 'SOBERED',
+    subject: {
+      firstName: 'Jane',
+      lastName: 'Doe',
+    },
+    facility: {
+      name: 'RESET',
+    },
+    incident: {
+      createdBy: {
+        firstName: 'Regular',
+        lastName: 'User',
+        email: 'regular.user@test.com',
+      },
+      cadNumber: 'CADEMAIL',
+      caseNumber: 'CASEMAIL',
+    },
+    releasedBy: {
+      firstName: 'Release',
+      lastName: 'Deputy',
+      badgeNumber: 'R123',
+      prop115Certified: false,
+      unit: { name: 'Release Unit' },
+    },
+    exitedBy: null,
+    drugType: 'FENTANYL',
+    behavior: null,
+    releaseNarrative: 'Release narrative.',
+    deflectionDocuments: [
+      {
+        formId: '647f',
+        file: '647f.pdf',
+        createdAt: new Date('2026-05-01T12:05:00.000Z'),
+        updatedAt: new Date('2026-05-01T12:05:00.000Z'),
+      },
+      {
+        formId: '849b',
+        file: '849b.pdf',
+        createdAt: new Date('2026-05-02T08:00:00.000Z'),
+        updatedAt: new Date('2026-05-02T08:00:00.000Z'),
+      },
+      {
+        formId: 'cert',
+        file: 'cert.pdf',
+        createdAt: new Date('2026-05-02T08:00:00.000Z'),
+        updatedAt: new Date('2026-05-02T08:00:00.000Z'),
+      },
+    ],
+  };
+
   const mockPrisma = {
     deflection: {
-      findUnique: async () => ({
-        transferredAt: new Date('2026-05-01T12:00:00.000Z'),
-        subject: {
-          firstName: 'Jane',
-          lastName: 'Doe',
-        },
-        facility: {
-          name: 'RESET',
-        },
-        incident: {
-          createdBy: {
-            firstName: 'Regular',
-            lastName: 'User',
-            email: 'regular.user@test.com',
-          },
-        },
-        deflectionDocuments: [
-          {
-            formId: '647f',
-            file: '647f.pdf',
-            createdAt: new Date('2026-05-01T12:05:00.000Z'),
-            updatedAt: new Date('2026-05-01T12:05:00.000Z'),
-          },
-          {
-            formId: '849b',
-            file: '849b.pdf',
-            createdAt: new Date('2026-05-02T08:00:00.000Z'),
-            updatedAt: new Date('2026-05-02T08:00:00.000Z'),
-          },
-          {
-            formId: 'cert',
-            file: 'cert.pdf',
-            createdAt: new Date('2026-05-02T08:00:00.000Z'),
-            updatedAt: new Date('2026-05-02T08:00:00.000Z'),
-          },
-        ],
-      }),
+      findUnique: async () => mockDeflection,
     },
     user: {
       findUnique: async () => ({
@@ -114,7 +135,15 @@ test('formsEmail job handler', async (t) => {
     ]);
     assert.deepStrictEqual(sentMail[0].cc, undefined);
     assert.deepStrictEqual(sentMail[0].subject, 'Incident forms for Jane Doe');
-    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b.pdf']);
+    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-4.pdf']);
+    assert.ok(sentMail[0].attachments[0].content, '849b should be generated live for email attachment');
+    assert.strictEqual(sentMail[0].attachments[0].path, undefined);
+    const doc = await PDFDocument.load(sentMail[0].attachments[0].content);
+    const pdfForm = doc.getForm();
+    assert.deepStrictEqual(pdfForm.getDropdown('Dropdown4').getSelected(), ['DET/REL']);
+    assert.strictEqual(pdfForm.getTextField('CODE_2').getText(), 'R1');
+    assert.strictEqual(pdfForm.getTextField('NAME LAST FIRST MIDDLE_2').getText(), 'Deputy, R, #R123');
+    assert.strictEqual(pdfForm.getTextField('Text4').getText() || '', '');
   });
 
   await t.test('sends self-requested 849b only to the current user', async () => {
@@ -131,7 +160,9 @@ test('formsEmail job handler', async (t) => {
     assert.deepStrictEqual(sentMail[0].to, 'releasing.user@test.com');
     assert.deepStrictEqual(sentMail[0].cc, undefined);
     assert.deepStrictEqual(sentMail[0].subject, '849(b) form for Jane Doe');
-    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b.pdf']);
+    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-4.pdf']);
+    assert.ok(sentMail[0].attachments[0].content, '849b should be generated live for email attachment');
+    assert.strictEqual(sentMail[0].attachments[0].path, undefined);
   });
 
   await t.test('sends release forms as one email to swaps supervisors and the releasing user', async () => {
@@ -151,29 +182,18 @@ test('formsEmail job handler', async (t) => {
     ]);
     assert.deepStrictEqual(sentMail[0].cc, undefined);
     assert.deepStrictEqual(sentMail[0].subject, 'Release forms for Jane Doe');
-    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['647f.pdf', '849b.pdf', 'cert.pdf']);
+    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-4.pdf', '647f.pdf', 'cert.pdf']);
+    const attachment849b = sentMail[0].attachments.find(a => a.filename === '849b-report-4.pdf');
+    assert.ok(attachment849b.content, '849b should be generated live for release email attachment');
+    assert.strictEqual(attachment849b.path, undefined);
   });
 
-  await t.test('sends an additional 647f-only release email when 647f was regenerated after transfer', async () => {
+  await t.test('does not send an additional 647f-only release email from timestamps alone', async () => {
     const regeneratedPrisma = {
       ...mockPrisma,
       deflection: {
         findUnique: async () => ({
-          transferredAt: new Date('2026-05-01T12:00:00.000Z'),
-          subject: {
-            firstName: 'Jane',
-            lastName: 'Doe',
-          },
-          facility: {
-            name: 'RESET',
-          },
-          incident: {
-            createdBy: {
-              firstName: 'Regular',
-              lastName: 'User',
-              email: 'regular.user@test.com',
-            },
-          },
+          ...mockDeflection,
           deflectionDocuments: [
             {
               formId: '647f',
@@ -206,13 +226,35 @@ test('formsEmail job handler', async (t) => {
     }, regeneratedPrisma);
 
     const sentMail = nodemailerMock.mock.getSentMail();
+    assert.deepStrictEqual(sentMail.length, 1);
+
+    assert.deepStrictEqual(sentMail[0].to, [
+      'sfso-swapsups@sfgov.org',
+      'releasing.user@test.com',
+    ]);
+    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-4.pdf', '647f.pdf', 'cert.pdf']);
+    const regeneratedAttachment849b = sentMail[0].attachments.find(a => a.filename === '849b-report-4.pdf');
+    assert.ok(regeneratedAttachment849b.content, '849b should be generated live for release email attachment');
+    assert.strictEqual(regeneratedAttachment849b.path, undefined);
+  });
+
+  await t.test('sends an additional 647f-only release email when 647f was regenerated during the release job', async () => {
+    await formsEmail({
+      deflectionId: 4,
+      formIds: ['647f', '849b', 'cert'],
+      template: 'release-forms',
+      userId: 'test-user-id',
+      regeneratedFormIds: ['647f', 'cert'],
+    }, mockPrisma);
+
+    const sentMail = nodemailerMock.mock.getSentMail();
     assert.deepStrictEqual(sentMail.length, 2);
 
     assert.deepStrictEqual(sentMail[0].to, [
       'sfso-swapsups@sfgov.org',
       'releasing.user@test.com',
     ]);
-    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['647f.pdf', '849b.pdf', 'cert.pdf']);
+    assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-4.pdf', '647f.pdf', 'cert.pdf']);
 
     assert.deepStrictEqual(sentMail[1].to, [
       'SFPD.Data.Transfer.Authorized@sfgov.org',

--- a/server/test/jobs/formsEmail.test.js
+++ b/server/test/jobs/formsEmail.test.js
@@ -146,6 +146,32 @@ test('formsEmail job handler', async (t) => {
     assert.strictEqual(pdfForm.getTextField('Text4').getText() || '', '');
   });
 
+  await t.test('throws when live 849b cannot be generated so the queue can retry / dead-letter', async () => {
+    const ungeneratablePrisma = {
+      ...mockPrisma,
+      deflection: {
+        findUnique: async () => ({
+          ...mockDeflection,
+          releasedAt: null,
+          exitedAt: null,
+          exitDestination: null,
+        }),
+      },
+    };
+
+    await assert.rejects(
+      () => formsEmail({
+        deflectionId: 4,
+        formIds: ['849b'],
+        template: 'self-849b',
+        userId: 'test-user-id',
+      }, ungeneratablePrisma),
+      /Live 849\(b\) generation failed for deflection 4/
+    );
+
+    assert.deepStrictEqual(nodemailerMock.mock.getSentMail(), []);
+  });
+
   await t.test('sends self-requested 849b only to the current user', async () => {
     await formsEmail({
       deflectionId: 4,

--- a/server/test/jobs/generateForms.test.js
+++ b/server/test/jobs/generateForms.test.js
@@ -74,12 +74,13 @@ test('generateForms 647f hash logic', async (t) => {
     const firstUpdatedAt = docAfterFirst.updatedAt;
 
     // Second generation with same data
-    const skipped = await generateForms(
+    const result = await generateForms(
       { deflectionId: deflection.id, userId: user.id, formIds: ['647f'] },
       prisma
     );
 
-    assert.deepStrictEqual(skipped, ['647f']);
+    assert.deepStrictEqual(result.skippedFormIds, ['647f']);
+    assert.deepStrictEqual(result.generatedFormIds, []);
 
     const docAfterSecond = await prisma.deflectionDocument.findUnique({
       where: { deflectionId_formId: { deflectionId: deflection.id, formId: '647f' } },
@@ -112,12 +113,13 @@ test('generateForms 647f hash logic', async (t) => {
     });
 
     // Second generation with changed data
-    const skipped = await generateForms(
+    const result = await generateForms(
       { deflectionId: deflection.id, userId: user.id, formIds: ['647f'] },
       prisma
     );
 
-    assert.deepStrictEqual(skipped, []);
+    assert.deepStrictEqual(result.skippedFormIds, []);
+    assert.deepStrictEqual(result.generatedFormIds, ['647f']);
 
     const docAfterSecond = await prisma.deflectionDocument.findUnique({
       where: { deflectionId_formId: { deflectionId: deflection.id, formId: '647f' } },
@@ -145,12 +147,13 @@ test('generateForms 647f hash logic', async (t) => {
       },
     });
 
-    const skipped = await generateForms(
+    const result = await generateForms(
       { deflectionId: deflection.id, userId: user.id, formIds: ['849b'] },
       prisma
     );
 
-    assert.deepStrictEqual(skipped, []);
+    assert.deepStrictEqual(result.skippedFormIds, []);
+    assert.deepStrictEqual(result.generatedFormIds, ['849b']);
 
     const docAfterRegeneration = await prisma.deflectionDocument.findUnique({
       where: { deflectionId_formId: { deflectionId: deflection.id, formId: '849b' } },

--- a/server/test/jobs/generateForms.test.js
+++ b/server/test/jobs/generateForms.test.js
@@ -124,4 +124,38 @@ test('generateForms 647f hash logic', async (t) => {
     });
     assert.notStrictEqual(docAfterSecond.sourceDataHash, firstHash, 'hash should have changed');
   });
+
+  await t.test('always regenerates existing 849b before e-mail attachments are sent', async () => {
+    const { user, deflection } = await createDeflection();
+    await prisma.deflection.update({
+      where: { id: deflection.id },
+      data: {
+        subjectStatus: 'RELEASED',
+        releasedAt: new Date(),
+        releasedById: user.id,
+      },
+    });
+    await prisma.deflectionDocument.create({
+      data: {
+        deflectionId: deflection.id,
+        formId: '849b',
+        file: 'stale-849b.pdf',
+        createdById: user.id,
+        updatedById: user.id,
+      },
+    });
+
+    const skipped = await generateForms(
+      { deflectionId: deflection.id, userId: user.id, formIds: ['849b'] },
+      prisma
+    );
+
+    assert.deepStrictEqual(skipped, []);
+
+    const docAfterRegeneration = await prisma.deflectionDocument.findUnique({
+      where: { deflectionId_formId: { deflectionId: deflection.id, formId: '849b' } },
+    });
+    assert.strictEqual(docAfterRegeneration.file, `849b-report-${deflection.id}.pdf`);
+    assert.strictEqual(docAfterRegeneration.sourceDataHash, null);
+  });
 });

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import * as assert from 'node:assert';
+import { PDFDocument } from 'pdf-lib';
 
 import form849b from '#lib/forms/849b/index.js';
 
@@ -31,4 +32,66 @@ test('849b form generation eligibility', async (t) => {
       message: 'The SFSO 849(b) Report can only be generated after the subject has been released or exited to jail.',
     });
   });
+});
+
+test('849b PDF fills release reporting party fields and leaves citation text blank', async () => {
+  const releasedAt = new Date('2026-05-05T20:00:00.000Z');
+  const pdfBytes = await form849b.generatePdf(form849b.transformData({
+    releasedAt,
+    exitedAt: null,
+    releaseReason: 'SOBERED',
+    releasedBy: {
+      firstName: 'Test',
+      lastName: 'SFSO',
+      badgeNumber: '5678',
+      prop115Certified: true,
+    },
+    exitedBy: null,
+    incident: {
+      cadNumber: 'CAD849B',
+      caseNumber: 'CS849B',
+      arrestedAt: releasedAt,
+      addressLine1: '100 Market St',
+      city: 'San Francisco',
+      state: 'CA',
+      encounteredVia: 'ON_VIEW',
+      createdBy: null,
+    },
+    subject: {
+      firstName: 'Swilly',
+      middleInitial: 'Q',
+      lastName: 'Willy',
+      race: 'WHITE',
+      sex: 'MALE',
+      dateOfBirth: new Date('2001-10-01T00:00:00.000Z'),
+      addressLine1: '123 Test St',
+      city: 'San Francisco',
+      state: 'CA',
+      postalCode: '94103',
+      driverLicense: 'D1234567',
+      localId: 'SF123',
+    },
+    drugType: 'FENTANYL',
+    behavior: null,
+    releaseNarrative: 'Release narrative.',
+  }), { prop115Certified: false });
+
+  const doc = await PDFDocument.load(pdfBytes);
+  const pdfForm = doc.getForm();
+
+  assert.deepStrictEqual(pdfForm.getDropdown('Dropdown4').getSelected(), ['DET/REL']);
+  assert.strictEqual(
+    pdfForm.getCheckBox('BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED').isChecked(),
+    true
+  );
+  assert.strictEqual(pdfForm.getTextField('Text3').getText(), '2');
+  assert.strictEqual(pdfForm.getTextField('CODE_2').getText(), 'R1');
+  assert.strictEqual(pdfForm.getTextField('NAME LAST FIRST MIDDLE_2').getText(), 'SFSO, T, #5678');
+  assert.strictEqual(pdfForm.getTextField('CONTACT PHONE NUMBER_2').getText(), '415-575-6461');
+  assert.strictEqual(
+    pdfForm.getTextField('BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO_2').getText(),
+    '70 Oak Grove St'
+  );
+  assert.strictEqual(pdfForm.getTextField('ZIP CODE_4').getText(), '94107');
+  assert.strictEqual(pdfForm.getTextField('Text4').getText() || '', '');
 });

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -94,7 +94,12 @@ test('849b PDF fills release reporting party fields and leaves citation text bla
     drugType: 'FENTANYL',
     behavior: null,
     releaseNarrative: 'Release narrative.',
-  }), { prop115Certified: false });
+  }), {
+    firstName: 'Generating',
+    lastName: 'Deputy',
+    badgeNumber: '9999',
+    prop115Certified: false,
+  });
 
   const doc = await PDFDocument.load(pdfBytes);
   const pdfForm = doc.getForm();
@@ -105,6 +110,7 @@ test('849b PDF fills release reporting party fields and leaves citation text bla
     true
   );
   assert.strictEqual(pdfForm.getTextField('Text3').getText(), '2');
+  assert.strictEqual(pdfForm.getTextField('REPORTING DEPUTY PRINT').getText(), 'G. Deputy');
   assert.strictEqual(pdfForm.getTextField('CODE_2').getText(), 'R1');
   assert.strictEqual(pdfForm.getTextField('NAME LAST FIRST MIDDLE_2').getText(), 'SFSO, T, #5678');
   assert.strictEqual(pdfForm.getTextField('CONTACT PHONE NUMBER_2').getText(), '415-575-6461');

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -232,3 +232,39 @@ test('849b PDF leaves prop 115 unchecked but checks post training when reporting
   );
   assert.strictEqual(pdfForm.getCheckBox('POST TRAINING').isChecked(), true);
 });
+
+test('849b PDF truncates overlong text fields to template max lengths', async () => {
+  const releasedAt = new Date('2026-05-05T20:00:00.000Z');
+  const pdfBytes = await form849b.generatePdf(form849b.transformData({
+    releasedAt,
+    exitedAt: null,
+    releaseReason: 'SOBERED',
+    releasedBy: {
+      firstName: 'Test',
+      lastName: 'SFSO',
+      badgeNumber: '5678',
+      prop115Certified: false,
+    },
+    exitedBy: null,
+    incident: {
+      cadNumber: 'CAD-TOO-LONG',
+      caseNumber: 'CASE-TOO-LONG',
+      arrestedAt: releasedAt,
+      addressLine1: '100 Market St',
+      city: 'San Francisco',
+      state: 'CA',
+      encounteredVia: 'ON_VIEW',
+      createdBy: null,
+    },
+    subject: null,
+    drugType: 'FENTANYL',
+    behavior: null,
+    releaseNarrative: 'Release narrative.',
+  }));
+
+  const doc = await PDFDocument.load(pdfBytes);
+  const pdfForm = doc.getForm();
+
+  assert.strictEqual(pdfForm.getTextField('INCIDENT NUMBER').getText(), 'CASE-TOO-');
+  assert.strictEqual(pdfForm.getTextField('CAD NUMBER').getText(), 'CAD-TOO-L');
+});

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -180,14 +180,15 @@ test('849b PDF fills release reporting party fields and leaves citation text bla
     pdfForm.getCheckBox('BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED').isChecked(),
     true
   );
+  assert.strictEqual(pdfForm.getCheckBox('POST TRAINING').isChecked(), true);
   assert.strictEqual(pdfForm.getTextField('Text3').getText(), '2');
-  assert.strictEqual(pdfForm.getTextField('REPORTING DEPUTY PRINT').getText(), 'G. Deputy');
+  assert.strictEqual(pdfForm.getTextField('REPORTING DEPUTY PRINT').getText(), 'T. SFSO');
   assert.strictEqual(pdfForm.getTextField('CODE_2').getText(), 'R1');
   assert.strictEqual(pdfForm.getTextField('NAME LAST FIRST MIDDLE_2').getText(), 'SFSO, T, #5678');
   assert.strictEqual(pdfForm.getTextField('CONTACT PHONE NUMBER_2').getText(), '415-575-6461');
   assert.strictEqual(
     pdfForm.getTextField('BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO_2').getText(),
-    '70 Oak Grove St'
+    '70 Oak Grove St.'
   );
   assert.strictEqual(pdfForm.getTextField('ZIP CODE_4').getText(), '94107');
   assert.strictEqual(pdfForm.getTextField('Text4').getText() || '', '');

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -180,7 +180,7 @@ test('849b PDF fills release reporting party fields and leaves citation text bla
     pdfForm.getCheckBox('BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED').isChecked(),
     true
   );
-  assert.strictEqual(pdfForm.getCheckBox('POST TRAINING').isChecked(), true);
+  assert.strictEqual(pdfForm.getCheckBox('POST TRAINING').isChecked(), false);
   assert.strictEqual(pdfForm.getTextField('Text3').getText(), '2');
   assert.strictEqual(pdfForm.getTextField('REPORTING DEPUTY PRINT').getText(), 'T. SFSO');
   assert.strictEqual(pdfForm.getTextField('CODE_2').getText(), 'R1');
@@ -192,4 +192,43 @@ test('849b PDF fills release reporting party fields and leaves citation text bla
   );
   assert.strictEqual(pdfForm.getTextField('ZIP CODE_4').getText(), '94107');
   assert.strictEqual(pdfForm.getTextField('Text4').getText() || '', '');
+});
+
+test('849b PDF leaves prop 115 unchecked but checks post training when reporting deputy is not certified', async () => {
+  const releasedAt = new Date('2026-05-05T20:00:00.000Z');
+  const pdfBytes = await form849b.generatePdf(form849b.transformData({
+    releasedAt,
+    exitedAt: null,
+    releaseReason: 'SOBERED',
+    releasedBy: {
+      firstName: 'Noncertified',
+      lastName: 'Deputy',
+      badgeNumber: '1357',
+      prop115Certified: false,
+    },
+    exitedBy: null,
+    incident: {
+      cadNumber: 'CAD849B',
+      caseNumber: 'CS849B',
+      arrestedAt: releasedAt,
+      addressLine1: '100 Market St',
+      city: 'San Francisco',
+      state: 'CA',
+      encounteredVia: 'ON_VIEW',
+      createdBy: null,
+    },
+    subject: null,
+    drugType: 'FENTANYL',
+    behavior: null,
+    releaseNarrative: 'Release narrative.',
+  }));
+
+  const doc = await PDFDocument.load(pdfBytes);
+  const pdfForm = doc.getForm();
+
+  assert.strictEqual(
+    pdfForm.getCheckBox('BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED').isChecked(),
+    false
+  );
+  assert.strictEqual(pdfForm.getCheckBox('POST TRAINING').isChecked(), true);
 });

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -30,9 +30,6 @@ test('/api/deflections', async (t) => {
   const custodyUser = await prisma.user.findUniqueOrThrow({
     where: { email: 'sfsouser1@test.com' },
   });
-  const careUser = await prisma.user.findUniqueOrThrow({
-    where: { email: 'careuser1@test.com' },
-  });
 
   // Fixtures are intentionally incomplete (see fixtures/db/incidents.yml,
   // deflections.yml). Tests opt into completeness when they exercise endpoints
@@ -1903,7 +1900,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
     });
 
-    await t.test('queues 849b email when final exit destination is jail', async () => {
+    await t.test('rejects JAIL as exit destination — care users record jail outcomes via custody', async () => {
       await app.prisma.deflection.update({
         where: { id: 6 },
         data: {
@@ -1926,20 +1923,11 @@ test('/api/deflections', async (t) => {
           exitConnectedToCare: 'NO',
         });
 
-      assert.strictEqual(response.statusCode, StatusCodes.OK);
-      const data = JSON.parse(response.body);
-
-      assert.strictEqual(data.subjectStatus, 'EXITED');
-      assert.strictEqual(data.exitDestination, 'JAIL');
-      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
-      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
-      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
-        deflectionId: 6,
-        userId: careUser.id,
-        formIds: ['849b'],
-        emailTemplate: 'incident-forms',
-        recipientEmail: 'careuser1@test.com',
-      });
+      assert.strictEqual(response.statusCode, StatusCodes.BAD_REQUEST);
+      const dbDeflection = await app.prisma.deflection.findUnique({ where: { id: 6 } });
+      assert.strictEqual(dbDeflection.subjectStatus, 'IN_CHAIR');
+      assert.strictEqual(dbDeflection.exitDestination, null);
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
     });
 
     await t.test('requires care user role', async () => {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -1923,7 +1923,7 @@ test('/api/deflections', async (t) => {
           exitConnectedToCare: 'NO',
         });
 
-      assert.strictEqual(response.statusCode, StatusCodes.BAD_REQUEST);
+      assert.strictEqual(response.statusCode, StatusCodes.UNPROCESSABLE_ENTITY);
       const dbDeflection = await app.prisma.deflection.findUnique({ where: { id: 6 } });
       assert.strictEqual(dbDeflection.subjectStatus, 'IN_CHAIR');
       assert.strictEqual(dbDeflection.exitDestination, null);

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import * as assert from 'node:assert';
 import { StatusCodes } from 'http-status-codes';
 
-import { authenticate, build } from '#test/helper.js';
+import { authenticate, build, nodemailerMock } from '#test/helper.js';
 import Facility from '#models/facility.js';
 
 function assertCareSubjectRedaction (subject) {
@@ -317,13 +317,14 @@ test('/api/deflections', async (t) => {
   });
 
   await t.test('POST /:id/849b-email', async (t) => {
-    await t.test('queues 849b regeneration and self e-mail for custody user', async () => {
+    await t.test('generates and e-mails a live 849b PDF to custody user', async () => {
       await prisma.deflection.update({
         where: { id: 6 },
         data: {
           subjectStatus: 'EXITED',
           releasedAt: new Date(),
           exitedAt: new Date(),
+          releasedById: '49acdf99-536f-49ac-8138-1c77e5087697',
         },
       });
 
@@ -333,18 +334,16 @@ test('/api/deflections', async (t) => {
 
       assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
       assert.deepStrictEqual(JSON.parse(response.body), {
-        queued: true,
+        queued: false,
         email: 'sfsouser1@test.com',
       });
-      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
-      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
-      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
-        deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
-        formIds: ['849b'],
-        emailTemplate: 'self-849b',
-        recipientEmail: 'sfsouser1@test.com',
-      });
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
+      const sentMail = nodemailerMock.mock.getSentMail();
+      assert.deepStrictEqual(sentMail.length, 1);
+      assert.deepStrictEqual(sentMail[0].to, 'sfsouser1@test.com');
+      assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-6.pdf']);
+      assert.ok(sentMail[0].attachments[0].content, '849b should be generated live for self-email attachment');
+      assert.strictEqual(sentMail[0].attachments[0].path, undefined);
     });
 
     await t.test('forbids non-custody users', async () => {
@@ -1832,6 +1831,47 @@ test('/api/deflections', async (t) => {
       assert.strictEqual(lastUpdate.exitHousingStatus, 'PERMANENT');
       assert.strictEqual(lastUpdate.exitSFResident, 'YES');
       assert.strictEqual(lastUpdate.exitConnectedToCare, 'YES');
+
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
+    });
+
+    await t.test('queues 849b email when final exit destination is jail', async () => {
+      await app.prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'IN_CHAIR',
+          status: 'ACTIVE',
+          completedAt: null,
+          exitedAt: null,
+          exitedById: null,
+          exitDestination: null,
+        },
+      });
+
+      const response = await app.inject()
+        .post('/api/deflections/6/exit')
+        .headers(careUserHeaders)
+        .payload({
+          exitDestination: 'JAIL',
+          exitHousingStatus: 'TEMPORARY',
+          exitSFResident: 'UNKNOWN',
+          exitConnectedToCare: 'NO',
+        });
+
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+
+      assert.strictEqual(data.subjectStatus, 'EXITED');
+      assert.strictEqual(data.exitDestination, 'JAIL');
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
+        deflectionId: 6,
+        userId: 'e2deed87-2733-41d7-b9f1-3c66869d5c2f',
+        formIds: ['849b'],
+        emailTemplate: 'incident-forms',
+        recipientEmail: 'careuser1@test.com',
+      });
     });
 
     await t.test('requires care user role', async () => {
@@ -1971,7 +2011,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(bedType.available, 5);
     });
 
-    await t.test('records sobered release from a pre-chair hold and finalizes the deflection', async () => {
+    await t.test('records sobered release from pending safety checks, finalizes the deflection, and queues release email', async () => {
       await prisma.deflection.expire();
       await prisma.bedType.update({
         where: { id: '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76' },
@@ -1980,7 +2020,7 @@ test('/api/deflections', async (t) => {
       await prisma.deflection.update({
         where: { id: 6 },
         data: {
-          subjectStatus: 'READY_FOR_INTAKE',
+          subjectStatus: 'AWAITING_INTAKE',
           releasedAt: null,
           releasedById: null,
           releaseReason: null,
@@ -2031,6 +2071,59 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(bedType.holds, 4);
       assert.deepStrictEqual(bedType.inTransit, 3);
       assert.deepStrictEqual(bedType.available, 4);
+
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
+        deflectionId: 6,
+        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        formIds: ['647f', '849b', 'cert'],
+        emailTemplate: 'release-forms',
+      });
+    });
+
+    await t.test('records sobered release from awaiting medical intake and queues release email', async () => {
+      await prisma.deflection.expire();
+      await prisma.bedType.update({
+        where: { id: '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76' },
+        data: { occupied: 0, holds: 5, inTransit: 3, available: 3 },
+      });
+      await prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'READY_FOR_INTAKE',
+          status: 'ACTIVE',
+          completedAt: null,
+          releasedAt: null,
+          releasedById: null,
+          releaseReason: null,
+          exitedAt: null,
+          exitedById: null,
+          exitDestination: null,
+        },
+      });
+
+      const response = await app.inject()
+        .post('/api/deflections/6/release')
+        .headers(custodyUserHeaders)
+        .payload({
+          releaseReason: 'SOBERED',
+        });
+
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+
+      assert.strictEqual(data.subjectStatus, 'EXITED');
+      assert.strictEqual(data.status, 'COMPLETED');
+      assert.strictEqual(data.releaseReason, 'SOBERED');
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
+        deflectionId: 6,
+        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        formIds: ['647f', '849b', 'cert'],
+        emailTemplate: 'release-forms',
+      });
     });
 
     await t.test('records sobered release from in-chair and lingers as ACTIVE/RELEASED', async () => {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -2,7 +2,7 @@ import { test } from 'node:test';
 import * as assert from 'node:assert';
 import { StatusCodes } from 'http-status-codes';
 
-import { authenticate, build, nodemailerMock } from '#test/helper.js';
+import { authenticate, build } from '#test/helper.js';
 import Facility from '#models/facility.js';
 
 function assertCareSubjectRedaction (subject) {
@@ -383,7 +383,7 @@ test('/api/deflections', async (t) => {
   });
 
   await t.test('POST /:id/849b-email', async (t) => {
-    await t.test('generates and e-mails a live 849b PDF to custody user', async () => {
+    await t.test('queues live 849b regeneration and self e-mail for custody user', async () => {
       await prisma.deflection.update({
         where: { id: 6 },
         data: {
@@ -400,16 +400,18 @@ test('/api/deflections', async (t) => {
 
       assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
       assert.deepStrictEqual(JSON.parse(response.body), {
-        queued: false,
+        queued: true,
         email: 'sfsouser1@test.com',
       });
-      assert.deepStrictEqual(app.backgroundJobs._sent.length, 0);
-      const sentMail = nodemailerMock.mock.getSentMail();
-      assert.deepStrictEqual(sentMail.length, 1);
-      assert.deepStrictEqual(sentMail[0].to, 'sfsouser1@test.com');
-      assert.deepStrictEqual(sentMail[0].attachments.map(a => a.filename), ['849b-report-6.pdf']);
-      assert.ok(sentMail[0].attachments[0].content, '849b should be generated live for self-email attachment');
-      assert.strictEqual(sentMail[0].attachments[0].path, undefined);
+      assert.deepStrictEqual(app.backgroundJobs._sent.length, 1);
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
+      assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
+        deflectionId: 6,
+        userId: custodyUser.id,
+        formIds: ['849b'],
+        emailTemplate: 'self-849b',
+        recipientEmail: 'sfsouser1@test.com',
+      });
     });
 
     await t.test('forbids non-custody users', async () => {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -24,6 +24,15 @@ test('/api/deflections', async (t) => {
   const cleanFieldHeaders = await authenticate(app, 'field.noholds@test.com', 'test');
   const custodyUserHeaders = await authenticate(app, 'sfsouser1@test.com', 'test');
   const careUserHeaders = await authenticate(app, 'careuser1@test.com', 'test');
+  const regularUser = await prisma.user.findUniqueOrThrow({
+    where: { email: 'regular.user@test.com' },
+  });
+  const custodyUser = await prisma.user.findUniqueOrThrow({
+    where: { email: 'sfsouser1@test.com' },
+  });
+  const careUser = await prisma.user.findUniqueOrThrow({
+    where: { email: 'careuser1@test.com' },
+  });
 
   // Fixtures are intentionally incomplete (see fixtures/db/incidents.yml,
   // deflections.yml). Tests opt into completeness when they exercise endpoints
@@ -301,7 +310,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['849b'],
       });
     });
@@ -592,7 +601,7 @@ test('/api/deflections', async (t) => {
           incidentId: 1,
           bedTypeId: '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76',
           subjectStatus: 'AWAITING_INTAKE',
-          createdById: '49acdf99-536f-49ac-8138-1c77e5087697',
+          createdById: custodyUser.id,
         },
       });
 
@@ -614,7 +623,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: testDeflection.id,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['849b'],
         emailTemplate: 'incident-forms',
         recipientEmail: 'sfsouser1@test.com',
@@ -1507,7 +1516,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 4,
-        userId: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5',
+        userId: regularUser.id,
         formIds: ['647f'],
         emailTemplate: 'transfer-form',
         recipientEmail: [
@@ -1867,7 +1876,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: 'e2deed87-2733-41d7-b9f1-3c66869d5c2f',
+        userId: careUser.id,
         formIds: ['849b'],
         emailTemplate: 'incident-forms',
         recipientEmail: 'careuser1@test.com',
@@ -2076,7 +2085,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['647f', '849b', 'cert'],
         emailTemplate: 'release-forms',
       });
@@ -2120,7 +2129,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['647f', '849b', 'cert'],
         emailTemplate: 'release-forms',
       });
@@ -2224,7 +2233,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['647f', '849b', 'cert'],
         emailTemplate: 'release-forms',
       });
@@ -2277,7 +2286,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['647f', '849b', 'cert'],
         emailTemplate: 'release-forms',
       });
@@ -2313,7 +2322,7 @@ test('/api/deflections', async (t) => {
       assert.deepStrictEqual(app.backgroundJobs._sent[0].name, 'generate-forms');
       assert.deepStrictEqual(app.backgroundJobs._sent[0].data, {
         deflectionId: 6,
-        userId: '49acdf99-536f-49ac-8138-1c77e5087697',
+        userId: custodyUser.id,
         formIds: ['647f', '849b', 'cert'],
         emailTemplate: 'release-forms',
       });


### PR DESCRIPTION
## Summary

- Populate additional 849(b) PDF fields during generation (at Deputy's request):
  - Disposition code: `DET/REL`
  - Reporting party code: `R1`
  - Reporting party name from the releasing deputy: `Last, FirstInitial, #Star`
  - Reporting party phone: `415-575-6461`
  - Reporting party business address: `70 Oak Grove St`
  - Reporting party ZIP: `94107`
- Fix the stray `2` appearing near the Citation / Booking Approved area by no longer writing to the unrelated `Text4` field.
- Keep the report page count field populated correctly as `2`.
- Source Prop 115 certification from the original releasing user, not the user who happens to generate the PDF.
- Preserve first-initial deputy formatting after the dev merge.

Closes #898 