### PR TITLE
[Paused] Custody: Show incident time and address for in-transit holds

### DIFF
--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -15,7 +15,7 @@ import useSessionState from '@/hooks/useSessionState';
 import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import useNow from '@/hooks/useNow';
 import useSubjectDetails from '@/hooks/useSubjectDetails';
-import { formatSmartDateTime, formatTime, formatTimeRemaining } from '@/utils/format';
+import { formatTime, formatTimeRemaining } from '@/utils/format';
 import { isValidDeflection, isValidIncident } from '@/utils/validators';
 
 import ChairAvailabilityCard from '../ChairAvailabilityCard';
@@ -147,9 +147,6 @@ function TransitCustodyCard ({ deflection, highlighted }) {
   // City omitted on display per product (always SF in current scope); buildAddressQuery
   // backfills "San Francisco, CA" so the underlying map link still resolves correctly.
   const incidentAddressDisplay = [deflection?.incident?.addressLine1, deflection?.incident?.addressLine2].filter(Boolean).join(', ');
-  const incidentTimeDisplay = deflection?.incident?.arrestedAt
-    ? formatSmartDateTime(deflection.incident.arrestedAt)
-    : null;
 
   return (
     <Card
@@ -173,7 +170,15 @@ function TransitCustodyCard ({ deflection, highlighted }) {
               <>
                 <Text size='md' c='gray.4'>•</Text>
                 <Text size='md' c='indigo.6' truncate>
-                  {deflection.arrivedAt ? `Arrived at ${formatTime(deflection.arrivedAt)}` : 'Arrived'}
+                  {deflection.arrivedAt ? `Arrived ${formatTime(deflection.arrivedAt)}` : 'Arrived'}
+                </Text>
+              </>
+            )}
+            {!isArrived && deflection.incident?.arrestedAt && (
+              <>
+                <Text size='md' c='gray.4'>•</Text>
+                <Text size='md' c='gray.6' truncate>
+                  Detained {formatTime(deflection.incident.arrestedAt)}
                 </Text>
               </>
             )}
@@ -184,31 +189,21 @@ function TransitCustodyCard ({ deflection, highlighted }) {
               <Text size='md'>{subjectDetails.join(', ')}</Text>
             )}
           </Stack>
-          {(incidentAddressDisplay || incidentTimeDisplay) && (
-            <Group gap='xs' wrap='nowrap'>
-              {incidentAddressDisplay && (
-                <FacilityAddressLinkFromParts
-                  addressLine1={deflection.incident?.addressLine1}
-                  addressLine2={deflection.incident?.addressLine2}
-                  city={deflection.incident?.city}
-                  state={deflection.incident?.state}
-                  postalCode={deflection.incident?.postalCode}
-                  style={{
-                    color: 'var(--mantine-color-gray-6)',
-                    textDecoration: 'none',
-                    fontSize: 'var(--mantine-font-size-md)',
-                  }}
-                >
-                  {incidentAddressDisplay}
-                </FacilityAddressLinkFromParts>
-              )}
-              {incidentAddressDisplay && incidentTimeDisplay && (
-                <Text size='md' c='gray.4'>•</Text>
-              )}
-              {incidentTimeDisplay && (
-                <Text size='md' c='gray.6'>{incidentTimeDisplay}</Text>
-              )}
-            </Group>
+          {incidentAddressDisplay && (
+            <FacilityAddressLinkFromParts
+              addressLine1={deflection.incident?.addressLine1}
+              addressLine2={deflection.incident?.addressLine2}
+              city={deflection.incident?.city}
+              state={deflection.incident?.state}
+              postalCode={deflection.incident?.postalCode}
+              style={{
+                color: 'var(--mantine-color-gray-6)',
+                textDecoration: 'none',
+                fontSize: 'var(--mantine-font-size-md)',
+              }}
+            >
+              {incidentAddressDisplay}
+            </FacilityAddressLinkFromParts>
           )}
         </Stack>
         {detailsComplete && (

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -144,8 +144,6 @@ function TransitCustodyCard ({ deflection, highlighted }) {
   const detailsComplete = isValidDeflection(deflection) && isValidIncident(deflection?.incident);
   const isArrived = deflection?.subjectStatus === 'ONSITE_AWAITING_TRANSFER';
   const now = useNow(1000, !isArrived && !!deflection?.expiresAt && detailsComplete);
-  // City omitted on display per product (always SF in current scope); buildAddressQuery
-  // backfills "San Francisco, CA" so the underlying map link still resolves correctly.
   const incidentAddressDisplay = [deflection?.incident?.addressLine1, deflection?.incident?.addressLine2].filter(Boolean).join(', ');
 
   return (

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -15,7 +15,7 @@ import useSessionState from '@/hooks/useSessionState';
 import { facilityLiveQueryOptions } from '@/hooks/facilityLiveQueryOptions';
 import useNow from '@/hooks/useNow';
 import useSubjectDetails from '@/hooks/useSubjectDetails';
-import { formatTime, formatTimeRemaining } from '@/utils/format';
+import { formatSmartDateTime, formatTime, formatTimeRemaining } from '@/utils/format';
 import { isValidDeflection, isValidIncident } from '@/utils/validators';
 
 import ChairAvailabilityCard from '../ChairAvailabilityCard';
@@ -147,6 +147,9 @@ function TransitCustodyCard ({ deflection, highlighted }) {
   // City omitted on display per product (always SF in current scope); buildAddressQuery
   // backfills "San Francisco, CA" so the underlying map link still resolves correctly.
   const incidentAddressDisplay = [deflection?.incident?.addressLine1, deflection?.incident?.addressLine2].filter(Boolean).join(', ');
+  const incidentTimeDisplay = deflection?.incident?.arrestedAt
+    ? formatSmartDateTime(deflection.incident.arrestedAt)
+    : null;
 
   return (
     <Card
@@ -181,21 +184,31 @@ function TransitCustodyCard ({ deflection, highlighted }) {
               <Text size='md'>{subjectDetails.join(', ')}</Text>
             )}
           </Stack>
-          {incidentAddressDisplay && (
-            <FacilityAddressLinkFromParts
-              addressLine1={deflection.incident?.addressLine1}
-              addressLine2={deflection.incident?.addressLine2}
-              city={deflection.incident?.city}
-              state={deflection.incident?.state}
-              postalCode={deflection.incident?.postalCode}
-              style={{
-                color: 'var(--mantine-color-gray-6)',
-                textDecoration: 'none',
-                fontSize: 'var(--mantine-font-size-md)',
-              }}
-            >
-              {incidentAddressDisplay}
-            </FacilityAddressLinkFromParts>
+          {(incidentAddressDisplay || incidentTimeDisplay) && (
+            <Group gap='xs' wrap='nowrap'>
+              {incidentAddressDisplay && (
+                <FacilityAddressLinkFromParts
+                  addressLine1={deflection.incident?.addressLine1}
+                  addressLine2={deflection.incident?.addressLine2}
+                  city={deflection.incident?.city}
+                  state={deflection.incident?.state}
+                  postalCode={deflection.incident?.postalCode}
+                  style={{
+                    color: 'var(--mantine-color-gray-6)',
+                    textDecoration: 'none',
+                    fontSize: 'var(--mantine-font-size-md)',
+                  }}
+                >
+                  {incidentAddressDisplay}
+                </FacilityAddressLinkFromParts>
+              )}
+              {incidentAddressDisplay && incidentTimeDisplay && (
+                <Text size='md' c='gray.4'>•</Text>
+              )}
+              {incidentTimeDisplay && (
+                <Text size='md' c='gray.6'>{incidentTimeDisplay}</Text>
+              )}
+            </Group>
           )}
         </Stack>
         {detailsComplete && (

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -20,6 +20,7 @@ import { isValidDeflection, isValidIncident } from '@/utils/validators';
 
 import ChairAvailabilityCard from '../ChairAvailabilityCard';
 import EmptyState from '../EmptyState';
+import FacilityAddressLinkFromParts from '@/components/facilityAddressLink/FacilityAddressLinkFromParts';
 import StatusAccordion from '@/components/StatusAccordion';
 import CustodyCard from './CustodyCard';
 
@@ -143,6 +144,9 @@ function TransitCustodyCard ({ deflection, highlighted }) {
   const detailsComplete = isValidDeflection(deflection) && isValidIncident(deflection?.incident);
   const isArrived = deflection?.subjectStatus === 'ONSITE_AWAITING_TRANSFER';
   const now = useNow(1000, !isArrived && !!deflection?.expiresAt && detailsComplete);
+  // City omitted on display per product (always SF in current scope); buildAddressQuery
+  // backfills "San Francisco, CA" so the underlying map link still resolves correctly.
+  const incidentAddressDisplay = [deflection?.incident?.addressLine1, deflection?.incident?.addressLine2].filter(Boolean).join(', ');
 
   return (
     <Card
@@ -177,6 +181,22 @@ function TransitCustodyCard ({ deflection, highlighted }) {
               <Text size='md'>{subjectDetails.join(', ')}</Text>
             )}
           </Stack>
+          {incidentAddressDisplay && (
+            <FacilityAddressLinkFromParts
+              addressLine1={deflection.incident?.addressLine1}
+              addressLine2={deflection.incident?.addressLine2}
+              city={deflection.incident?.city}
+              state={deflection.incident?.state}
+              postalCode={deflection.incident?.postalCode}
+              style={{
+                color: 'var(--mantine-color-gray-6)',
+                textDecoration: 'none',
+                fontSize: 'var(--mantine-font-size-md)',
+              }}
+            >
+              {incidentAddressDisplay}
+            </FacilityAddressLinkFromParts>
+          )}
         </Stack>
         {detailsComplete && (
           <Group gap='md' wrap='nowrap' justify={isArrived ? 'flex-end' : 'space-between'}>

--- a/client/src/lesc/components/custody/Custody.test.jsx
+++ b/client/src/lesc/components/custody/Custody.test.jsx
@@ -327,4 +327,19 @@ describe('Custody', () => {
       includeCurrentOfficer: true,
     }));
   });
+
+  it('renders the incident address as a tappable map link, omitting the city', async () => {
+    mockSessionStateValue.current = 'transit';
+
+    renderCustody();
+
+    await screen.findByText('Onsite Person');
+    // Hold 4's incident address (addressLine1 only, city omitted).
+    const addressLink = screen.getByRole('link', { name: '1 Main St' });
+    expect(addressLink.getAttribute('href')).toMatch(/^(https:\/\/www\.google\.com\/maps|https:\/\/maps\.apple\.com|geo:)/);
+    // Hold 8's incident address.
+    expect(screen.getByRole('link', { name: '2 Main St' })).toBeInTheDocument();
+    // Hold 5's incident is empty — no address link rendered for it.
+    expect(screen.queryByRole('link', { name: /Incomplete Person/i })).not.toBeInTheDocument();
+  });
 });

--- a/client/src/lesc/components/custody/Custody.test.jsx
+++ b/client/src/lesc/components/custody/Custody.test.jsx
@@ -342,4 +342,17 @@ describe('Custody', () => {
     // Hold 5's incident is empty — no address link rendered for it.
     expect(screen.queryByRole('link', { name: /Incomplete Person/i })).not.toBeInTheDocument();
   });
+
+  it('renders the incident time alongside the address using the smart date/time format', async () => {
+    mockSessionStateValue.current = 'transit';
+
+    renderCustody();
+
+    await screen.findByText('Onsite Person');
+    // Holds 4 and 8 each have an arrestedAt; Hold 5's incident is empty.
+    // formatSmartDateTime renders time-only when arrestedAt is today, otherwise full date+time —
+    // accept both shapes so the test is stable regardless of when it runs.
+    const incidentTimeMatcher = /^(\d{1,2}\/\d{1,2}\/\d{4} )?\d{1,2}:\d{2} (AM|PM)$/;
+    expect(screen.getAllByText(incidentTimeMatcher)).toHaveLength(2);
+  });
 });

--- a/client/src/lesc/components/custody/Custody.test.jsx
+++ b/client/src/lesc/components/custody/Custody.test.jsx
@@ -290,10 +290,10 @@ describe('Custody', () => {
     renderCustody();
 
     await screen.findByText('Onsite Person');
-    // Hold 8 has arrivedAt → "Arrived at HH:MM"; Hold 5 has no arrivedAt → plain "Arrived" (defensive fallback).
+    // Hold 8 has arrivedAt → "Arrived HH:MM AM/PM"; Hold 5 has no arrivedAt → plain "Arrived" (defensive fallback).
     // Implementation gates the inline label and the expiry Title as mutually-exclusive,
     // so label presence implies timer suppression on those cards.
-    expect(screen.getByText(/^Arrived at \d{1,2}:\d{2} (AM|PM)$/)).toBeInTheDocument();
+    expect(screen.getByText(/^Arrived \d{1,2}:\d{2} (AM|PM)$/)).toBeInTheDocument();
     expect(screen.getByText('Arrived')).toBeInTheDocument();
   });
 
@@ -343,16 +343,15 @@ describe('Custody', () => {
     expect(screen.queryByRole('link', { name: /Incomplete Person/i })).not.toBeInTheDocument();
   });
 
-  it('renders the incident time alongside the address using the smart date/time format', async () => {
+  it('shows a Detained inline label with arrest time on DETAINED holds', async () => {
     mockSessionStateValue.current = 'transit';
 
     renderCustody();
 
-    await screen.findByText('Onsite Person');
-    // Holds 4 and 8 each have an arrestedAt; Hold 5's incident is empty.
-    // formatSmartDateTime renders time-only when arrestedAt is today, otherwise full date+time —
-    // accept both shapes so the test is stable regardless of when it runs.
-    const incidentTimeMatcher = /^(\d{1,2}\/\d{1,2}\/\d{4} )?\d{1,2}:\d{2} (AM|PM)$/;
-    expect(screen.getAllByText(incidentTimeMatcher)).toHaveLength(2);
+    await screen.findByText('Complete Person');
+    // Hold 4 is DETAINED with an arrestedAt → "Detained HH:MM AM/PM" inline next to the Hold ID.
+    // Holds 5 and 8 are ONSITE_AWAITING_TRANSFER → render "Arrived ..." instead, not "Detained".
+    expect(screen.getByText(/^Detained \d{1,2}:\d{2} (AM|PM)$/)).toBeInTheDocument();
+    expect(screen.queryAllByText(/^Detained /)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Closes #904.

Intent of this quick work is: show more context to help `CUSTODY` users at the Facility understand who's en route to the facility and how soon to expect people.

(We already have signal that deputies want more context. They've asked for live location of transports in progress, which is hard to deliver. This PR adds some context that's quick/easy to deliver.)

Changes:
- For Custody users, for cards in the `Transit` tab:
  - Before this PR: if the hold is already onsite_awaiting_transfer, show `Arrived X:XX AM`
  - In this PR: if the hold is not yet onsite_awaiting_transfer, show `Detained X:XX AM`.
- Below the person's age and sex, show the incident address (tappable to open a map). 
- Minor: removed the word `at` to preserve space. E.g. `Arrived at 4:32 AM` -> `Arrived 4:32 AM`

Note: It might be easy for a user to misinterpret the address as the hold's _home_ address, rather than the incident/arrest address. I considered a few alternatives but didn't find one that I thought was better overall. I figured users would get accustomed to the behavior and learn how to interpret it.



<img width="293" height="633" alt="IMG_0227" src="https://github.com/user-attachments/assets/7331c424-cada-4a7b-b642-93f625401c3b" />

