### PR TITLE
[Bugfix] Show 'Handed off' label only for holds that were actually handed off

### DIFF
--- a/client/src/lesc/components/Hold.jsx
+++ b/client/src/lesc/components/Hold.jsx
@@ -75,16 +75,16 @@ function Hold ({ incident, deflection, highlighted, onCancelClick, onDetailsClic
                 <Text size='md' c='red.6'>Canceled after expiry</Text>
               </>
             )}
-            {isHandedOff && (
-              <>
-                <Text size='md' c='gray.5'>•</Text>
-                <Text size='md' c='indigo.6'>Handed off</Text>
-              </>
-            )}
-            {!isHandedOff && isCustodyTransferred && (
+            {isCustodyTransferred && (
               <>
                 <Text size='md' c='gray.5'>•</Text>
                 <Text size='md' c='teal.5'>Transferred</Text>
+              </>
+            )}
+            {!isCustodyTransferred && isHandedOff && (
+              <>
+                <Text size='md' c='gray.5'>•</Text>
+                <Text size='md' c='indigo.6'>Handed off</Text>
               </>
             )}
           </Group>

--- a/client/src/lesc/components/Hold.test.jsx
+++ b/client/src/lesc/components/Hold.test.jsx
@@ -147,6 +147,28 @@ describe('Hold', () => {
     expect(screen.getByText(/Released on scene/)).toBeInTheDocument();
   });
 
+  it('shows "Transferred" rather than "Handed off" when both apply (lifecycle precedence)', () => {
+    // Scenario: officer handed off, got the hold back, arrived at RESET, transferred custody, then left.
+    // After leaving, currentOfficerId is cleared and wasHandedOffByMe is still true — but the most
+    // recent meaningful action was the custody transfer, so the badge should reflect that.
+    renderHold({
+      isHistory: true,
+      isHandedOff: true,
+      deflection: {
+        id: 10,
+        incidentId: 7,
+        status: 'ACTIVE',
+        subjectId: 22,
+        subjectStatus: 'AWAITING_INTAKE',
+        createdAt: '2026-03-14T15:00:00.000Z',
+        subject: { firstName: 'Person', lastName: 'X', sex: 'FEMALE', dateOfBirth: '1982-03-14' },
+      },
+    });
+
+    expect(screen.getByText('Transferred')).toBeInTheDocument();
+    expect(screen.queryByText('Handed off')).not.toBeInTheDocument();
+  });
+
   it('does not show the QR code in history for a handed-off onsite hold (issue #694)', () => {
     // Alice's view of a hold she handed to Bob after Bob arrived: still
     // status=ACTIVE + subjectStatus=ONSITE_AWAITING_TRANSFER, but shown in

--- a/client/src/lesc/components/HoldsHistory.jsx
+++ b/client/src/lesc/components/HoldsHistory.jsx
@@ -45,7 +45,7 @@ function HoldsHistory ({ deflections, isFetchingDeflections = false, currentUser
                   key={deflection.id}
                   deflection={deflection}
                   isHistory
-                  isHandedOff={!!currentUserId && !!deflection.currentOfficerId && deflection.currentOfficerId !== currentUserId}
+                  isHandedOff={!!deflection.wasHandedOffByMe && deflection.currentOfficerId !== currentUserId}
                   onDetailsClick={() => {
                     navigate(`/holds/${deflection.id}`);
                   }}

--- a/client/src/lesc/components/HoldsHistory.test.jsx
+++ b/client/src/lesc/components/HoldsHistory.test.jsx
@@ -134,7 +134,7 @@ describe('HoldsHistory', () => {
     expect(screen.getByText(/200 Main St/)).toBeInTheDocument();
   });
 
-  it('shows the "Handed off" badge when currentOfficerId is not the viewer', () => {
+  it('shows the "Handed off" badge when the viewer authored a handoff and no longer owns the hold', () => {
     renderHoldsHistory({
       currentUserId: 'alice',
       deflections: [
@@ -143,12 +143,53 @@ describe('HoldsHistory', () => {
           status: 'ACTIVE',
           subjectStatus: 'DETAINED',
           currentOfficerId: 'bob',
+          wasHandedOffByMe: true,
           incident: { id: 100, addressLine1: '1 A St', arrestedAt: '2026-03-14T12:00:00.000Z' },
         }),
       ],
     });
 
     expect(screen.getByText('Handed off')).toBeInTheDocument();
+  });
+
+  it('does not show the "Handed off" badge when the viewer never handed it off (regression for issue #880)', () => {
+    // Pre-fix, the badge fired purely on currentOfficerId mismatch — so admins
+    // (who see every deflection) and post-departure rows (currentOfficerId=null)
+    // would get false "Handed off" labels. The badge now requires a real Handoff
+    // row authored by the viewer.
+    renderHoldsHistory({
+      currentUserId: 'alice',
+      deflections: [
+        makeDeflection({
+          id: 1,
+          status: 'ACTIVE',
+          subjectStatus: 'DETAINED',
+          currentOfficerId: 'bob',
+          wasHandedOffByMe: false,
+          incident: { id: 100, addressLine1: '1 A St', arrestedAt: '2026-03-14T12:00:00.000Z' },
+        }),
+      ],
+    });
+
+    expect(screen.queryByText('Handed off')).not.toBeInTheDocument();
+  });
+
+  it('does not show "Handed off" if the viewer handed off and got the hold back', () => {
+    renderHoldsHistory({
+      currentUserId: 'alice',
+      deflections: [
+        makeDeflection({
+          id: 1,
+          status: 'ACTIVE',
+          subjectStatus: 'DETAINED',
+          currentOfficerId: 'alice',
+          wasHandedOffByMe: true,
+          incident: { id: 100, addressLine1: '1 A St', arrestedAt: '2026-03-14T12:00:00.000Z' },
+        }),
+      ],
+    });
+
+    expect(screen.queryByText('Handed off')).not.toBeInTheDocument();
   });
 
   it('navigates to /holds/{id} when a history row is clicked', () => {

--- a/server/models/deflection.js
+++ b/server/models/deflection.js
@@ -124,6 +124,7 @@ const DeflectionResponseSchema = DeflectionCreateSchema.extend({
   createdById: z.string().uuid(),
   createdBy: User.ResponseSchema.optional(),
   updatedAt: z.coerce.date(),
+  wasHandedOffByMe: z.boolean().optional(),
 });
 
 export class Deflection extends Base {

--- a/server/routes/api/deflections/list.js
+++ b/server/routes/api/deflections/list.js
@@ -145,12 +145,19 @@ export default async function (fastify) {
           propertyPhotos: true,
           ...(includeCurrentOfficer === 'true' ? { currentOfficer: true } : {}),
           ...(includeIncident === 'true' ? { incident: true } : {}),
+          ...(scope === 'history' ? { handoffs: { where: { fromOfficerId: request.user.id }, select: { id: true } } } : {}),
         },
       };
 
       const { records, total } = await fastify.prisma.deflection.paginate(options);
       records.forEach(record => {
         record.propertyPhotos = record.propertyPhotos.map(photo => new PropertyPhoto(photo));
+        if (scope === 'history') {
+          // Determine whether user previously handed off this hold.
+          // Only keep boolean; don't need to ship detailed handoff history over wire.
+          record.wasHandedOffByMe = (record.handoffs?.length ?? 0) > 0;
+          delete record.handoffs;
+        }
       });
       return reply.setPaginationHeaders(page, perPage, total).send(redactDeflectionsForUser(records, request.user));
     });

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -190,6 +190,63 @@ test('/api/deflections', async (t) => {
       });
     });
 
+    await t.test('scope=history attaches wasHandedOffByMe based on the Handoff table (issue #880)', async () => {
+      // Pre-fix the History view inferred "Handed off" from currentOfficerId mismatch,
+      // which lied for admins and for currentOfficerId=null after departure. The route
+      // now attaches a real per-user signal: wasHandedOffByMe = exists Handoff where
+      // fromOfficerId = viewer.id. We assert all three relevant cases.
+      const USER2_ID = 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5'; // regular.user@test.com
+      const FIELDUSER1_ID = '7a8b9c0d-1e2f-4a4b-8c6d-7e8f9a0b1c2d'; // field.noholds@test.com
+
+      // Case A: user2 hands off deflection 7 → fielduser1, then fielduser1 hands it back.
+      // Both users have a Handoff row authored by them, so both should see wasHandedOffByMe=true.
+      await prisma.handoff.create({
+        data: { deflectionId: 7, fromOfficerId: USER2_ID, toOfficerId: FIELDUSER1_ID },
+      });
+      await prisma.handoff.create({
+        data: { deflectionId: 7, fromOfficerId: FIELDUSER1_ID, toOfficerId: USER2_ID },
+      });
+
+      try {
+        const userResponse = await app.inject().get('/api/deflections?scope=history').headers(userHeaders);
+        assert.deepStrictEqual(userResponse.statusCode, StatusCodes.OK);
+        const userData = JSON.parse(userResponse.body);
+
+        const handedOffOne = userData.find(d => d.id === 7);
+        assert.ok(handedOffOne, 'expected deflection 7 in user2 history');
+        assert.strictEqual(handedOffOne.wasHandedOffByMe, true, 'user2 authored a handoff on 7');
+
+        // Deflection 6: ACTIVE/READY_FOR_INTAKE owned by user2 — appears in History
+        // (post-transfer active state), and user2 has never handed it off.
+        const neverHandedOff = userData.find(d => d.id === 6);
+        assert.ok(neverHandedOff, 'expected deflection 6 in user2 history');
+        assert.strictEqual(neverHandedOff.wasHandedOffByMe, false, 'user2 never handed off 6');
+
+        // fielduser1 also handed off 7 (back to user2) — they should also see the flag.
+        const fieldResponse = await app.inject().get('/api/deflections?scope=history').headers(cleanFieldHeaders);
+        assert.deepStrictEqual(fieldResponse.statusCode, StatusCodes.OK);
+        const fieldData = JSON.parse(fieldResponse.body);
+        const sevenForFielduser = fieldData.find(d => d.id === 7);
+        assert.ok(sevenForFielduser, 'expected deflection 7 in fielduser1 history (via Handoff relation)');
+        assert.strictEqual(sevenForFielduser.wasHandedOffByMe, true, 'fielduser1 authored a handoff on 7');
+
+        // The raw `handoffs` array used to derive the flag should be stripped from the response.
+        assert.ok(!('handoffs' in handedOffOne), 'handoffs include should not leak to clients');
+      } finally {
+        await prisma.handoff.deleteMany({ where: { deflectionId: 7 } });
+      }
+    });
+
+    await t.test('wasHandedOffByMe is omitted outside scope=history', async () => {
+      const response = await app.inject().get('/api/deflections').headers(userHeaders);
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+      assert.ok(data.length > 0);
+      for (const d of data) {
+        assert.ok(!('wasHandedOffByMe' in d), `wasHandedOffByMe leaked outside scope=history: ${JSON.stringify(d)}`);
+      }
+    });
+
     await t.test('active=true + subjectStatus filter: ownership OR does not clobber the subjectStatus OR', async () => {
       // user2 owns four active holds across subjectStatus DETAINED (4, 5), READY_FOR_INTAKE (6), RELEASED (7).
       // Asking for only the post-transfer ones must exclude the DETAINED holds — a regression test for the


### PR DESCRIPTION
Closes #880 

### Changes
- Previously: we inferred the `Handed off` label without directly checking the `Handoff` table. The logic was approximately: if your History call to `list.js` returns a hold, and you're not the current officer on the hold, then you handed it off. This logic was brittle, and turned out to be incorrect for admins (whose History call returns _all_ deflections.)
- In this PR: Only show the `Handed off` label for deflections where we have explicitly seen a `Handoff` row where the current user handed this deflection off.

### Not in this PR:
- This PR **does not** change the _scope_ of the History call for admins. I originally said that we should reduce this so that the History view behaves in a more normal way for Admins (and make up for it by providing the right kind of global view for admins elsewhere.) I still think that's directionally correct, but I realized I could (and should) fix this bug more narrowly. We can treat "query behavior for admin users" as a separate problem for a separate PR.
- Note: until we do change the admin behavior, I expect users with admin privileges may continue to see confusing/misleading things in the History view. I'll file a separate ticket for that.

