### PR TITLE
Show warning banner in non-prod environments

### DIFF
--- a/client/src/AppLayout.jsx
+++ b/client/src/AppLayout.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { AppShell } from '@mantine/core';
+import { AppShell, Box } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { matchPath, useLocation, useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
@@ -8,12 +8,20 @@ import Header from './Header';
 
 import Api from './Api';
 import AppRoutes from './AppRoutes';
+import EnvironmentBanner, {
+  ENVIRONMENT_BANNER_HEIGHT,
+  shouldShowEnvironmentBanner,
+} from './components/EnvironmentBanner';
 import { useFacilityContext } from './FacilityContext';
+import { useStaticContext } from './StaticContext';
+
+const HEADER_HEIGHT = 80;
 
 function AppLayout () {
   const [opened, { close, toggle }] = useDisclosure();
   const navigate = useNavigate();
   const { facility, setFacility } = useFacilityContext();
+  const { env } = useStaticContext();
   const queryClient = useQueryClient();
 
   async function logout (event) {
@@ -36,6 +44,13 @@ function AppLayout () {
     '/invites/*',
     '/register',
   ].some(path => matchPath(path, location.pathname));
+  const showHeader = !isHeaderHidden;
+  const showBanner = shouldShowEnvironmentBanner(env);
+  // Banner lives inside AppShell.Header so Mantine's sticky/positioning math
+  // accounts for it (otherwise the header overlays the banner on mobile).
+  // Header height stretches to fit both when both are visible.
+  const totalHeaderHeight =
+    (showBanner ? ENVIRONMENT_BANNER_HEIGHT : 0) + (showHeader ? HEADER_HEIGHT : 0);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -43,14 +58,23 @@ function AppLayout () {
 
   return (
     <AppShell
-      header={{ height: 80 }}
+      header={{ height: totalHeaderHeight }}
       navbar={{ width: 300, breakpoint: 'sm', collapsed: { desktop: true, mobile: !opened } }}
       padding='sm'
-      bg={!isHeaderHidden && facility ? 'gray.0' : 'white'}
+      bg={showHeader && facility ? 'gray.0' : 'white'}
     >
-      {!isHeaderHidden && (
-        <AppShell.Header bg={facility ? 'gray.0' : 'white'} withBorder={!facility}>
-          <Header opened={opened} close={close} toggle={toggle} logout={logout} />
+      {totalHeaderHeight > 0 && (
+        <AppShell.Header
+          bg={facility ? 'gray.0' : 'white'}
+          withBorder={showHeader && !facility}
+          style={{ display: 'flex', flexDirection: 'column' }}
+        >
+          {showBanner && <EnvironmentBanner />}
+          {showHeader && (
+            <Box style={{ flex: 1, minHeight: 0 }}>
+              <Header opened={opened} close={close} toggle={toggle} logout={logout} />
+            </Box>
+          )}
         </AppShell.Header>
       )}
       <AppShell.Main px={0}>

--- a/client/src/FacilitySelector.jsx
+++ b/client/src/FacilitySelector.jsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Head } from '@unhead/react';
 
 import Api from './Api';
+import EnvironmentBanner from './components/EnvironmentBanner';
 import { useFacilityContext } from './FacilityContext';
 
 function FacilitySelector ({ children }) {
@@ -28,6 +29,9 @@ function FacilitySelector ({ children }) {
         <Head>
           <title>Facility Selector</title>
         </Head>
+        {/* This branch bypasses AppLayout, so we have to mount the env banner
+            ourselves to cover real users who land here on a non-prod env. */}
+        <EnvironmentBanner />
         <Container py='xl'>
           <Stack align='center' gap='xl'>
             <Stack align='center' gap='md'>

--- a/client/src/StaticContext.js
+++ b/client/src/StaticContext.js
@@ -9,6 +9,8 @@ export const defaultValue = {
     VITE_FEATURE_REGISTRATION: import.meta.env.VITE_FEATURE_REGISTRATION,
     VITE_POSTHOG_KEY: import.meta.env.VITE_POSTHOG_KEY,
     VITE_POSTHOG_HOST: import.meta.env.VITE_POSTHOG_HOST,
+    VITE_ENVIRONMENT_LABEL: import.meta.env.VITE_ENVIRONMENT_LABEL,
+    VITE_PRODUCTION_URL: import.meta.env.VITE_PRODUCTION_URL,
   },
   facility: {},
 };

--- a/client/src/StaticContext.js
+++ b/client/src/StaticContext.js
@@ -10,7 +10,7 @@ export const defaultValue = {
     VITE_POSTHOG_KEY: import.meta.env.VITE_POSTHOG_KEY,
     VITE_POSTHOG_HOST: import.meta.env.VITE_POSTHOG_HOST,
     VITE_ENVIRONMENT_LABEL: import.meta.env.VITE_ENVIRONMENT_LABEL,
-    VITE_PRODUCTION_URL: import.meta.env.VITE_PRODUCTION_URL,
+    VITE_PRODUCTION_URL_OVERRIDE: import.meta.env.VITE_PRODUCTION_URL_OVERRIDE,
   },
   facility: {},
 };

--- a/client/src/components/EnvironmentBanner.jsx
+++ b/client/src/components/EnvironmentBanner.jsx
@@ -1,0 +1,60 @@
+import { Anchor, Box, Group, Text } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+import { useStaticContext } from '@/StaticContext';
+
+// Banner height in px. Exported so AppLayout can reserve matching header
+// space; otherwise AppShell.Header pins to viewport top and the banner gets
+// rendered behind it on mobile.
+export const ENVIRONMENT_BANNER_HEIGHT = 40;
+
+// Single source of truth for the visibility check. AppLayout uses this to
+// decide whether to add the banner's height to the AppShell header config;
+// the component itself short-circuits to null with the same predicate.
+export function shouldShowEnvironmentBanner (env) {
+  return env?.VITE_ENVIRONMENT_LABEL !== 'PROD';
+}
+
+// Surfaces a non-dismissable warning across the top of every page when the
+// build is anything other than production (issue #760). Default-deny: only an
+// explicit VITE_ENVIRONMENT_LABEL=PROD hides it. A misconfigured non-prod
+// deploy without the env var loudly shows the banner — that's the safe
+// failure mode we want.
+function EnvironmentBanner () {
+  const { env } = useStaticContext();
+  const prodUrl = env?.VITE_PRODUCTION_URL;
+
+  if (!shouldShowEnvironmentBanner(env)) return null;
+
+  return (
+    <Box
+      bg='yellow.4'
+      h={ENVIRONMENT_BANNER_HEIGHT}
+      px='md'
+      role='alert'
+      data-testid='environment-banner'
+      style={{ borderBottom: '2px solid var(--mantine-color-yellow-7)', overflow: 'hidden' }}
+    >
+      <Group justify='center' gap='sm' wrap='nowrap' h='100%' style={{ minWidth: 0 }}>
+        <IconAlertTriangle size={20} color='var(--mantine-color-dark-7)' style={{ flexShrink: 0 }} />
+        <Text fw={700} c='dark.9' size='sm' style={{ flexShrink: 0 }}>
+          This is a test site.
+        </Text>
+        {prodUrl && (
+          <Anchor
+            href={prodUrl}
+            fw={700}
+            c='dark.9'
+            size='sm'
+            td='underline'
+            style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}
+          >
+            Go to CareConnect →
+          </Anchor>
+        )}
+      </Group>
+    </Box>
+  );
+}
+
+export default EnvironmentBanner;

--- a/client/src/components/EnvironmentBanner.jsx
+++ b/client/src/components/EnvironmentBanner.jsx
@@ -8,6 +8,12 @@ import { useStaticContext } from '@/StaticContext';
 // rendered behind it on mobile.
 export const ENVIRONMENT_BANNER_HEIGHT = 40;
 
+// Fallback production URL surfaced in the banner. We accept VITE_PRODUCTION_URL
+// as an override (e.g. for staging environments that should point to a
+// different "prod"), but fall back to this constant so a misconfigured deploy
+// never strands users on a non-prod page without a link out.
+const DEFAULT_PRODUCTION_URL = 'https://reset.careconnect.sf.gov/login';
+
 // Single source of truth for the visibility check. AppLayout uses this to
 // decide whether to add the banner's height to the AppShell header config;
 // the component itself short-circuits to null with the same predicate.
@@ -22,7 +28,7 @@ export function shouldShowEnvironmentBanner (env) {
 // failure mode we want.
 function EnvironmentBanner () {
   const { env } = useStaticContext();
-  const prodUrl = env?.VITE_PRODUCTION_URL;
+  const prodUrl = env?.VITE_PRODUCTION_URL || DEFAULT_PRODUCTION_URL;
 
   if (!shouldShowEnvironmentBanner(env)) return null;
 
@@ -40,18 +46,16 @@ function EnvironmentBanner () {
         <Text fw={700} c='dark.9' size='sm' style={{ flexShrink: 0 }}>
           This is a test site.
         </Text>
-        {prodUrl && (
-          <Anchor
-            href={prodUrl}
-            fw={700}
-            c='dark.9'
-            size='sm'
-            td='underline'
-            style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}
-          >
-            Go to CareConnect →
-          </Anchor>
-        )}
+        <Anchor
+          href={prodUrl}
+          fw={700}
+          c='dark.9'
+          size='sm'
+          td='underline'
+          style={{ whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', minWidth: 0 }}
+        >
+          Go to CareConnect →
+        </Anchor>
       </Group>
     </Box>
   );

--- a/client/src/components/EnvironmentBanner.jsx
+++ b/client/src/components/EnvironmentBanner.jsx
@@ -8,10 +8,10 @@ import { useStaticContext } from '@/StaticContext';
 // rendered behind it on mobile.
 export const ENVIRONMENT_BANNER_HEIGHT = 40;
 
-// Fallback production URL surfaced in the banner. We accept VITE_PRODUCTION_URL
-// as an override (e.g. for staging environments that should point to a
-// different "prod"), but fall back to this constant so a misconfigured deploy
-// never strands users on a non-prod page without a link out.
+// Fallback production URL surfaced in the banner. VITE_PRODUCTION_URL_OVERRIDE
+// can override this at deploy time (e.g. a staging environment that wants to
+// point users at a different "prod"), but the fallback ensures a misconfigured
+// deploy never strands users on a non-prod page without a link out.
 const DEFAULT_PRODUCTION_URL = 'https://reset.careconnect.sf.gov/login';
 
 // Single source of truth for the visibility check. AppLayout uses this to
@@ -28,7 +28,7 @@ export function shouldShowEnvironmentBanner (env) {
 // failure mode we want.
 function EnvironmentBanner () {
   const { env } = useStaticContext();
-  const prodUrl = env?.VITE_PRODUCTION_URL || DEFAULT_PRODUCTION_URL;
+  const prodUrl = env?.VITE_PRODUCTION_URL_OVERRIDE || DEFAULT_PRODUCTION_URL;
 
   if (!shouldShowEnvironmentBanner(env)) return null;
 

--- a/client/src/components/EnvironmentBanner.test.jsx
+++ b/client/src/components/EnvironmentBanner.test.jsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { MantineProvider } from '@mantine/core';
+
+import EnvironmentBanner from './EnvironmentBanner';
+import { staticContext } from '@/StaticContext';
+
+function renderWithEnv (env) {
+  return render(
+    <MantineProvider>
+      <staticContext.Provider value={{ env }}>
+        <EnvironmentBanner />
+      </staticContext.Provider>
+    </MantineProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('EnvironmentBanner', () => {
+  it('renders nothing when label is PROD', () => {
+    renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'PROD', VITE_PRODUCTION_URL: 'https://reset.example.com' });
+    expect(screen.queryByTestId('environment-banner')).not.toBeInTheDocument();
+  });
+
+  it('renders the test-site warning when no label is set', () => {
+    renderWithEnv({});
+    expect(screen.getByTestId('environment-banner')).toBeInTheDocument();
+    expect(screen.getByText(/this is a test site/i)).toBeInTheDocument();
+  });
+
+  it('renders the same copy regardless of label name', () => {
+    // Copy is layperson-facing and intentionally does not vary by env label.
+    renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'DEV' });
+    expect(screen.getByText(/this is a test site/i)).toBeInTheDocument();
+  });
+
+  it('renders the production URL as a link when configured', () => {
+    renderWithEnv({
+      VITE_ENVIRONMENT_LABEL: 'STAGING',
+      VITE_PRODUCTION_URL: 'https://reset.careconnect.example.com',
+    });
+    const link = screen.getByRole('link', { name: /go to careconnect/i });
+    expect(link).toHaveAttribute('href', 'https://reset.careconnect.example.com');
+  });
+
+  it('omits the link when no production URL is configured', () => {
+    renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'DEV' });
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  // Anything that's not the literal string PROD must show the banner. This
+  // protects against case-sensitivity surprises (e.g. someone typing 'prod').
+  it('still shows the banner for case variants of PROD', () => {
+    renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'prod' });
+    expect(screen.getByTestId('environment-banner')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/EnvironmentBanner.test.jsx
+++ b/client/src/components/EnvironmentBanner.test.jsx
@@ -38,7 +38,7 @@ describe('EnvironmentBanner', () => {
     expect(screen.getByText(/this is a test site/i)).toBeInTheDocument();
   });
 
-  it('renders the production URL as a link when configured', () => {
+  it('uses VITE_PRODUCTION_URL as the link target when configured', () => {
     renderWithEnv({
       VITE_ENVIRONMENT_LABEL: 'STAGING',
       VITE_PRODUCTION_URL: 'https://reset.careconnect.example.com',
@@ -47,9 +47,14 @@ describe('EnvironmentBanner', () => {
     expect(link).toHaveAttribute('href', 'https://reset.careconnect.example.com');
   });
 
-  it('omits the link when no production URL is configured', () => {
+  it('falls back to a hardcoded URL when no override is configured', () => {
+    // Defense in depth: a misconfigured deploy without VITE_PRODUCTION_URL must
+    // still surface a working escape link, otherwise users get stranded on a
+    // banner that says "go to prod" with no way to actually get there.
     renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'DEV' });
-    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /go to careconnect/i });
+    expect(link).toHaveAttribute('href', expect.stringMatching(/^https?:\/\//));
+    expect(link.getAttribute('href')).not.toBe('');
   });
 
   // Anything that's not the literal string PROD must show the banner. This

--- a/client/src/components/EnvironmentBanner.test.jsx
+++ b/client/src/components/EnvironmentBanner.test.jsx
@@ -22,7 +22,7 @@ afterEach(() => {
 
 describe('EnvironmentBanner', () => {
   it('renders nothing when label is PROD', () => {
-    renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'PROD', VITE_PRODUCTION_URL: 'https://reset.example.com' });
+    renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'PROD', VITE_PRODUCTION_URL_OVERRIDE: 'https://reset.example.com' });
     expect(screen.queryByTestId('environment-banner')).not.toBeInTheDocument();
   });
 
@@ -38,17 +38,18 @@ describe('EnvironmentBanner', () => {
     expect(screen.getByText(/this is a test site/i)).toBeInTheDocument();
   });
 
-  it('uses VITE_PRODUCTION_URL as the link target when configured', () => {
+  it('uses VITE_PRODUCTION_URL_OVERRIDE as the link target when configured', () => {
+    // (sanity: the override wins over the hardcoded fallback)
     renderWithEnv({
       VITE_ENVIRONMENT_LABEL: 'STAGING',
-      VITE_PRODUCTION_URL: 'https://reset.careconnect.example.com',
+      VITE_PRODUCTION_URL_OVERRIDE: 'https://reset.careconnect.example.com',
     });
     const link = screen.getByRole('link', { name: /go to careconnect/i });
     expect(link).toHaveAttribute('href', 'https://reset.careconnect.example.com');
   });
 
   it('falls back to a hardcoded URL when no override is configured', () => {
-    // Defense in depth: a misconfigured deploy without VITE_PRODUCTION_URL must
+    // Defense in depth: a misconfigured deploy without VITE_PRODUCTION_URL_OVERRIDE must
     // still surface a working escape link, otherwise users get stranded on a
     // banner that says "go to prod" with no way to actually get there.
     renderWithEnv({ VITE_ENVIRONMENT_LABEL: 'DEV' });

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,11 +1,21 @@
 import { Box, Container } from '@mantine/core';
 import classNames from 'classnames';
 
+import { useStaticContext } from '@/StaticContext';
+import { ENVIRONMENT_BANNER_HEIGHT, shouldShowEnvironmentBanner } from '@/components/EnvironmentBanner';
+
 import classes from './Header.module.css';
 
+// This is the page-level "fixed at viewport top" header that some detail/form
+// pages use as their own custom header (with a back button, etc.). It would
+// otherwise overlay the EnvironmentBanner because both want to live at top: 0.
+// We offset by the banner's height when the banner is showing so the banner
+// stays visible above this header.
 function Header ({ children, className }) {
+  const { env } = useStaticContext();
+  const top = shouldShowEnvironmentBanner(env) ? ENVIRONMENT_BANNER_HEIGHT : 0;
   return (
-    <Box className={classNames(classes.header, className)}>
+    <Box className={classNames(classes.header, className)} style={{ top }}>
       <Container className={classes.headerContainer}>
         {children}
       </Container>


### PR DESCRIPTION
Closes #760 , #912 

## In this PR

The problem this tries to solve is: "real users keep accidentally hitting the staging URL and being confused about why the data is not there, or why they can no longer log in. let's make it extremely obvious that they're not on the right URL, and easy to go to the right URL."

- We check for an environment variable `VITE_ENVIRONMENT_LABEL=PROD`, which tells us that our current environment is production.
- If that exists, do nothing.
- If it doesn't exist, display a prominent, un-dismissable banner on every page that says `This is a test site` and provides a link to production CareConnect.
- If `VITE_PRODUCTION_URL_OVERRIDE` is set, the link will use the URL provided there. Otherwise it falls back to the primary Production URL `https://reset.careconnect.sf.gov/login`, hard-coded.


Note that the env vars are **build-time** for Vite — they must be set when the deploy runs `npm run build`, not at server runtime.

### Deployer instructions (Production)
Set `VITE_ENVIRONMENT_LABEL=PROD`. This is the only way to hide the banner. Any other value, or omitting it, shows the banner.

### Deployer instructions (Dev/Staging/Etc)
Leave `VITE_ENVIRONMENT_LABEL` unset, or set it to anything except `PROD`

### Developer instructions

If you do nothing, then you will see the yellow banner in your local development and testing.

**You may wish** to hide the banner locally, to get a more accurate view of what a real user would see.) To do this:
1. In your local `client/.env`, add: `VITE_ENVIRONMENT_LABEL=PROD`.
2. Restart your docker container to pick up the env change.

## Screenshots

<img width="293" height="633" alt="IMG_0240" src="https://github.com/user-attachments/assets/064cda93-00ba-413d-8358-f8dcae7fcc0b" />
<img width="293" height="633" alt="IMG_0239" src="https://github.com/user-attachments/assets/4aa78d28-c438-431f-8e1b-113123f2d272" />
<img width="293" height="633" alt="IMG_0238" src="https://github.com/user-attachments/assets/3b603e76-3500-4dbc-8d2e-cfd3be1e47e2" />
<img width="293" height="633" alt="IMG_0237" src="https://github.com/user-attachments/assets/0688d302-ffd8-4bf6-9ea1-d78796c5e6f5" />
<img width="293" height="633" alt="IMG_0236" src="https://github.com/user-attachments/assets/a5402154-2c1d-4853-ba29-be57ea098ebe" />
<img width="293" height="633" alt="IMG_0235" src="https://github.com/user-attachments/assets/5759ba88-624b-49ee-9cf4-331ae1861755" />

## Caveats
- The banner appears on almost every page in the app. I deliberately left out full-screen modals and the full-page camera views. Didn't seem necessary to mess with the layout on those pages.
- Right now this designed as an extremely binary feature. It crudely differentiates between "prod" and "non-prod", and is focused on **minimizing confusion for laypeople who accidentally hit a non-prod page**. It doesn't show fine distinctions between environments.
- I could have called the flag `HIDE_ENVIRONMENT_BANNER` (with `true`/`false`) instead of asking for a `VITE_ENVIRONMENT_LABEL`. But in the future it's possible we'd wire additional functionality that's environment-sensitive, or want to respond in a more granular way to the different environments, or make use of the provided label. So I did it this way.