### PR TITLE
Shows person details after release (#914)

### DIFF
--- a/client/src/lesc/components/care/CareCard.test.jsx
+++ b/client/src/lesc/components/care/CareCard.test.jsx
@@ -101,9 +101,27 @@ describe('CareCard', () => {
     expect(screen.queryByRole('button', { name: 'Start exit' })).not.toBeInTheDocument();
   });
 
-  it('shows no buttons for EXITED', () => {
+  it('shows Details for EXITED without legal release', () => {
     renderCard({ deflection: buildDeflection({ subjectStatus: 'EXITED' }) });
-    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Update status' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start exit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Finish exit' })).not.toBeInTheDocument();
+  });
+
+  it('shows Details for EXITED after legal release', () => {
+    renderCard({
+      deflection: buildDeflection({
+        subjectStatus: 'EXITED',
+        releasedAt: '2026-05-05T12:00:00.000Z',
+        exitedAt: '2026-05-05T18:00:00.000Z',
+      }),
+    });
+
+    expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start exit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Finish exit' })).not.toBeInTheDocument();
   });
 
   it('calls onCompleteIntake when Update status is clicked', () => {

--- a/client/src/lesc/components/care/careFlow.test.js
+++ b/client/src/lesc/components/care/careFlow.test.js
@@ -20,20 +20,41 @@ afterEach(() => {
 });
 
 describe('Care flow unit tests', () => {
-  it('hides Details for all EXITED records', () => {
+  it('shows Details for pre-release and post-release care records', () => {
+    expect(
+      shouldShowCareCardViewDetails({
+        subjectStatus: 'IN_MEDICAL_INTAKE',
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowCareCardViewDetails({
+        subjectStatus: 'IN_CHAIR',
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowCareCardViewDetails({
+        subjectStatus: 'RELEASED',
+        releasedAt: '2026-05-05T12:00:00.000Z',
+      })
+    ).toBe(true);
+
     expect(
       shouldShowCareCardViewDetails({
         subjectStatus: 'EXITED',
         exitDestination: 'JAIL',
       })
-    ).toBe(false);
+    ).toBe(true);
 
     expect(
       shouldShowCareCardViewDetails({
         subjectStatus: 'EXITED',
         exitDestination: 'HOSPITAL',
+        releasedAt: '2026-05-05T12:00:00.000Z',
+        exitedAt: '2026-05-05T18:00:00.000Z',
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('detects persisted exit details only when all required fields exist', () => {

--- a/client/src/lesc/components/care/careFlowUtils.js
+++ b/client/src/lesc/components/care/careFlowUtils.js
@@ -14,7 +14,7 @@ function isTransferredToHospital (deflection) {
 }
 
 export function shouldShowCareCardViewDetails (deflection) {
-  return deflection?.subjectStatus !== 'EXITED';
+  return ['IN_MEDICAL_INTAKE', 'IN_CHAIR', 'RELEASED', 'EXITED'].includes(deflection?.subjectStatus);
 }
 
 export function hasPersistedExitDetails (deflection) {


### PR DESCRIPTION
## Summary

- Allow Care users to open the usual details view for post-release person records.
- Show the `Details` button on Care cards for `EXITED` records, including people who exited without legal release and people who were legally released then exited.

Closes #914 