### PR TITLE
Adds release narrative at SFSO request (#919)

### DIFF
--- a/server/lib/forms/849b/releaseNarrative.js
+++ b/server/lib/forms/849b/releaseNarrative.js
@@ -1,4 +1,4 @@
-import { firstLastName } from '../shared/formUtils.js';
+import { firstInitialLastName, firstLastName } from '../shared/formUtils.js';
 
 const SEE_ABOVE = 'SEE ABOVE';
 const MEDICAL_STAFF_BLANK = '_'.repeat(30);
@@ -10,12 +10,6 @@ function normalizeValue (value) {
     normalized = value.trim();
   }
   return normalized || null;
-}
-
-function firstInitialLastNameNoPeriod (person) {
-  const firstInitial = person?.firstName?.trim()?.charAt(0)?.toUpperCase();
-  const lastName = normalizeValue(person?.lastName);
-  return [firstInitial, lastName].filter(Boolean).join(' ');
 }
 
 function formatReleaseTime (date) {
@@ -65,7 +59,7 @@ export function buildSobered849bReleaseNarrativeAppendix ({
   subject,
 } = {}) {
   const subjectName = firstLastName(subject);
-  const deputyName = firstInitialLastNameNoPeriod(releasingDeputy);
+  const deputyName = firstInitialLastName(releasingDeputy, { period: false });
   const deputyStar = normalizeValue(releasingDeputy?.badgeNumber) || '';
 
   return `At approximately ${formatReleaseTime(releasedAt)} hours on ${formatReleaseDate(releasedAt)}, Connections medical staff, ${MEDICAL_STAFF_BLANK} , determined that the subject, ${subjectName}, was able to care for themselves and voice their needs appropriately. Deputy ${deputyName}, #${deputyStar}, issued ${subjectName} a certificate of release stating that they were just detained and not under arrest.`;

--- a/server/lib/forms/849b/releaseNarrative.js
+++ b/server/lib/forms/849b/releaseNarrative.js
@@ -1,4 +1,6 @@
 const SEE_ABOVE = 'SEE ABOVE';
+const MEDICAL_STAFF_BLANK = '_'.repeat(30);
+const FORM_TIMEZONE = 'America/Los_Angeles';
 
 function normalizeValue (value) {
   let normalized = value;
@@ -6,6 +8,42 @@ function normalizeValue (value) {
     normalized = value.trim();
   }
   return normalized || null;
+}
+
+function firstInitialLastNameNoPeriod (person) {
+  const firstInitial = person?.firstName?.trim()?.charAt(0)?.toUpperCase();
+  const lastName = normalizeValue(person?.lastName);
+  return [firstInitial, lastName].filter(Boolean).join(' ');
+}
+
+function firstLastName (person) {
+  return [normalizeValue(person?.firstName), normalizeValue(person?.lastName)].filter(Boolean).join(' ');
+}
+
+function formatReleaseTime (date) {
+  if (!date) return 'XX:XX';
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return 'XX:XX';
+
+  return d.toLocaleString('en-US', {
+    timeZone: FORM_TIMEZONE,
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).replace('24:', '00:');
+}
+
+function formatReleaseDate (date) {
+  if (!date) return 'MM/DD/YY';
+  const d = new Date(date);
+  if (isNaN(d.getTime())) return 'MM/DD/YY';
+
+  return d.toLocaleString('en-US', {
+    timeZone: FORM_TIMEZONE,
+    month: '2-digit',
+    day: '2-digit',
+    year: '2-digit',
+  });
 }
 
 export function build849bReleaseNarrative ({ caseNumber, cadNumber, behavior } = {}) {
@@ -20,5 +58,43 @@ export function build849bReleaseNarrative ({ caseNumber, cadNumber, behavior } =
     '',
     'The Officer who brought the person to RESET recorded the following observations on the 647(f) documentation:',
     behaviorNarrative,
+  ].join('\n');
+}
+
+export function buildSobered849bReleaseNarrativeAppendix ({
+  releasedAt,
+  releasingDeputy,
+  subject,
+} = {}) {
+  const subjectName = firstLastName(subject);
+  const deputyName = firstInitialLastNameNoPeriod(releasingDeputy);
+  const deputyStar = normalizeValue(releasingDeputy?.badgeNumber) || '';
+
+  return `At approximately ${formatReleaseTime(releasedAt)} hours on ${formatReleaseDate(releasedAt)}, Connections medical staff, ${MEDICAL_STAFF_BLANK} , determined that the subject, ${subjectName}, was able to care for themselves and voice their needs appropriately. Deputy ${deputyName}, #${deputyStar}, issued ${subjectName} a certificate of release stating that they were just detained and not under arrest.`;
+}
+
+export function appendSobered849bReleaseNarrative ({
+  releaseNarrative,
+  caseNumber,
+  cadNumber,
+  behavior,
+  releasedAt,
+  releasingDeputy,
+  subject,
+} = {}) {
+  const baseNarrative = normalizeValue(releaseNarrative) || build849bReleaseNarrative({
+    caseNumber,
+    cadNumber,
+    behavior,
+  });
+
+  return [
+    baseNarrative,
+    '',
+    buildSobered849bReleaseNarrativeAppendix({
+      releasedAt,
+      releasingDeputy,
+      subject,
+    }),
   ].join('\n');
 }

--- a/server/lib/forms/849b/releaseNarrative.js
+++ b/server/lib/forms/849b/releaseNarrative.js
@@ -1,3 +1,5 @@
+import { firstLastName } from '../shared/formUtils.js';
+
 const SEE_ABOVE = 'SEE ABOVE';
 const MEDICAL_STAFF_BLANK = '_'.repeat(30);
 const FORM_TIMEZONE = 'America/Los_Angeles';
@@ -14,10 +16,6 @@ function firstInitialLastNameNoPeriod (person) {
   const firstInitial = person?.firstName?.trim()?.charAt(0)?.toUpperCase();
   const lastName = normalizeValue(person?.lastName);
   return [firstInitial, lastName].filter(Boolean).join(' ');
-}
-
-function firstLastName (person) {
-  return [normalizeValue(person?.firstName), normalizeValue(person?.lastName)].filter(Boolean).join(' ');
 }
 
 function formatReleaseTime (date) {

--- a/server/lib/forms/shared/formUtils.js
+++ b/server/lib/forms/shared/formUtils.js
@@ -47,7 +47,7 @@ export function joinWords (...words) {
 }
 
 export function firstLastName (obj) {
-  return [obj?.firstName, obj?.lastName].filter(Boolean).join(' ');
+  return [obj?.firstName?.trim(), obj?.lastName?.trim()].filter(Boolean).join(' ');
 }
 
 export function firstInitialLastName (obj) {

--- a/server/lib/forms/shared/formUtils.js
+++ b/server/lib/forms/shared/formUtils.js
@@ -50,9 +50,12 @@ export function firstLastName (obj) {
   return [obj?.firstName?.trim(), obj?.lastName?.trim()].filter(Boolean).join(' ');
 }
 
-export function firstInitialLastName (obj) {
-  const firstInitial = obj?.firstName?.trim()?.charAt(0);
-  return [firstInitial && `${firstInitial}.`, obj?.lastName].filter(Boolean).join(' ');
+export function firstInitialLastName (obj, { period = true } = {}) {
+  const firstInitial = obj?.firstName?.trim()?.charAt(0)?.toUpperCase();
+  return [
+    firstInitial && (period ? `${firstInitial}.` : firstInitial),
+    obj?.lastName?.trim(),
+  ].filter(Boolean).join(' ');
 }
 
 export function streetCityState (obj) {

--- a/server/routes/api/deflections/release.js
+++ b/server/routes/api/deflections/release.js
@@ -139,9 +139,7 @@ export default async function (fastify, opts) {
           }
 
           const now = new Date();
-          const releasingDeputy = await tx.user.findUnique({
-            where: { id: request.user.id },
-          });
+          const releasingDeputy = request.user;
           const previousSubjectStatus = deflection.subjectStatus;
           // `sobered` releases from a pre-chair hold finalize immediately as
           // EXITED. Medical, behavioral-health, and "other" releases also

--- a/server/routes/api/deflections/release.js
+++ b/server/routes/api/deflections/release.js
@@ -6,6 +6,7 @@ import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { conflictError } from '#lib/httpErrors.js';
 import { queueReleaseFormsEmail } from '#lib/forms/formEmailJobs.js';
+import { appendSobered849bReleaseNarrative } from '#lib/forms/849b/releaseNarrative.js';
 
 const RELEASABLE_STATUSES = [
   Deflection.SubjectStatus.AWAITING_INTAKE,
@@ -127,6 +128,10 @@ export default async function (fastify, opts) {
           // re-fetch deflection after lock
           deflection = await tx.deflection.findUnique({
             where: { id },
+            include: {
+              incident: true,
+              subject: true,
+            },
           });
 
           if (!RELEASABLE_STATUSES.includes(deflection.subjectStatus)) {
@@ -134,6 +139,9 @@ export default async function (fastify, opts) {
           }
 
           const now = new Date();
+          const releasingDeputy = await tx.user.findUnique({
+            where: { id: request.user.id },
+          });
           const previousSubjectStatus = deflection.subjectStatus;
           // `sobered` releases from a pre-chair hold finalize immediately as
           // EXITED. Medical, behavioral-health, and "other" releases also
@@ -186,6 +194,19 @@ export default async function (fastify, opts) {
               releaseReason,
               otherReleaseReason: isOtherRelease ? otherReleaseReason : null,
               otherReleaseDestination: isOtherRelease ? otherReleaseDestination : null,
+              ...(releaseReason === 'SOBERED'
+                ? {
+                    releaseNarrative: appendSobered849bReleaseNarrative({
+                      releaseNarrative: deflection.releaseNarrative,
+                      caseNumber: deflection.incident?.caseNumber,
+                      cadNumber: deflection.incident?.cadNumber,
+                      behavior: deflection.behavior,
+                      releasedAt: now,
+                      releasingDeputy,
+                      subject: deflection.subject,
+                    }),
+                  }
+                : {}),
               ...(releaseFinalizesAsExited
                 ? {
                     exitedAt: now,

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -3,6 +3,50 @@ import * as assert from 'node:assert';
 import { PDFDocument } from 'pdf-lib';
 
 import form849b from '#lib/forms/849b/index.js';
+import {
+  appendSobered849bReleaseNarrative,
+  buildSobered849bReleaseNarrativeAppendix,
+} from '#lib/forms/849b/releaseNarrative.js';
+
+test('849b sobered release appendix includes medical staff blank and release details', () => {
+  const appendix = buildSobered849bReleaseNarrativeAppendix({
+    releasedAt: new Date('2026-05-05T20:15:00.000Z'),
+    subject: {
+      firstName: 'Swilly',
+      lastName: 'Willy',
+    },
+    releasingDeputy: {
+      firstName: 'Test',
+      lastName: 'SFSO',
+      badgeNumber: '5678',
+    },
+  });
+
+  assert.strictEqual(
+    appendix,
+    'At approximately 13:15 hours on 05/05/26, Connections medical staff, ______________________________ , determined that the subject, Swilly Willy, was able to care for themselves and voice their needs appropriately. Deputy T SFSO, #5678, issued Swilly Willy a certificate of release stating that they were just detained and not under arrest.'
+  );
+});
+
+test('849b sobered release appendix is appended to the stored release narrative', () => {
+  const narrative = appendSobered849bReleaseNarrative({
+    releaseNarrative: 'Existing release narrative.',
+    releasedAt: new Date('2026-05-05T20:15:00.000Z'),
+    subject: {
+      firstName: 'Swilly',
+      lastName: 'Willy',
+    },
+    releasingDeputy: {
+      firstName: 'Test',
+      lastName: 'SFSO',
+      badgeNumber: '5678',
+    },
+  });
+
+  assert.ok(narrative.startsWith('Existing release narrative.\n\nAt approximately 13:15 hours'));
+  assert.match(narrative, /_{30}/);
+  assert.match(narrative, /Deputy T SFSO, #5678/);
+});
 
 test('849b form generation eligibility', async (t) => {
   await t.test('allows jail exits without a legal release timestamp', () => {

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -2182,6 +2182,48 @@ test('/api/deflections', async (t) => {
       });
     });
 
+    await t.test('persists sobered release appendix before forms are queued', async () => {
+      await prisma.deflection.expire();
+      await prisma.user.update({
+        where: { id: custodyUser.id },
+        data: { badgeNumber: '8675' },
+      });
+      await prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'READY_FOR_INTAKE',
+          status: 'ACTIVE',
+          completedAt: null,
+          releasedAt: null,
+          releasedById: null,
+          releaseReason: null,
+          releaseNarrative: 'Existing 849(b) release narrative.',
+          exitedAt: null,
+          exitedById: null,
+          exitDestination: null,
+        },
+      });
+
+      const response = await app.inject()
+        .post('/api/deflections/6/release')
+        .headers(custodyUserHeaders)
+        .payload({
+          releaseReason: 'SOBERED',
+        });
+
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+
+      assert.ok(data.releaseNarrative.startsWith('Existing 849(b) release narrative.\n\n'));
+      assert.match(data.releaseNarrative, /At approximately \d{2}:\d{2} hours on \d{2}\/\d{2}\/\d{2}/);
+      assert.match(data.releaseNarrative, /Connections medical staff, _{30} , determined/);
+      assert.match(data.releaseNarrative, /subject, Test Client3, was able to care for themselves/);
+      assert.match(data.releaseNarrative, /Deputy S User 1, #8675, issued Test Client3 a certificate of release/);
+
+      const dbDeflection = await prisma.deflection.findUnique({ where: { id: 6 } });
+      assert.strictEqual(dbDeflection.releaseNarrative, data.releaseNarrative);
+    });
+
     await t.test('records sobered release from in-chair and lingers as ACTIVE/RELEASED', async () => {
       await prisma.deflection.expire();
       await prisma.bedType.update({


### PR DESCRIPTION
## Summary

- Appends the required “can care for themselves” medical-staff paragraph to the 849(b) release narrative during SOBERED custody release _only_.
- Persists the appended narrative on `Deflection.releaseNarrative` before release forms are queued, generated, stored, or e-mailed.
- Uses release confirmation date/time, released subject first/last name, and releasing deputy first initial, last name, and star number.

Closes #906 