### PR TITLE
Upper casing guards on org unit

### DIFF
--- a/client/src/Admin/Organizations/Units/AdminUnitForm.jsx
+++ b/client/src/Admin/Organizations/Units/AdminUnitForm.jsx
@@ -6,6 +6,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { Head } from '@unhead/react';
 
 import Api from '@/Api';
+import { formatUnitName } from '@/utils/unit';
 
 function AdminUnitForm () {
   const location = useLocation();
@@ -47,10 +48,14 @@ function AdminUnitForm () {
 
   const onSubmitMutation = useMutation({
     mutationFn: (values) => {
+      const payload = {
+        ...values,
+        name: formatUnitName(values.name),
+      };
       if (isNew) {
-        return Api.organizations.units.create(organizationId, values);
+        return Api.organizations.units.create(organizationId, payload);
       } else {
-        return Api.organizations.units.update(organizationId, unitId, values);
+        return Api.organizations.units.update(organizationId, unitId, payload);
       }
     },
     onMutate: () => setSuccess(false),
@@ -108,6 +113,7 @@ function AdminUnitForm () {
                 key={form.key('name')}
                 label='Name'
                 placeholder='e.g. Patrol'
+                onChange={(event) => form.setFieldValue('name', formatUnitName(event.currentTarget.value))}
               />
               <Group>
                 <Button disabled={onSubmitMutation.isPending} type='submit'>Submit</Button>

--- a/client/src/Admin/Organizations/Units/AdminUnitsList.jsx
+++ b/client/src/Admin/Organizations/Units/AdminUnitsList.jsx
@@ -8,6 +8,7 @@ import { IconTrash } from '@tabler/icons-react';
 
 import Api from '@/Api';
 import Pagination from '@/components/Pagination';
+import { formatUnitName } from '@/utils/unit';
 
 function AdminUnitsList () {
   const { organizationId } = useParams();
@@ -47,7 +48,7 @@ function AdminUnitsList () {
       centered: true,
       children: (
         <Text>
-          Are you sure you want to delete <b>{unit.name}</b>? This action cannot be undone.
+          Are you sure you want to delete <b>{formatUnitName(unit.name)}</b>? This action cannot be undone.
         </Text>
       ),
       labels: { confirm: 'Delete', cancel: 'Cancel' },
@@ -106,7 +107,7 @@ function AdminUnitsList () {
               {!isLoading && units?.map((unit) => (
                 <Table.Tr key={unit.id}>
                   <Table.Td>{unit.id}</Table.Td>
-                  <Table.Td>{unit.name}</Table.Td>
+                  <Table.Td>{formatUnitName(unit.name)}</Table.Td>
                   <Table.Td>
                     <Group gap='xs'>
                       <Anchor component={Link} to={`${unit.id}`}>Edit</Anchor>

--- a/client/src/Admin/Users/AdminUserForm.jsx
+++ b/client/src/Admin/Users/AdminUserForm.jsx
@@ -13,6 +13,7 @@ import { useAuthContext } from '@/AuthContext';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useToast } from '@/components/ToastContext';
+import { formatUnitName } from '@/utils/unit';
 
 function AdminUserForm () {
   const { user } = useAuthContext();
@@ -188,7 +189,7 @@ function AdminUserForm () {
                   {...form.getInputProps('unitId')}
                   key={form.key('unitId')}
                   label='Unit'
-                  data={units?.map((unit) => ({ value: unit.id, label: unit.name })) || []}
+                  data={units?.map((unit) => ({ value: unit.id, label: formatUnitName(unit.name) })) || []}
                 />
               )}
               {user?.isAdmin && (() => {

--- a/client/src/Header.jsx
+++ b/client/src/Header.jsx
@@ -19,6 +19,7 @@ import {
   readStoredWorkMode,
   writeStoredWorkMode,
 } from './utils/workMode';
+import { formatUnitName } from './utils/unit';
 import { useAuthContext } from '@/AuthContext';
 import { useFacilityContext } from '@/FacilityContext';
 import { useUserRole } from '@/hooks/useUserRole';
@@ -143,7 +144,7 @@ function Header ({ opened, close, toggle, logout }) {
           </Group>
           {user?.unit?.name && (
             <Text size='sm' color='dimmed' truncate>
-              {user.unit.name}
+              {formatUnitName(user.unit.name)}
             </Text>
           )}
         </Box>

--- a/client/src/Header.test.jsx
+++ b/client/src/Header.test.jsx
@@ -215,7 +215,7 @@ describe('Header — subtitle', () => {
       { id: '1', firstName: 'A', lastName: 'B', roles: ['FIELD', 'CUSTODY'], unit: { name: 'K-9 Unit' } },
       '/holds'
     );
-    expect(await screen.findByText(/K-9 Unit/)).toBeInTheDocument();
+    expect(await screen.findByText(/K-9 UNIT/)).toBeInTheDocument();
   });
 
   it('omits subtitle entirely when no unit is set', async () => {

--- a/client/src/ManageUsers/EditManagedUserPage.jsx
+++ b/client/src/ManageUsers/EditManagedUserPage.jsx
@@ -10,6 +10,7 @@ import Api from '@/Api';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useToast } from '@/components/ToastContext';
+import { formatUnitName } from '@/utils/unit';
 
 function EditManagedUserPage () {
   const { userId, section } = useParams();
@@ -63,19 +64,20 @@ function EditManagedUserPage () {
     };
     form.setValues(values);
     form.resetDirty(values);
-    setUnitName(user.unit?.name || '');
+    setUnitName(formatUnitName(user.unit?.name));
     setUnitId(user.unitId || '');
   }, [user]);
 
   const autocompleteData = units?.map((unit) => ({
-    value: unit.name,
-    label: unit.name,
+    value: formatUnitName(unit.name),
+    label: formatUnitName(unit.name),
   })) || [];
 
   function handleUnitChange (value) {
-    setUnitName(value);
-    const normalizedValue = value.trim().toLowerCase();
-    const selectedUnit = units?.find((unit) => unit.name.trim().toLowerCase() === normalizedValue);
+    const nextUnitName = formatUnitName(value);
+    setUnitName(nextUnitName);
+    const normalizedValue = nextUnitName.toLowerCase();
+    const selectedUnit = units?.find((unit) => formatUnitName(unit.name).toLowerCase() === normalizedValue);
     setUnitId(selectedUnit?.id || '');
   }
 
@@ -91,7 +93,7 @@ function EditManagedUserPage () {
     const positionPayload = {
       badgeNumber: form.values.badgeNumber,
       unitId,
-      unitName: unitName.trim(),
+      unitName: formatUnitName(unitName),
     };
 
     if (form.values.organizationId === 'sfso') {
@@ -102,7 +104,7 @@ function EditManagedUserPage () {
     return positionPayload;
   }, [form.values, section, unitId, unitName]);
 
-  const hasChanged = form.isDirty() || (section === 'position' && (unitId !== (user?.unitId || '') || unitName !== (user?.unit?.name || '')));
+  const hasChanged = form.isDirty() || (section === 'position' && (unitId !== (user?.unitId || '') || unitName !== formatUnitName(user?.unit?.name)));
   const isValidPersonalName = section !== 'personal' || (payload.firstName.length >= 2 && payload.lastName.length >= 2);
 
   const onSubmitMutation = useMutation({

--- a/client/src/ManageUsers/ManagedUserDetailsPage.jsx
+++ b/client/src/ManageUsers/ManagedUserDetailsPage.jsx
@@ -7,6 +7,7 @@ import { useParams } from 'react-router';
 import Api from '@/Api';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
+import { formatUnitName } from '@/utils/unit';
 
 function DetailItem ({ label, value }) {
   return (
@@ -47,7 +48,7 @@ function ManagedUserDetailsPage () {
           <Stack>
             <Box>
               <Title order={2}>{user.firstName} {user.lastName}</Title>
-              {user.unit && <Text c='gray.6' size='sm'>{user.unit.name}</Text>}
+              {user.unit && <Text c='gray.6' size='sm'>{formatUnitName(user.unit.name)}</Text>}
             </Box>
             <Stack gap='sm'>
               <Group justify='space-between' wrap='nowrap'>
@@ -66,7 +67,7 @@ function ManagedUserDetailsPage () {
                     <IconButtonLink icon={IconPencilMinus} to={`/manage-users/${user.id}/edit/position`} aria-label='Edit position details' />
                   </Group>
                   <DetailItem label='Star number' value={user.badgeNumber} />
-                  <DetailItem label='Unit' value={user.unit?.name} />
+                  <DetailItem label='Unit' value={formatUnitName(user.unit?.name)} />
                   {user.organizationId === 'sfso' && (
                     <>
                       <DetailItem label='Rank' value={user.title?.name} />

--- a/client/src/UnitSelector.jsx
+++ b/client/src/UnitSelector.jsx
@@ -17,6 +17,7 @@ import { useLocation, useNavigate } from 'react-router';
 import Api from './Api';
 import { useAuthContext } from './AuthContext';
 import { useUserRole } from './hooks/useUserRole';
+import { formatUnitName } from './utils/unit';
 import { readStoredWorkMode, writeStoredWorkMode } from './utils/workMode';
 
 const MODE_HOME_PATH = { FIELD: '/holds', CUSTODY: '/custody' };
@@ -74,23 +75,24 @@ function UnitSelector () {
   });
 
   const autocompleteData = units.map((unit) => ({
-    value: unit.id,
-    label: unit.name,
+    value: formatUnitName(unit.name),
+    label: formatUnitName(unit.name),
   }));
   const hasUnit = unitName.trim().length >= 3;
   const canConfirm = hasUnit && (!needsModeSelection || !!mode);
 
   function handleOptionSubmit (value) {
-    setUnitName(value);
-    const normalizedValue = value.trim().toLowerCase();
-    const selectedUnit = units.find((unit) => unit.name.trim().toLowerCase() === normalizedValue);
+    const nextUnitName = formatUnitName(value);
+    setUnitName(nextUnitName);
+    const normalizedValue = nextUnitName.toLowerCase();
+    const selectedUnit = units.find((unit) => formatUnitName(unit.name).toLowerCase() === normalizedValue);
     setUnitId(selectedUnit?.id ?? null);
   }
 
   function onConfirm () {
     onSubmitMutation.mutate({
       unitId,
-      unitName: unitName.trim(),
+      unitName: formatUnitName(unitName),
     });
   }
 

--- a/client/src/UserProfile/EditUserProfilePage.jsx
+++ b/client/src/UserProfile/EditUserProfilePage.jsx
@@ -11,6 +11,7 @@ import { useAuthContext } from '@/AuthContext';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useToast } from '@/components/ToastContext';
+import { formatUnitName } from '@/utils/unit';
 
 function EditUserProfilePage () {
   const { user } = useAuthContext();
@@ -55,20 +56,21 @@ function EditUserProfilePage () {
         ...data,
         password: '',
       });
-      setUnitName(data.unit?.name || '');
+      setUnitName(formatUnitName(data.unit?.name));
       setUnitId(data.unitId || '');
     }
   }, [data]);
 
   const autocompleteData = units?.map((unit) => ({
-    value: unit.id,
-    label: unit.name,
+    value: formatUnitName(unit.name),
+    label: formatUnitName(unit.name),
   })) || [];
 
   function handleUnitChange (value) {
-    setUnitName(value);
-    const normalizedValue = value.trim().toLowerCase();
-    const selectedUnit = units?.find((unit) => unit.name.trim().toLowerCase() === normalizedValue);
+    const nextUnitName = formatUnitName(value);
+    setUnitName(nextUnitName);
+    const normalizedValue = nextUnitName.toLowerCase();
+    const selectedUnit = units?.find((unit) => formatUnitName(unit.name).toLowerCase() === normalizedValue);
     const nextUnitId = selectedUnit?.id || '';
     setUnitId(nextUnitId);
     form.setFieldValue('unitId', nextUnitId);
@@ -79,7 +81,7 @@ function EditUserProfilePage () {
       const payload = {
         badgeNumber: values.badgeNumber,
         unitId,
-        unitName: unitName.trim(),
+        unitName: formatUnitName(unitName),
       };
 
       if (values.organizationId === 'sfso') {

--- a/client/src/UserProfile/UserProfilePage.jsx
+++ b/client/src/UserProfile/UserProfilePage.jsx
@@ -5,6 +5,7 @@ import { Head } from '@unhead/react';
 import { useAuthContext } from '@/AuthContext';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
+import { formatUnitName } from '@/utils/unit';
 
 function UserProfilePage () {
   const { user } = useAuthContext();
@@ -23,7 +24,7 @@ function UserProfilePage () {
         <Stack>
           <Box>
             <Title order={2}>{user.firstName} {user.lastName}</Title>
-            {user.unit && <Text c='gray.6' size='sm'>{user.unit?.name}</Text>}
+            {user.unit && <Text c='gray.6' size='sm'>{formatUnitName(user.unit?.name)}</Text>}
           </Box>
           <Stack gap='sm'>
             <Title order={3}>Personal Information</Title>
@@ -50,7 +51,7 @@ function UserProfilePage () {
                 </Box>
                 <Box>
                   <Text size='md' c='gray.6'>Unit</Text>
-                  <Text size='md'>{user.unit?.name}</Text>
+                  <Text size='md'>{formatUnitName(user.unit?.name)}</Text>
                 </Box>
                 {user.organizationId === 'sfso' && (
                   <>

--- a/client/src/utils/unit.js
+++ b/client/src/utils/unit.js
@@ -1,0 +1,3 @@
+export function formatUnitName (value) {
+  return value == null ? '' : value.toString().trim().toUpperCase();
+}

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { fill647f } from './fill647f.js';
 import { getHospitalCancellationReleaseNarrative, HOSPITAL_CANCEL_REASON } from '#lib/hospitalCancellation647f.js';
 import i18n from '#lib/i18n.js';
+import { formatUnitName } from '#lib/unitName.js';
 import {
   FORM_TIMEZONE,
   firstInitialLastName,
@@ -41,7 +42,7 @@ export function transformData (deflection) {
   const arrestingOfficerRank = incident?.createdByTitle?.name || arrestingOfficer?.title?.name || '';
   const arrestingOfficerName = firstInitialLastName(arrestingOfficer);
   const arrestingOfficerBadge = incident?.createdByBadgeNumber || arrestingOfficer?.badgeNumber || '';
-  const arrestingOfficerUnit = incident?.createdByUnit?.name || arrestingOfficer?.unit?.name || '';
+  const arrestingOfficerUnit = formatUnitName(incident?.createdByUnit?.name || arrestingOfficer?.unit?.name);
   const arrestingOfficerAgency = incident?.createdByOrganization?.name || arrestingOfficer?.organization?.name || '';
 
   // find the field officer who handed the subject to RESET:
@@ -51,7 +52,7 @@ export function transformData (deflection) {
   const custodyReleaseOfficerRank = custodyReleaseOfficer?.title?.name || '';
   const custodyReleaseOfficerName = firstInitialLastName(custodyReleaseOfficer);
   const custodyReleaseOfficerBadge = custodyReleaseOfficer?.badgeNumber || '';
-  const custodyReleaseOfficerUnit = custodyReleaseOfficer?.unit?.name || '';
+  const custodyReleaseOfficerUnit = formatUnitName(custodyReleaseOfficer?.unit?.name);
 
   const facility = deflection.facility;
   const facilityAddress = streetCityStateZip(facility);
@@ -141,7 +142,7 @@ export async function generatePdf (deflectionData) {
     caseNumber: deflectionData.caseNumber,
 
     arrestingOfficerDisplay,
-    arrestingOfficerUnit: deflectionData.arrestingOfficerUnit,
+    arrestingOfficerUnit: formatUnitName(deflectionData.arrestingOfficerUnit),
     arrestingOfficerAgency: deflectionData.arrestingOfficerAgency,
     supervisorBadgeNumber: deflectionData.supervisorBadgeNumber,
     custodyReleaseOfficerDisplay,

--- a/server/lib/forms/849b/generate.js
+++ b/server/lib/forms/849b/generate.js
@@ -5,6 +5,7 @@ import { firstInitialLastName, formatDateTime24 } from '../shared/formUtils.js';
 import { fill849b } from './fill849b.js';
 import { build849bReleaseNarrative } from './releaseNarrative.js';
 import i18n from '#lib/i18n.js';
+import { formatUnitName } from '#lib/unitName.js';
 const { DrugTypeEnum } = prismaPkg;
 
 function formatDeputyNameForReportingParty (deputy) {
@@ -121,7 +122,7 @@ export async function generatePdf (deflectionData) {
     // Deputy fields - from persisted reporting deputy (not incident creator or current user)
     reportingDeputy: firstInitialLastName(reportingDeputy),
     star: reportingDeputy?.badgeNumber || '',
-    divisionUnit: reportingDeputy?.unit?.name || '',
+    divisionUnit: formatUnitName(reportingDeputy?.unit?.name),
     supervisorApproval: '',
     watch: '',
     assignTo: '',

--- a/server/lib/forms/cert/generate.js
+++ b/server/lib/forms/cert/generate.js
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { PDFDocument } from 'pdf-lib';
 import { firstInitialLastName, formatDateParts, formatTime, formatDateOnly } from '../shared/formUtils.js';
 import { fillCoR } from './fillCoR.js';
+import { formatUnitName } from '#lib/unitName.js';
 
 export function transformData (deflection) {
   const subject = deflection.subject;
@@ -14,7 +15,7 @@ export function transformData (deflection) {
   const deputyTitle = deputy?.title?.name || '';
   const deputyName = firstInitialLastName(deputy);
   const deputyBadge = deputy?.badgeNumber || '';
-  const unitIdentifier = deputy?.unit?.name || '';
+  const unitIdentifier = formatUnitName(deputy?.unit?.name);
 
   const detention = formatDateParts(deflection.createdAt?.toISOString());
   const release = formatDateParts(deflection.releasedAt.toISOString());
@@ -60,7 +61,7 @@ export async function generatePdf (deflectionData, user) {
     releaseYear: deflectionData.releaseYear,
     releaseTime: deflectionData.releaseTime,
     deputyPrint,
-    unitIdentifier: deflectionData.unitIdentifier,
+    unitIdentifier: formatUnitName(deflectionData.unitIdentifier),
     signature: `${deflectionData.deputyName} #${deflectionData.deputyBadge}`,
   };
 

--- a/server/lib/unitName.js
+++ b/server/lib/unitName.js
@@ -1,0 +1,7 @@
+export function normalizeUnitName (value) {
+  return value == null ? value : value.toString().trim().toUpperCase();
+}
+
+export function formatUnitName (value) {
+  return normalizeUnitName(value) || '';
+}

--- a/server/models/unit.js
+++ b/server/models/unit.js
@@ -2,6 +2,7 @@ import prismaPkg from '@prisma/client';
 import { z } from 'zod';
 
 import Base from './base.js';
+import { formatUnitName } from '#lib/unitName.js';
 const { Prisma } = prismaPkg;
 
 const UnitAttributesSchema = z.object({
@@ -27,6 +28,12 @@ export class Unit extends Base {
   static ResponseSchema = UnitResponseSchema;
 
   constructor (data) {
+    if (data?.name) {
+      data = {
+        ...data,
+        name: formatUnitName(data.name),
+      };
+    }
     super(Prisma.UnitScalarFieldEnum, data);
   }
 }

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -5,6 +5,7 @@ import { z } from 'zod';
 
 import Base from './base.js';
 import mailer from '#lib/mailer.js';
+import { formatUnitName } from '#lib/unitName.js';
 import Organization from '#models/organization.js';
 import Title from '#models/title.js';
 import Unit from '#models/unit.js';
@@ -70,6 +71,15 @@ export class User extends Base {
   static Role = RoleEnum;
 
   constructor (data) {
+    if (data?.unit?.name) {
+      data = {
+        ...data,
+        unit: {
+          ...data.unit,
+          name: formatUnitName(data.unit.name),
+        },
+      };
+    }
     super(Prisma.UserScalarFieldEnum, data);
   }
 

--- a/server/prisma/migrations/20260507000000_uppercase_unit_names/migration.sql
+++ b/server/prisma/migrations/20260507000000_uppercase_unit_names/migration.sql
@@ -1,3 +1,0 @@
-UPDATE "public"."Unit"
-SET "name" = UPPER(TRIM("name"))
-WHERE "name" IS DISTINCT FROM UPPER(TRIM("name"));

--- a/server/prisma/migrations/20260507000000_uppercase_unit_names/migration.sql
+++ b/server/prisma/migrations/20260507000000_uppercase_unit_names/migration.sql
@@ -1,0 +1,3 @@
+UPDATE "public"."Unit"
+SET "name" = UPPER(TRIM("name"))
+WHERE "name" IS DISTINCT FROM UPPER(TRIM("name"));

--- a/server/routes/api/organizations/_organizationId/units/create.js
+++ b/server/routes/api/organizations/_organizationId/units/create.js
@@ -1,6 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
+import { normalizeUnitName } from '#lib/unitName.js';
 import Unit from '#models/unit.js';
 
 export default async function (fastify, opts) {
@@ -38,6 +39,7 @@ export default async function (fastify, opts) {
       const unit = await fastify.prisma.unit.create({
         data: {
           ...data,
+          name: normalizeUnitName(data.name),
           organizationId,
           createdById: userId,
         },

--- a/server/routes/api/organizations/_organizationId/units/patch.js
+++ b/server/routes/api/organizations/_organizationId/units/patch.js
@@ -1,6 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
+import { normalizeUnitName } from '#lib/unitName.js';
 import Unit from '#models/unit.js';
 
 export default async function (fastify, opts) {
@@ -24,7 +25,10 @@ export default async function (fastify, opts) {
     },
     async function (request, reply) {
       const { organizationId, id } = request.params;
-      const data = request.body;
+      const data = {
+        ...request.body,
+        ...(request.body.name === undefined ? {} : { name: normalizeUnitName(request.body.name) }),
+      };
 
       try {
         const unit = await fastify.prisma.unit.update({

--- a/server/routes/api/users/patch.js
+++ b/server/routes/api/users/patch.js
@@ -5,6 +5,7 @@ import crypto from 'node:crypto';
 import { z } from 'zod';
 
 import slugifyUnitId from '#lib/slugifyUnitId.js';
+import { normalizeUnitName } from '#lib/unitName.js';
 import User from '#models/user.js';
 
 const ORG_ADMIN_ALLOWED_FIELDS = new Set([
@@ -21,7 +22,7 @@ const ORG_ADMIN_ALLOWED_FIELDS = new Set([
 ]);
 
 async function resolveUnitId (tx, { organizationId, userId, unitId, unitName }) {
-  const trimmedUnitName = unitName?.trim();
+  const trimmedUnitName = normalizeUnitName(unitName);
 
   if (!trimmedUnitName || unitId) {
     return unitId;

--- a/server/test/lib/forms/647f.test.js
+++ b/server/test/lib/forms/647f.test.js
@@ -29,7 +29,7 @@ test('647f transferOfficer: no handoffs — falls back to incident.createdBy', (
   assert.equal(data.custodyReleaseOfficerName, 'J. Smith');
   assert.equal(data.custodyReleaseOfficerBadge, 'B001');
   assert.equal(data.custodyReleaseOfficerRank, 'Officer');
-  assert.equal(data.custodyReleaseOfficerUnit, 'Unit 1');
+  assert.equal(data.custodyReleaseOfficerUnit, 'UNIT 1');
 });
 
 test('647f transferOfficer: no handoffs and no incident — falls back to deflection.createdBy', () => {
@@ -59,7 +59,7 @@ test('647f transferOfficer: handoff exists — uses toOfficer from the most rece
   assert.equal(data.custodyReleaseOfficerName, 'A. Vega');
   assert.equal(data.custodyReleaseOfficerBadge, 'F100');
   assert.equal(data.custodyReleaseOfficerRank, 'Deputy');
-  assert.equal(data.custodyReleaseOfficerUnit, 'Field Unit');
+  assert.equal(data.custodyReleaseOfficerUnit, 'FIELD UNIT');
 });
 
 test('647f hospital cancellation appends the release narrative', () => {

--- a/server/test/lib/forms/cert.test.js
+++ b/server/test/lib/forms/cert.test.js
@@ -28,7 +28,7 @@ test('cert unitIdentifier uses releasedBy.unit before incident.createdByUnit', (
     },
   });
 
-  assert.equal(data.unitIdentifier, 'SFSO Intake');
+  assert.equal(data.unitIdentifier, 'SFSO INTAKE');
   assert.equal(data.deputyName, 'S. Deputy');
 });
 

--- a/server/test/routes/api/units.test.js
+++ b/server/test/routes/api/units.test.js
@@ -26,7 +26,7 @@ test('/api/organizations/:organizationId/units', async (t) => {
 
       const unit = data.find(u => u.id === 'option-1');
       assert.ok(unit);
-      assert.deepStrictEqual(unit.name, 'Option 1');
+      assert.deepStrictEqual(unit.name, 'OPTION 1');
       assert.deepStrictEqual(unit.organizationId, organizationId);
     });
   });
@@ -40,7 +40,7 @@ test('/api/organizations/:organizationId/units', async (t) => {
       assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
       const data = JSON.parse(response.body);
       assert.deepStrictEqual(data.id, 'option-1');
-      assert.deepStrictEqual(data.name, 'Option 1');
+      assert.deepStrictEqual(data.name, 'OPTION 1');
       assert.deepStrictEqual(data.organizationId, organizationId);
     });
 
@@ -67,7 +67,7 @@ test('/api/organizations/:organizationId/units', async (t) => {
       assert.deepStrictEqual(response.statusCode, StatusCodes.CREATED);
       const data = JSON.parse(response.body);
       assert.deepStrictEqual(data.id, newUnitId);
-      assert.deepStrictEqual(data.name, 'New Unit');
+      assert.deepStrictEqual(data.name, 'NEW UNIT');
       assert.deepStrictEqual(data.organizationId, organizationId);
 
       // Verify in database
@@ -80,7 +80,7 @@ test('/api/organizations/:organizationId/units', async (t) => {
         },
       });
       assert.ok(unit);
-      assert.deepStrictEqual(unit.name, 'New Unit');
+      assert.deepStrictEqual(unit.name, 'NEW UNIT');
     });
 
     await t.test('returns 403 for non-admin user', async () => {
@@ -119,7 +119,7 @@ test('/api/organizations/:organizationId/units', async (t) => {
 
       assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
       const data = JSON.parse(response.body);
-      assert.deepStrictEqual(data.name, 'Updated Unit');
+      assert.deepStrictEqual(data.name, 'UPDATED UNIT');
 
       // Verify in database
       const unit = await prisma.unit.findUnique({
@@ -130,7 +130,7 @@ test('/api/organizations/:organizationId/units', async (t) => {
           },
         },
       });
-      assert.deepStrictEqual(unit.name, 'Updated Unit');
+      assert.deepStrictEqual(unit.name, 'UPDATED UNIT');
     });
 
     await t.test('returns 403 for non-admin user', async () => {

--- a/server/test/routes/api/users.test.js
+++ b/server/test/routes/api/users.test.js
@@ -447,7 +447,7 @@ test('/api/users', async (t) => {
 
       const data = JSON.parse(response.body);
       assert.deepStrictEqual(data.unitId, 'car_42');
-      assert.deepStrictEqual(data.unit.name, 'Car 42');
+      assert.deepStrictEqual(data.unit.name, 'CAR 42');
 
       const unit = await prisma.unit.findUnique({
         where: {
@@ -458,7 +458,7 @@ test('/api/users', async (t) => {
         },
       });
       assert.ok(unit);
-      assert.deepStrictEqual(unit.name, 'Car 42');
+      assert.deepStrictEqual(unit.name, 'CAR 42');
 
       const user = await prisma.user.findUnique({ where: { id: 'dab5dff3-360d-4dbb-98dd-1990dfb5c4c5' } });
       assert.deepStrictEqual(user.unitId, 'car_42');
@@ -472,7 +472,7 @@ test('/api/users', async (t) => {
 
       const data = JSON.parse(response.body);
       assert.deepStrictEqual(data.unitId, 'option-1');
-      assert.deepStrictEqual(data.unit.name, 'Option 1');
+      assert.deepStrictEqual(data.unit.name, 'OPTION 1');
 
       const matchingUnits = await prisma.unit.findMany({
         where: {


### PR DESCRIPTION
## Summary

- Uppercase unit names anywhere users or admins type/select units.
- Normalize unit names before persistence when new units are created through user profile/unit selection flows or admin unit management.
- Force unit display to uppercase across profile, header, managed-user, and admin unit screens.
- Uppercase unit values before inserting them into legal PDF forms.
- Add a Prisma migration to retrospectively uppercase and trim existing `Unit.name` values.

Closes #919 