### PR TITLE
Removed mention of SFPD from narcotics boilerplate (#929)

### DIFF
--- a/server/lib/forms/647f/Form647f.jsx
+++ b/server/lib/forms/647f/Form647f.jsx
@@ -65,7 +65,7 @@ export default function Form647f ({ data = {} }) {
   const custodyReleaseOfficerDisplay = joinWords(custodyReleaseOfficerRank, custodyReleaseOfficerName, custodyReleaseOfficerBadge && `#${custodyReleaseOfficerBadge}`);
   const substanceNot = substanceFound ? '' : 'not ';
   const paraphernaliaNot = paraphernaliaFound ? '' : 'not ';
-  const narcoticsStatement = `SFPD Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
+  const narcoticsStatement = `Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
 
   const narrative = [justification, narcoticsStatement, hospitalCancellationReleaseNarrative]
     .filter(Boolean)

--- a/server/lib/forms/647f/generate.js
+++ b/server/lib/forms/647f/generate.js
@@ -118,7 +118,7 @@ export async function generatePdf (deflectionData) {
 
   const substanceNot = deflectionData.substanceFound ? '' : 'not ';
   const paraphernaliaNot = deflectionData.paraphernaliaFound ? '' : 'not ';
-  const narcoticsStatement = `SFPD Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
+  const narcoticsStatement = `Officer searched for narcotics. Subject was ${substanceNot}found to be in possession of a controlled substance. Subject was ${paraphernaliaNot}found to be in possession of narcotics paraphernalia.`;
   const narrative = [deflectionData.justification, narcoticsStatement, deflectionData.hospitalCancellationReleaseNarrative]
     .filter(Boolean)
     .join('\n\n');


### PR DESCRIPTION
## Summary

Removes a couple mentions of "SFPD Officer" from 647f, replacing with "Officer", for portability when SFPD versus SFSO officers do the arrest.

Closes #929 