### PR TITLE
all links generate pdf, open as downloadable

### DIFF
--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -123,7 +123,7 @@ function Deflection () {
     openInBrowser(url, `647f-${deflection.id}.pdf`)
       .then(() => {
         removeToast(toastId);
-        showToast('647(f) form ready', 'success', 4000, 'Open it from your downloads to view or print.');
+        showToast('647(f) form ready', 'success', 4000, 'Open your downloads/Files app to view or print.');
       })
       .catch(() => {
         removeToast(toastId);

--- a/client/src/lesc/components/Deflection.jsx
+++ b/client/src/lesc/components/Deflection.jsx
@@ -17,6 +17,7 @@ import ActionFooter from '@/components/ActionFooter';
 import IconButtonLink from '@/components/IconButtonLink';
 import { useToast } from '@/components/ToastContext';
 import { formatAddress, formatDateTime, formatTimeRemaining } from '@/utils/format';
+import { openInBrowser } from '@/utils/openInBrowser';
 import { isValidDeflection, isValidSubject, isValidSubstance, isValidNarcotics, isValidBehavior, isValidProperty, isValidCertification, isValidIncident } from '@/utils/validators';
 import DeflectionStatusChip from './DeflectionStatusChip';
 import { getSfpdDeflectionStatusChip, isExpiredBeforeTransfer } from './deflectionStatusChipUtils';
@@ -27,7 +28,7 @@ function Deflection () {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { showToast } = useToast();
+  const { showToast, removeToast } = useToast();
   const { user } = useAuthContext();
 
   const { data: deflection } = useQuery({
@@ -117,8 +118,17 @@ function Deflection () {
   }
 
   function on647fClick () {
-    const url = doc647f?.fileUrl || `/api/forms/647f/pdf/${deflection.id}`;
-    window.open(url, '_blank');
+    const url = `/api/forms/647f/pdf/${deflection.id}`;
+    const toastId = showToast('Downloading 647(f) form…', 'success', 0, 'This may take a moment.');
+    openInBrowser(url, `647f-${deflection.id}.pdf`)
+      .then(() => {
+        removeToast(toastId);
+        showToast('647(f) form ready', 'success', 4000, 'Open it from your downloads to view or print.');
+      })
+      .catch(() => {
+        removeToast(toastId);
+        showToast('Couldn’t download 647(f) form', 'error', 4000, 'Please try again.');
+      });
   }
 
   return (

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -17,6 +17,7 @@ import useEnsureReleaseNarrative from '../../../hooks/useEnsureReleaseNarrative'
 import useNow from '../../../hooks/useNow';
 import { useUserRole } from '../../../hooks/useUserRole';
 import { formatAddress, formatDateTime, formatIntakeStartedAt, formatTimeRemaining } from '@/utils/format';
+import { openInBrowser } from '@/utils/openInBrowser';
 import { releaseTiming } from '@/utils/releaseTiming';
 
 import CompleteIntakeModal from '../care/CompleteIntakeModal';
@@ -50,7 +51,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   const queryClient = useQueryClient();
   const { t } = useTranslation();
   const { facility } = useFacilityContext();
-  const { showToast } = useToast();
+  const { showToast, removeToast } = useToast();
   const { isCustody } = useUserRole();
   const isCareView = viewerMode === 'care';
   const careFooterState = getCareDetailFooterState({ viewerMode, deflection });
@@ -215,7 +216,6 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
     incidentReady: !deflection?.incidentId || incidentQuery.isFetched,
   });
 
-  const docCert = deflection?.deflectionDocuments?.find(d => d.formId === 'cert');
   const showPostReleaseNarrativeActions = !isCareView && isCustody && isPostRelease;
 
   const email849bMutation = useMutation({
@@ -229,7 +229,16 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   });
 
   function open849bPdf () {
-    window.open(`/api/forms/849b/pdf/${deflection.id}`, '_blank');
+    const toastId = showToast('Downloading 849(b) form…', 'success', 0, 'This may take a moment.');
+    openInBrowser(`/api/forms/849b/pdf/${deflection.id}`, `849b-${deflection.id}.pdf`)
+      .then(() => {
+        removeToast(toastId);
+        showToast('849(b) form ready', 'success', 4000, 'Open it from your downloads to view or print.');
+      })
+      .catch(() => {
+        removeToast(toastId);
+        showToast('Couldn’t download 849(b) form', 'error', 4000, 'Please try again.');
+      });
   }
 
   return (
@@ -697,8 +706,17 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                         return;
                       }
                       if (showPrimaryPrintCertificate) {
-                        const url = docCert?.fileUrl || `/api/forms/cert/pdf/${deflection.id}`;
-                        window.open(url, '_blank');
+                        const url = `/api/forms/cert/pdf/${deflection.id}`;
+                        const toastId = showToast('Downloading release certificate…', 'success', 0, 'This may take a moment.');
+                        openInBrowser(url, `cert-${deflection.id}.pdf`)
+                          .then(() => {
+                            removeToast(toastId);
+                            showToast('Release certificate ready', 'success', 4000, 'Open it from your downloads to view or print.');
+                          })
+                          .catch(() => {
+                            removeToast(toastId);
+                            showToast('Couldn’t download release certificate', 'error', 4000, 'Please try again.');
+                          });
                       }
                     }}
                   >

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -233,7 +233,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
     openInBrowser(`/api/forms/849b/pdf/${deflection.id}`, `849b-${deflection.id}.pdf`)
       .then(() => {
         removeToast(toastId);
-        showToast('849(b) form ready', 'success', 4000, 'Open it from your downloads to view or print.');
+        showToast('849(b) form ready', 'success', 4000, 'Open your downloads/Files app to view or print.');
       })
       .catch(() => {
         removeToast(toastId);
@@ -711,7 +711,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                         openInBrowser(url, `cert-${deflection.id}.pdf`)
                           .then(() => {
                             removeToast(toastId);
-                            showToast('Release certificate ready', 'success', 4000, 'Open it from your downloads to view or print.');
+                            showToast('Release certificate ready', 'success', 4000, 'Open your downloads/Files app to view or print.');
                           })
                           .catch(() => {
                             removeToast(toastId);

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -68,6 +68,10 @@ vi.mock('@/utils/releaseTiming', () => ({
   releaseTiming: () => null,
 }));
 
+vi.mock('@/utils/openInBrowser', () => ({
+  openInBrowser: vi.fn(),
+}));
+
 vi.mock('../../../hooks/useUserRole', () => ({
   useUserRole: () => ({
     isCustody: true,

--- a/client/src/utils/openInBrowser.js
+++ b/client/src/utils/openInBrowser.js
@@ -1,0 +1,33 @@
+/**
+ * Fetch a file and trigger a download via a blob URL.
+ *
+ * Avoids two failure modes of `<a href={url} download>`:
+ * - Cross-origin URLs (e.g. S3 fileUrls): the download attribute is
+ *   silently ignored and the anchor click navigates the current tab to
+ *   the URL.
+ * - PWA scope capture: in a standalone PWA on Android, in-scope link
+ *   clicks (even with target="_blank") get captured into a new PWA
+ *   instance that doesn't inherit the SameSite=Strict session cookie →
+ *   401 with no UI to escape.
+ *
+ * Fetching to a blob URL sidesteps both: the fetch carries the cookie,
+ * the blob: URL is treated as same-origin so `download` is honored, and
+ * no top-level navigation happens.
+ */
+export async function openInBrowser (url, filename) {
+  const response = await fetch(url, { credentials: 'include' });
+  if (!response.ok) {
+    throw new Error(`Download failed: ${response.status}`);
+  }
+  const blob = await response.blob();
+  const blobUrl = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = blobUrl;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+
+  setTimeout(() => URL.revokeObjectURL(blobUrl), 60_000);
+}


### PR DESCRIPTION
## Problem

PWA links were opening in no browser chrome mode and sometimes displaying PDF or downloading file in background and then user was stuck on that page and didn't know how to get back.

## Solution

All pdf links now:

- Hit API endpoint to generate pdf
- Gets file object and downloads it
- Shows toast to user to explain what is happening

This standardizes all pdf activity so it behaves the same all the time and works reliably in the PWA experience, doesn't take over the window sometimes. Users will have to learn where the files go on their device but toasts explain it and this behavior is universal so they should get familiar with it.

## Note

When I tried to preserve the retrieval of pregenerated pdf urls I we run into different behavior and couldn't reliably preserve the download behavior so with @beaudrykock-moi's approval switched to regen the pdf always.

Close #921 