### PR TITLE
Removes sfso incident email (#928)

### DIFF
--- a/server/jobs/formsEmail.js
+++ b/server/jobs/formsEmail.js
@@ -5,12 +5,10 @@ import DeflectionDocument from '#models/deflectionDocument.js';
 import { captureException } from '#lib/posthog.js';
 
 const EMAIL_RECIPIENT = 'careconnect@sfgov.org';
-const INCIDENT_REPORTS_RECIPIENT = 'Sfso-incidentreports@sfgov.org';
 const SWAPSUPS_RECIPIENT = 'sfso-swapsups@sfgov.org';
 const TRANSFER_RECIPIENTS = [
   'SFPD.Data.Transfer.Authorized@sfgov.org',
   'Andrew.bley@sfgov.org',
-  INCIDENT_REPORTS_RECIPIENT,
 ];
 
 export default async function formsEmail (data, prismaClient = prisma) {
@@ -165,7 +163,6 @@ export default async function formsEmail (data, prismaClient = prisma) {
       to = uniqueEmails([...recipientEmail, arrestingOfficerEmail]);
     } else if (remainingFormIds.includes('647f') && !recipientEmail) {
       if (arrestingOfficerEmail) cc.push(arrestingOfficerEmail);
-      cc.push(INCIDENT_REPORTS_RECIPIENT);
     }
 
     await sendFormsMessage({

--- a/server/routes/api/deflections/cancel.js
+++ b/server/routes/api/deflections/cancel.js
@@ -155,7 +155,6 @@ export default async function (fastify, opts) {
           recipientEmail: [
             'SFPD.Data.Transfer.Authorized@sfgov.org',
             'Andrew.bley@sfgov.org',
-            'Sfso-incidentreports@sfgov.org',
           ],
         });
       }

--- a/server/routes/api/deflections/transfer.js
+++ b/server/routes/api/deflections/transfer.js
@@ -142,7 +142,6 @@ export default async function (fastify, opts) {
         recipientEmail: [
           'SFPD.Data.Transfer.Authorized@sfgov.org',
           'Andrew.bley@sfgov.org',
-          'Sfso-incidentreports@sfgov.org',
         ],
       });
 

--- a/server/test/jobs/formsEmail.test.js
+++ b/server/test/jobs/formsEmail.test.js
@@ -93,7 +93,7 @@ test('formsEmail job handler', async (t) => {
     },
   };
 
-  await t.test('sends custody-transfer 647f to the three fixed addresses plus the arresting officer', async () => {
+  await t.test('sends custody-transfer 647f to the two fixed addresses plus the arresting officer', async () => {
     await formsEmail({
       deflectionId: 4,
       formIds: ['647f'],
@@ -102,7 +102,6 @@ test('formsEmail job handler', async (t) => {
       recipientEmail: [
         'SFPD.Data.Transfer.Authorized@sfgov.org',
         'Andrew.bley@sfgov.org',
-        'Sfso-incidentreports@sfgov.org',
       ],
     }, mockPrisma);
 
@@ -112,7 +111,6 @@ test('formsEmail job handler', async (t) => {
     assert.deepStrictEqual(sentMail[0].to, [
       'SFPD.Data.Transfer.Authorized@sfgov.org',
       'Andrew.bley@sfgov.org',
-      'Sfso-incidentreports@sfgov.org',
       'regular.user@test.com',
     ]);
     assert.deepStrictEqual(sentMail[0].cc, undefined);
@@ -285,7 +283,6 @@ test('formsEmail job handler', async (t) => {
     assert.deepStrictEqual(sentMail[1].to, [
       'SFPD.Data.Transfer.Authorized@sfgov.org',
       'Andrew.bley@sfgov.org',
-      'Sfso-incidentreports@sfgov.org',
       'regular.user@test.com',
     ]);
     assert.deepStrictEqual(sentMail[1].cc, undefined);

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -1578,7 +1578,6 @@ test('/api/deflections', async (t) => {
         recipientEmail: [
           'SFPD.Data.Transfer.Authorized@sfgov.org',
           'Andrew.bley@sfgov.org',
-          'Sfso-incidentreports@sfgov.org',
         ],
       });
     });


### PR DESCRIPTION
## Summary

Removes Sfso-incidentreports@sfgov.org email from any generated emails, per SFSO request.

Closes #928 