### PR TITLE
Fix/833 persist survey draft to server

### DIFF
--- a/client/src/lesc/components/care/Care.jsx
+++ b/client/src/lesc/components/care/Care.jsx
@@ -23,7 +23,7 @@ import StatusAccordion from '@/components/StatusAccordion';
 import CareCard from './CareCard';
 import CompleteIntakeModal from './CompleteIntakeModal';
 import ScanAdmitCodeModal from './ScanAdmitCodeModal';
-import { groupCareNotInCustodySections, hasPersistedExitDetails, hasSavedExitDraft } from './careFlowUtils';
+import { groupCareNotInCustodySections, hasAnyPersistedExitDetails } from './careFlowUtils';
 
 const IN_CUSTODY_STATUSES = 'IN_MEDICAL_INTAKE,IN_CHAIR';
 const NOT_IN_CUSTODY_STATUSES = 'RELEASED,EXITED';
@@ -45,10 +45,6 @@ function groupByStatus (deflections) {
     grouped[d.subjectStatus].push(d);
   }
   return grouped;
-}
-
-function hasSavedOrPersistedExitDetails (deflection) {
-  return hasSavedExitDraft(deflection.id) || hasPersistedExitDetails(deflection);
 }
 
 function Care () {
@@ -186,7 +182,7 @@ function Care () {
                       deflection={d}
                       highlighted={String(d.id) === highlightedId}
                       onCompleteIntake={() => setIntakeModalDeflection(d)}
-                      hasExitDraft={hasSavedOrPersistedExitDetails(d)}
+                      hasExitDraft={hasAnyPersistedExitDetails(d)}
                       onExitDetails={() => navigate(`/care/${d.id}/exit?from=detail`)}
                     />}
                 />
@@ -208,7 +204,7 @@ function Care () {
                   deflection={d}
                   highlighted={String(d.id) === highlightedId}
                   onCompleteIntake={() => setIntakeModalDeflection(d)}
-                  hasExitDraft={hasSavedOrPersistedExitDetails(d)}
+                  hasExitDraft={hasAnyPersistedExitDetails(d)}
                   onExitDetails={() => navigate(`/care/${d.id}/exit?from=detail`)}
                 />}
             />

--- a/client/src/lesc/components/care/CareExitDetails.jsx
+++ b/client/src/lesc/components/care/CareExitDetails.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Button, Checkbox, Chip, Container, Divider, Group, Input, Stack, Text, Title } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
@@ -12,7 +12,7 @@ import { useToast } from '@/components/ToastContext';
 import { useFacilityContext } from '@/FacilityContext';
 import ConfirmExitModal from './ConfirmExitModal';
 import { hasAssociatedProperty } from '../custody/propertyReturnUtils';
-import { getCareExitBackTo, getCareExitPrimaryActionState, getCareExitSuccessPayload, getSavedExitDraft, setSavedExitDraft } from './careFlowUtils';
+import { getCareExitBackTo, getCareExitPrimaryActionState, getCareExitSuccessPayload } from './careFlowUtils';
 
 const SF_RESIDENCY_OPTIONS = [
   { value: 'YES', label: 'Yes' },
@@ -36,6 +36,7 @@ function CareExitDetails () {
   const { showToast } = useToast();
   const { t } = useTranslation();
   const [initialized, setInitialized] = useState(false);
+  const lastSavedExitDetailsRef = useRef(null);
 
   const [exitDestination, setExitDestination] = useState(null);
   const [exitSFResident, setExitSFResident] = useState(null);
@@ -63,15 +64,30 @@ function CareExitDetails () {
 
   useEffect(() => {
     if (!deflection || initialized) return;
-    const draft = getSavedExitDraft(id);
-
-    setExitDestination(draft?.exitDestination ?? deflection.exitDestination ?? null);
-    setExitSFResident(draft?.exitSFResident ?? deflection.exitSFResident ?? null);
-    setExitHousingStatus(draft?.exitHousingStatus ?? deflection.exitHousingStatus ?? null);
-    setExitConnectedToCare(draft?.exitConnectedToCare ?? deflection.exitConnectedToCare ?? null);
-    setPropertyReturnHandledConfirmed(draft?.propertyReturnHandledConfirmed ?? null);
+    setExitDestination(deflection.exitDestination ?? null);
+    setExitSFResident(deflection.exitSFResident ?? null);
+    setExitHousingStatus(deflection.exitHousingStatus ?? null);
+    setExitConnectedToCare(deflection.exitConnectedToCare ?? null);
+    setPropertyReturnHandledConfirmed(null);
+    lastSavedExitDetailsRef.current = JSON.stringify({
+      exitDestination: deflection.exitDestination ?? null,
+      exitSFResident: deflection.exitSFResident ?? null,
+      exitHousingStatus: deflection.exitHousingStatus ?? null,
+      exitConnectedToCare: deflection.exitConnectedToCare ?? null,
+    });
     setInitialized(true);
   }, [deflection, id, initialized]);
+
+  const { mutate: saveExitDetails } = useMutation({
+    mutationFn: (data) => Api.deflections.saveExitDetails(id, data),
+    onSuccess: (response) => {
+      queryClient.setQueryData(['deflections', id], response.data);
+      queryClient.invalidateQueries({ queryKey: ['deflections', facility.id] });
+    },
+    onError: () => {
+      showToast('Exit details were not saved. Please try again.', 'error');
+    },
+  });
 
   const completeExitMutation = useMutation({
     mutationFn: () => Api.deflections.exit(id, {
@@ -83,7 +99,6 @@ function CareExitDetails () {
     onSuccess: () => {
       const successPayload = getCareExitSuccessPayload(id);
       setConfirmExitOpened(false);
-      setSavedExitDraft(id, false);
       window.sessionStorage.setItem('careHighlightTarget', successPayload.highlightTarget);
       queryClient.invalidateQueries({ queryKey: ['deflections', id] });
       queryClient.invalidateQueries({ queryKey: ['deflections', facility.id] });
@@ -121,16 +136,17 @@ function CareExitDetails () {
 
   useEffect(() => {
     if (!initialized) return;
-    setSavedExitDraft(id, isExitFormEdited
-      ? {
-          exitDestination,
-          exitSFResident,
-          exitHousingStatus,
-          exitConnectedToCare,
-          propertyReturnHandledConfirmed,
-        }
-      : false
-    );
+    if (!isExitFormEdited) return;
+    const exitDetails = {
+      exitDestination,
+      exitSFResident,
+      exitHousingStatus,
+      exitConnectedToCare,
+    };
+    const serializedExitDetails = JSON.stringify(exitDetails);
+    if (serializedExitDetails === lastSavedExitDetailsRef.current) return;
+    lastSavedExitDetailsRef.current = serializedExitDetails;
+    saveExitDetails(exitDetails);
   }, [
     exitConnectedToCare,
     exitDestination,
@@ -139,7 +155,7 @@ function CareExitDetails () {
     id,
     initialized,
     isExitFormEdited,
-    propertyReturnHandledConfirmed,
+    saveExitDetails,
   ]);
 
   const {

--- a/client/src/lesc/components/care/careFlow.test.js
+++ b/client/src/lesc/components/care/careFlow.test.js
@@ -1,23 +1,17 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   getCareExitBackTo,
   getCareExitPrimaryActionState,
   getCareExitSuccessPayload,
   groupCareNotInCustodySections,
+  hasAnyPersistedExitDetails,
   hasPersistedExitDetails,
-  getSavedExitDraft,
-  hasSavedExitDraft,
-  setSavedExitDraft,
   shouldShowCareCardViewDetails,
 } from './careFlowUtils';
 import {
   getCareDetailFooterState,
 } from '../custody/careDetailFooterUtils';
-
-afterEach(() => {
-  vi.unstubAllGlobals();
-});
 
 describe('Care flow unit tests', () => {
   it('hides Details for all EXITED records', () => {
@@ -49,6 +43,22 @@ describe('Care flow unit tests', () => {
       exitHousingStatus: null,
       exitConnectedToCare: 'YES',
       exitSFResident: 'YES',
+    })).toBe(false);
+  });
+
+  it('detects any persisted exit details for in-progress server drafts', () => {
+    expect(hasAnyPersistedExitDetails({
+      exitDestination: 'HOSPITAL',
+      exitHousingStatus: null,
+      exitConnectedToCare: null,
+      exitSFResident: null,
+    })).toBe(true);
+
+    expect(hasAnyPersistedExitDetails({
+      exitDestination: null,
+      exitHousingStatus: null,
+      exitConnectedToCare: null,
+      exitSFResident: null,
     })).toBe(false);
   });
 
@@ -88,6 +98,12 @@ describe('Care flow unit tests', () => {
     expect(releasedState.showFooter).toBe(true);
     expect(releasedState.primaryAction).toBe('start-exit');
     expect(releasedState.startExitPath).toBe('/care/99/exit?from=detail');
+
+    const partialExitDetailsState = getCareDetailFooterState({
+      viewerMode: 'care',
+      deflection: { id: 100, subjectStatus: 'RELEASED', exitDestination: 'HOME' },
+    });
+    expect(partialExitDetailsState.primaryLabel).toBe('Finish exit');
 
     const inChairState = getCareDetailFooterState({
       viewerMode: 'care',
@@ -152,40 +168,5 @@ describe('Care flow unit tests', () => {
       label: 'Confirm exit',
       disabled: false,
     });
-  });
-
-  it('tracks edited exit forms in local storage', () => {
-    const storage = {};
-    vi.stubGlobal('window', {
-      localStorage: {
-        getItem: (key) => storage[key] ?? null,
-        setItem: (key, value) => {
-          storage[key] = String(value);
-        },
-      },
-    });
-
-    expect(hasSavedExitDraft(44)).toBe(false);
-
-    setSavedExitDraft(44, {
-      exitDestination: 'HOME',
-      exitSFResident: 'YES',
-      exitHousingStatus: 'TEMPORARY',
-      exitConnectedToCare: 'NO',
-      propertyReturnHandledConfirmed: false,
-    });
-    expect(hasSavedExitDraft(44)).toBe(true);
-    expect(getSavedExitDraft(44)).toMatchObject({
-      exitDestination: 'HOME',
-      exitSFResident: 'YES',
-      exitHousingStatus: 'TEMPORARY',
-      exitConnectedToCare: 'NO',
-      propertyReturnHandledConfirmed: false,
-      exitFormEdited: true,
-    });
-
-    setSavedExitDraft(44, false);
-    expect(hasSavedExitDraft(44)).toBe(false);
-    expect(getSavedExitDraft(44)).toBe(null);
   });
 });

--- a/client/src/lesc/components/care/careFlowUtils.js
+++ b/client/src/lesc/components/care/careFlowUtils.js
@@ -26,45 +26,13 @@ export function hasPersistedExitDetails (deflection) {
   );
 }
 
-export const EXIT_DRAFT_STORAGE_KEY = 'careExitDraftByDeflectionId';
-
-export function getSavedExitDraftMap () {
-  if (typeof window === 'undefined') return {};
-  try {
-    return JSON.parse(window.localStorage.getItem(EXIT_DRAFT_STORAGE_KEY) || '{}');
-  } catch {
-    return {};
-  }
-}
-
-export function hasSavedExitDraft (deflectionId) {
-  const draft = getSavedExitDraftMap()?.[String(deflectionId)];
-  return Boolean(draft?.exitFormEdited || draft?.exitDetailsSaved);
-}
-
-export function getSavedExitDraft (deflectionId) {
-  return getSavedExitDraftMap()?.[String(deflectionId)] ?? null;
-}
-
-export function setSavedExitDraft (deflectionId, draft) {
-  if (typeof window === 'undefined' || !deflectionId) return;
-  const draftMap = getSavedExitDraftMap();
-  const key = String(deflectionId);
-
-  if (draft) {
-    window.localStorage.setItem(EXIT_DRAFT_STORAGE_KEY, JSON.stringify({
-      ...draftMap,
-      [key]: {
-        ...draftMap[key],
-        ...draft,
-        exitFormEdited: true,
-      },
-    }));
-    return;
-  }
-
-  const { [key]: _removed, ...nextDraftMap } = draftMap;
-  window.localStorage.setItem(EXIT_DRAFT_STORAGE_KEY, JSON.stringify(nextDraftMap));
+export function hasAnyPersistedExitDetails (deflection) {
+  return Boolean(
+    deflection?.exitDestination ||
+    deflection?.exitHousingStatus ||
+    deflection?.exitConnectedToCare ||
+    deflection?.exitSFResident
+  );
 }
 
 export function groupCareNotInCustodySections (deflections = []) {

--- a/client/src/lesc/components/custody/careDetailFooterUtils.js
+++ b/client/src/lesc/components/custody/careDetailFooterUtils.js
@@ -1,10 +1,8 @@
-import { hasSavedExitDraft } from '../care/careFlowUtils';
-
 function hasPersistedExitDetails (deflection) {
   return Boolean(
-    deflection?.exitDestination &&
-    deflection?.exitHousingStatus &&
-    deflection?.exitConnectedToCare &&
+    deflection?.exitDestination ||
+    deflection?.exitHousingStatus ||
+    deflection?.exitConnectedToCare ||
     deflection?.exitSFResident
   );
 }
@@ -26,8 +24,7 @@ export function getCareDetailFooterState ({ viewerMode, deflection }) {
   }
 
   if (deflection?.subjectStatus === 'RELEASED') {
-    const hasExitDraft = hasSavedExitDraft(deflection?.id);
-    const hasExitDetails = hasExitDraft || hasPersistedExitDetails(deflection);
+    const hasExitDetails = hasPersistedExitDetails(deflection);
     return {
       showFooter: true,
       primaryLabel: hasExitDetails ? 'Finish exit' : 'Start exit',

--- a/server/routes/api/deflections/exit-details.js
+++ b/server/routes/api/deflections/exit-details.js
@@ -19,6 +19,13 @@ const EXIT_DETAIL_EDITABLE_STATUSES = [
   Deflection.SubjectStatus.RELEASED,
 ];
 
+const ExitDetailsBodySchema = z.object({
+  exitDestination: CareExitDestinationEnum.nullable().optional(),
+  exitHousingStatus: z.string().nullable().optional(),
+  exitSFResident: ResidencyEnum.nullable().optional(),
+  exitConnectedToCare: ConnectionToCareEnum.nullable().optional(),
+});
+
 export default async function (fastify, opts) {
   fastify.post('/:id/exit-details',
     {
@@ -28,12 +35,7 @@ export default async function (fastify, opts) {
         params: z.object({
           id: z.coerce.number(),
         }),
-        body: z.object({
-          exitDestination: CareExitDestinationEnum,
-          exitHousingStatus: z.string(),
-          exitSFResident: ResidencyEnum,
-          exitConnectedToCare: ConnectionToCareEnum,
-        }),
+        body: ExitDetailsBodySchema,
         response: {
           [StatusCodes.OK]: Deflection.ResponseSchema,
           [StatusCodes.NOT_FOUND]: z.null(),
@@ -63,6 +65,13 @@ export default async function (fastify, opts) {
       }
 
       const now = new Date();
+      const updateData = {
+        exitDestination,
+        exitHousingStatus,
+        exitConnectedToCare,
+        exitSFResident,
+        updatedAt: now,
+      };
 
       await fastify.prisma.$transaction(async (tx) => {
         await tx.deflectionUpdate.create({
@@ -79,13 +88,7 @@ export default async function (fastify, opts) {
 
         deflection = await tx.deflection.update({
           where: { id },
-          data: {
-            exitDestination,
-            exitHousingStatus,
-            exitConnectedToCare,
-            exitSFResident,
-            updatedAt: now,
-          },
+          data: updateData,
           include: {
             subject: true,
             propertyPhotos: true,

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -1796,6 +1796,44 @@ test('/api/deflections', async (t) => {
       assert.strictEqual(lastUpdate.exitConnectedToCare, 'YES');
     });
 
+    await t.test('records partial exit details while the form is in progress', async () => {
+      await app.prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'RELEASED',
+          exitDestination: null,
+          exitHousingStatus: null,
+          exitSFResident: null,
+          exitConnectedToCare: null,
+        },
+      });
+
+      const response = await app.inject()
+        .post('/api/deflections/6/exit-details')
+        .headers(careUserHeaders)
+        .payload({
+          exitDestination: 'HOME',
+          exitHousingStatus: null,
+          exitSFResident: null,
+          exitConnectedToCare: null,
+        });
+
+      assert.strictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+
+      assert.strictEqual(data.subjectStatus, 'RELEASED');
+      assert.strictEqual(data.exitDestination, 'HOME');
+      assert.strictEqual(data.exitHousingStatus, null);
+      assert.strictEqual(data.exitSFResident, null);
+      assert.strictEqual(data.exitConnectedToCare, null);
+
+      const dbDeflection = await app.prisma.deflection.findUnique({ where: { id: 6 } });
+      assert.strictEqual(dbDeflection.exitDestination, 'HOME');
+      assert.strictEqual(dbDeflection.exitHousingStatus, null);
+      assert.strictEqual(dbDeflection.exitSFResident, null);
+      assert.strictEqual(dbDeflection.exitConnectedToCare, null);
+    });
+
     await t.test('requires care user role', async () => {
       const response = await app.inject()
         .post('/api/deflections/6/exit-details')


### PR DESCRIPTION
## Summary

- Move care exit-question draft persistence from browser localStorage to the server.
- Autosave in-progress exit details through `/api/deflections/:id/exit-details`.
- Allow the exit-details endpoint to accept partial nullable exit fields so users can leave and resume before the form is complete.
- Update “Start exit” / “Finish exit” behavior to use server-persisted exit details.

Closes #833 