### PR TITLE
Fix/886 rename legal release option

### DIFF
--- a/client/src/lesc/components/custody/CustodyCard.jsx
+++ b/client/src/lesc/components/custody/CustodyCard.jsx
@@ -139,7 +139,7 @@ function CustodyCard ({ deflection, highlighted }) {
                 size='md'
                 onClick={() => navigate(`/custody/${deflection.id}/legal-release`)}
               >
-                Legal release
+                Release and exit
               </Button>
             )}
             {showStartRelease && (

--- a/client/src/lesc/components/custody/CustodyCard.test.jsx
+++ b/client/src/lesc/components/custody/CustodyCard.test.jsx
@@ -104,12 +104,13 @@ describe('CustodyCard', () => {
     expect(screen.queryByText(/Transfer code:/)).not.toBeInTheDocument();
   });
 
-  it('shows intake-not-completed banner and legal release for failed intake', () => {
+  it('shows intake-not-completed banner and release-and-exit action for failed intake', () => {
     renderCard(buildDeflection({ subjectStatus: 'FAILED_INTAKE' }));
 
     expect(screen.getByText('Intake not completed')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Legal release' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Release and exit' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Legal release' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Safety check' })).not.toBeInTheDocument();
   });
 
@@ -148,10 +149,10 @@ describe('CustodyCard', () => {
     expect(window.sessionStorage.getItem('custodyScrollTarget')).toBe('123');
   });
 
-  it('navigates to legal release when Legal release is clicked', () => {
+  it('navigates to legal release when Release and exit is clicked', () => {
     renderCard(buildDeflection({ subjectStatus: 'FAILED_INTAKE' }));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Legal release' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Release and exit' }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/custody/123/legal-release');
   });

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -32,8 +32,8 @@ import SafetyCheckResultModal from './SafetyCheckResultModal';
 import classes from './CustodyDetailContent.module.css';
 
 const CUSTODY_ACTION_FOOTER_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR', 'RELEASED', 'EXITED'];
-const HOSPITAL_RELEASE_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
-const OTHER_EXIT_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
+const HOSPITAL_RELEASE_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
+const OTHER_EXIT_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
 const PRE_TRANSFER_STATUSES = ['DETAINED', 'ONSITE_AWAITING_TRANSFER'];
 const PROPERTY_RETURN_TOAST_KEY = 'custodyPropertyReturnToast';
 
@@ -664,7 +664,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                           leftSection={<IconDoorExit size={18} color='var(--mantine-color-gray-5)' />}
                           onClick={() => setExitToJailModalOpened(true)}
                         >
-                          Record exit to jail
+                          {isFailedIntake ? 'Exit to jail' : 'Record exit to jail'}
                         </Menu.Item>
                         {canExitToHospitalViaRelease && (
                           <Menu.Item
@@ -682,12 +682,14 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                             Record exit to other
                           </Menu.Item>
                         )}
-                        <Menu.Item
-                          leftSection={<IconFileAlert size={18} color='var(--mantine-color-gray-5)' />}
-                          onClick={() => setRecordDeathModalOpened(true)}
-                        >
-                          Record death
-                        </Menu.Item>
+                        {!isFailedIntake && (
+                          <Menu.Item
+                            leftSection={<IconFileAlert size={18} color='var(--mantine-color-gray-5)' />}
+                            onClick={() => setRecordDeathModalOpened(true)}
+                          >
+                            Record death
+                          </Menu.Item>
+                        )}
                       </Menu.Dropdown>
                     </Menu>
                   )}
@@ -710,7 +712,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                   >
                     {isAwaitingSafetyCheck
                       ? 'Record result'
-                      : (showPrimaryPrintCertificate ? 'Print release certificate' : 'Start legal release')}
+                      : (showPrimaryPrintCertificate ? 'Print release certificate' : (isFailedIntake ? 'Release and exit' : 'Start legal release'))}
                   </Button>
                 </Group>
               </Stack>

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -33,6 +33,7 @@ import classes from './CustodyDetailContent.module.css';
 
 const CUSTODY_ACTION_FOOTER_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR', 'RELEASED', 'EXITED'];
 const HOSPITAL_RELEASE_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
+const OTHER_EXIT_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
 const PRE_TRANSFER_STATUSES = ['DETAINED', 'ONSITE_AWAITING_TRANSFER'];
 const PROPERTY_RETURN_TOAST_KEY = 'custodyPropertyReturnToast';
 
@@ -76,6 +77,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   const showPrimaryStartLegalRelease = isInChair || isFailedIntake;
   const showPrimaryPrintCertificate = isPostRelease;
   const canExitToHospitalViaRelease = HOSPITAL_RELEASE_ELIGIBLE_STATUSES.includes(deflection?.subjectStatus);
+  const canExitToOtherViaRelease = OTHER_EXIT_ELIGIBLE_STATUSES.includes(deflection?.subjectStatus);
   const showAwaitingPropertyReturnChip = shouldShowPropertyReturnEntryPoint({
     viewerMode,
     isCustody,
@@ -92,6 +94,10 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
 
   function navigateToHospitalReleaseFlow () {
     navigate(`/custody/${deflection.id}/legal-release?from=detail&releaseReason=MEDICAL_ISSUE&exitDestination=HOSPITAL`);
+  }
+
+  function navigateToOtherExitReleaseFlow () {
+    navigate(`/custody/${deflection.id}/legal-release?from=detail&releaseReason=OTHER`);
   }
 
   useEffect(() => {
@@ -594,25 +600,25 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                 </Menu.Target>
                 <Menu.Dropdown>
                   <Menu.Item
-                    leftSection={<IconFileCheck size={18} color='var(--mantine-color-gray-5)' />}
-                    onClick={() => navigate(`/custody/${deflection.id}/legal-release?from=detail`)}
-                  >
-                    Legal release
-                  </Menu.Item>
-                  <Menu.Item
                     leftSection={<IconDoorExit size={18} color='var(--mantine-color-gray-5)' />}
                     onClick={() => setExitToJailModalOpened(true)}
                   >
-                    Exit to jail
+                    Record exit to jail
                   </Menu.Item>
                   {canExitToHospitalViaRelease && (
                     <Menu.Item
                       leftSection={<IconBuildingHospital size={18} color='var(--mantine-color-gray-5)' />}
                       onClick={navigateToHospitalReleaseFlow}
                     >
-                      Exit to hospital
+                      Record exit to hospital
                     </Menu.Item>
                   )}
+                  <Menu.Item
+                    leftSection={<IconFileCheck size={18} color='var(--mantine-color-gray-5)' />}
+                    onClick={navigateToOtherExitReleaseFlow}
+                  >
+                    Record exit to other
+                  </Menu.Item>
                   <Menu.Item
                     leftSection={<IconFileAlert size={18} color='var(--mantine-color-gray-5)' />}
                     onClick={() => setRecordDeathModalOpened(true)}
@@ -654,14 +660,6 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                         </ActionIcon>
                       </Menu.Target>
                       <Menu.Dropdown>
-                        {isAwaitingSafetyCheck && (
-                          <Menu.Item
-                            leftSection={<IconFileCheck size={18} color='var(--mantine-color-gray-5)' />}
-                            onClick={() => navigate(`/custody/${deflection.id}/legal-release?from=detail`)}
-                          >
-                            Legal release
-                          </Menu.Item>
-                        )}
                         <Menu.Item
                           leftSection={<IconDoorExit size={18} color='var(--mantine-color-gray-5)' />}
                           onClick={() => setExitToJailModalOpened(true)}
@@ -674,6 +672,14 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                             onClick={navigateToHospitalReleaseFlow}
                           >
                             Record exit to hospital
+                          </Menu.Item>
+                        )}
+                        {canExitToOtherViaRelease && (
+                          <Menu.Item
+                            leftSection={<IconFileCheck size={18} color='var(--mantine-color-gray-5)' />}
+                            onClick={navigateToOtherExitReleaseFlow}
+                          >
+                            Record exit to other
                           </Menu.Item>
                         )}
                         <Menu.Item

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -322,10 +322,16 @@ describe('CustodyDetailContent', () => {
     expect(html).not.toContain('Record exit to hospital');
   });
 
-  it('shows record exit to other for failed intake', () => {
+  it('only shows exit to jail in overflow actions for failed intake', () => {
     const html = render({ subjectStatus: 'FAILED_INTAKE' });
 
-    expect(html).toContain('Record exit to other');
+    expect(html).toContain('>Exit to jail</a>');
+    expect(html).not.toContain('>Record exit to jail</a>');
+    expect(html).not.toContain('>Record exit to hospital</a>');
+    expect(html).not.toContain('>Record exit to other</a>');
+    expect(html).not.toContain('>Record death</a>');
+    expect(html).toContain('Release and exit');
+    expect(html).not.toContain('Start legal release');
   });
 
   it('renders the updated safety check modal copy in the footer action flow', () => {

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -253,12 +253,14 @@ describe('CustodyDetailContent', () => {
     const html = render();
 
     expect(html).toContain('Intake staff can scan this code to start full intake.');
-    expect(html).toContain('Legal release');
+    expect(html).toContain('Record exit to other');
     expect(html).toContain('Behavioral observations');
     expect(html).toContain('Substance-related details');
     expect(html).toContain('Property details');
     expect(html).toContain('Incident details');
     expect(html).toContain('CASE-456');
+
+    expect(html.indexOf('Record exit to hospital')).toBeLessThan(html.indexOf('Record exit to other'));
   });
 
   it('renders 849(b) narrative in read-only mode by default with edit button', () => {
@@ -318,6 +320,12 @@ describe('CustodyDetailContent', () => {
 
     expect(html).not.toContain('Exit to hospital');
     expect(html).not.toContain('Record exit to hospital');
+  });
+
+  it('shows record exit to other for failed intake', () => {
+    const html = render({ subjectStatus: 'FAILED_INTAKE' });
+
+    expect(html).toContain('Record exit to other');
   });
 
   it('renders the updated safety check modal copy in the footer action flow', () => {

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -42,6 +42,15 @@ function LegalReleaseQuestions () {
     queryKey: ['deflections', id],
     queryFn: () => Api.deflections.get(id).then(response => response.data),
   });
+  const isInChair = deflection?.subjectStatus === 'IN_CHAIR';
+  const canReleaseAsSobered = isInChair;
+  const isDefaultSoberedReleaseFlow = isInChair && !prefilledState.releaseReason;
+
+  useEffect(() => {
+    if (isDefaultSoberedReleaseFlow && !releaseReason) {
+      setReleaseReason('SOBERED');
+    }
+  }, [isDefaultSoberedReleaseFlow, releaseReason]);
 
   const incidentQuery = useQuery({
     queryKey: ['incidents', deflection?.incidentId],
@@ -134,7 +143,7 @@ function LegalReleaseQuestions () {
       <Container>
         <Stack gap='xl'>
           <Stack gap={0}>
-            <Text size='xl' c='dimmed'>Confirm legal release</Text>
+            <Text size='xl' c='dimmed'>{isExitRelease ? 'Confirm legal release and exit' : 'Confirm legal release'}</Text>
             <Title order={3}>Review the 849(b).</Title>
           </Stack>
 
@@ -210,19 +219,34 @@ function LegalReleaseQuestions () {
           {hasReviewedNarrative && (
             <>
               <Stack gap='xl'>
-                <Title order={3}>Choose a release reason.</Title>
-                <Input.Wrapper label='Release reason' required>
-                  <Box mt='md'>
-                    <Chip.Group value={releaseReason} onChange={setReleaseReason}>
-                      <Stack gap='sm' align='flex-start'>
-                        <Chip data-testid='release-reason-sobered' value='SOBERED'>Can care for themselves</Chip>
-                        <Chip value='MEDICAL_ISSUE'>Medical issue (physical)</Chip>
-                        <Chip value='BEHAVIORAL_HEALTH_EVALUATION'>Behavioral health evaluation</Chip>
-                        <Chip value='OTHER'>Other (please specify)</Chip>
-                      </Stack>
-                    </Chip.Group>
-                  </Box>
-                </Input.Wrapper>
+                {isDefaultSoberedReleaseFlow
+                  ? (
+                    <Stack gap='xs'>
+                      <Title order={3}>Release reason: can care for themselves</Title>
+                      <Text size='md' c='dimmed'>
+                        If this person cannot care for themselves and instead needs to be exited to jail, to hospital, or for another reason, go back and choose a different option via the overflow menu.
+                      </Text>
+                    </Stack>
+                    )
+                  : (
+                    <>
+                      <Title order={3}>Choose a release reason.</Title>
+                      <Input.Wrapper label='Release reason' required>
+                        <Box mt='md'>
+                          <Chip.Group value={releaseReason} onChange={setReleaseReason}>
+                            <Stack gap='sm' align='flex-start'>
+                              {canReleaseAsSobered && (
+                                <Chip data-testid='release-reason-sobered' value='SOBERED'>Can care for themselves</Chip>
+                              )}
+                              <Chip value='MEDICAL_ISSUE'>Medical issue (physical)</Chip>
+                              <Chip value='BEHAVIORAL_HEALTH_EVALUATION'>Behavioral health evaluation</Chip>
+                              <Chip value='OTHER'>Other (please specify)</Chip>
+                            </Stack>
+                          </Chip.Group>
+                        </Box>
+                      </Input.Wrapper>
+                    </>
+                    )}
                 {(isMedicalRelease || isBehavioralHealthRelease) && (
                   <>
                     <Text size='md' c='dimmed'>
@@ -267,7 +291,11 @@ function LegalReleaseQuestions () {
 
               <Group gap='md' wrap='nowrap' align='flex-start'>
                 <IconAlertCircle size={24} color='var(--mantine-color-indigo-6)' stroke={1.75} />
-                <Text size='md'>When you confirm release, the 849(b) will be sent to SFSO records and your e-mail.</Text>
+                <Text size='md'>
+                  {isExitRelease
+                    ? 'When you confirm release and exit, the 849(b) will be sent to SFSO records and your e-mail.'
+                    : 'When you confirm release, the 849(b) will be sent to SFSO records and your e-mail.'}
+                </Text>
               </Group>
 
               <Group>
@@ -288,6 +316,7 @@ function LegalReleaseQuestions () {
                   loading={releaseMutation.isPending || saveNarrativeMutation.isPending}
                   disabled={
                     !releaseReason ||
+                    (releaseReason === 'SOBERED' && !canReleaseAsSobered) ||
                     ((releaseReason === 'MEDICAL_ISSUE' || releaseReason === 'BEHAVIORAL_HEALTH_EVALUATION') && !exitDestination) ||
                     (releaseReason === 'OTHER' && (!otherReason.trim() || !otherDestination.trim())) ||
                     (releaseReason !== 'SOBERED' &&

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.jsx
@@ -43,8 +43,10 @@ function LegalReleaseQuestions () {
     queryFn: () => Api.deflections.get(id).then(response => response.data),
   });
   const isInChair = deflection?.subjectStatus === 'IN_CHAIR';
+  const isFailedIntake = deflection?.subjectStatus === 'FAILED_INTAKE';
   const canReleaseAsSobered = isInChair;
   const isDefaultSoberedReleaseFlow = isInChair && !prefilledState.releaseReason;
+  const usesReleaseAndExitCopy = isExitRelease || isFailedIntake;
 
   useEffect(() => {
     if (isDefaultSoberedReleaseFlow && !releaseReason) {
@@ -143,7 +145,7 @@ function LegalReleaseQuestions () {
       <Container>
         <Stack gap='xl'>
           <Stack gap={0}>
-            <Text size='xl' c='dimmed'>{isExitRelease ? 'Confirm legal release and exit' : 'Confirm legal release'}</Text>
+            <Text size='xl' c='dimmed'>{usesReleaseAndExitCopy ? 'Confirm legal release and exit' : 'Confirm legal release'}</Text>
             <Title order={3}>Review the 849(b).</Title>
           </Stack>
 
@@ -292,7 +294,7 @@ function LegalReleaseQuestions () {
               <Group gap='md' wrap='nowrap' align='flex-start'>
                 <IconAlertCircle size={24} color='var(--mantine-color-indigo-6)' stroke={1.75} />
                 <Text size='md'>
-                  {isExitRelease
+                  {usesReleaseAndExitCopy
                     ? 'When you confirm release and exit, the 849(b) will be sent to SFSO records and your e-mail.'
                     : 'When you confirm release, the 849(b) will be sent to SFSO records and your e-mail.'}
                 </Text>
@@ -325,7 +327,7 @@ function LegalReleaseQuestions () {
                       releaseReason !== 'OTHER')
                   }
                 >
-                  {isExitRelease ? 'Confirm release and exit' : 'Confirm release'}
+                  {usesReleaseAndExitCopy ? 'Confirm release and exit' : 'Confirm release'}
                 </Button>
               </Group>
             </>

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
@@ -12,6 +12,7 @@ const {
   mockDeflectionRelease,
   mockDeflectionUpdate,
   mockIncidentGet,
+  mockSearchParams,
 } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockShowToast: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockDeflectionRelease: vi.fn(),
   mockDeflectionUpdate: vi.fn(),
   mockIncidentGet: vi.fn(),
+  mockSearchParams: { value: new URLSearchParams() },
 }));
 
 vi.mock('@/Api', () => ({
@@ -37,7 +39,7 @@ vi.mock('@/Api', () => ({
 vi.mock('react-router', () => ({
   useNavigate: () => mockNavigate,
   useParams: () => ({ id: '123' }),
-  useSearchParams: () => [new URLSearchParams()],
+  useSearchParams: () => [mockSearchParams.value],
 }));
 
 vi.mock('@unhead/react', () => ({
@@ -87,6 +89,7 @@ describe('LegalReleaseQuestions', () => {
       data: {
         id: '123',
         incidentId: 'incident-1',
+        subjectStatus: 'READY_FOR_INTAKE',
       },
     });
     mockIncidentGet.mockResolvedValue({
@@ -96,6 +99,7 @@ describe('LegalReleaseQuestions', () => {
     });
     mockDeflectionRelease.mockResolvedValue({ data: {} });
     mockDeflectionUpdate.mockResolvedValue({ data: {} });
+    mockSearchParams.value = new URLSearchParams();
   });
 
   afterEach(() => {
@@ -150,8 +154,10 @@ describe('LegalReleaseQuestions', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
     fireEvent.click(screen.getByRole('radio', { name: 'Behavioral health evaluation' }));
+    expect(screen.getByText('Confirm legal release and exit')).toBeInTheDocument();
     expect(screen.getByText('This will also mark the person as exited from RESET.')).toBeInTheDocument();
     expect(screen.getByText('Exit destination')).toBeInTheDocument();
+    expect(screen.getByText('When you confirm release and exit, the 849(b) will be sent to SFSO records and your e-mail.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Confirm release and exit' })).toBeDisabled();
     fireEvent.click(screen.getByRole('radio', { name: 'Other' }));
     fireEvent.click(screen.getByRole('button', { name: 'Confirm release and exit' }));
@@ -161,6 +167,57 @@ describe('LegalReleaseQuestions', () => {
         releaseReason: 'BEHAVIORAL_HEALTH_EVALUATION',
         exitDestination: 'OTHER',
       });
+    });
+  });
+
+  it('preselects other release and shows supplemental fields from search params', async () => {
+    mockSearchParams.value = new URLSearchParams({
+      from: 'detail',
+      releaseReason: 'OTHER',
+    });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+
+    expect(screen.getByText('Confirm legal release and exit')).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Other (please specify)' })).toBeChecked();
+    expect(screen.getByText('Other release reason')).toBeInTheDocument();
+    expect(screen.getByText('Other release destination')).toBeInTheDocument();
+    expect(screen.getByText('When you confirm release and exit, the 849(b) will be sent to SFSO records and your e-mail.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm release and exit' })).toBeDisabled();
+  });
+
+  it('hides can care for themselves when the person is not in chair', async () => {
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+
+    expect(screen.queryByRole('radio', { name: 'Can care for themselves' })).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Medical issue (physical)' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Other (please specify)' })).toBeInTheDocument();
+  });
+
+  it('shows fixed can-care-for-themselves reason when the person is in chair', async () => {
+    mockDeflectionGet.mockResolvedValue({
+      data: {
+        id: '123',
+        incidentId: 'incident-1',
+        subjectStatus: 'IN_CHAIR',
+      },
+    });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+
+    expect(screen.getByText('Confirm legal release')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Release reason: can care for themselves' })).toBeInTheDocument();
+    expect(screen.getByText('If this person cannot care for themselves and instead needs to be exited to jail, to hospital, or for another reason, go back and choose a different option via the overflow menu.')).toBeInTheDocument();
+    expect(screen.getByText('When you confirm release, the 849(b) will be sent to SFSO records and your e-mail.')).toBeInTheDocument();
+    expect(screen.queryByText('Release reason')).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Can care for themselves' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'Medical issue (physical)' })).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Confirm release' })).not.toBeDisabled();
     });
   });
 });

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.screen.test.jsx
@@ -197,6 +197,23 @@ describe('LegalReleaseQuestions', () => {
     expect(screen.getByRole('radio', { name: 'Other (please specify)' })).toBeInTheDocument();
   });
 
+  it('uses release-and-exit copy for failed intake', async () => {
+    mockDeflectionGet.mockResolvedValue({
+      data: {
+        id: '123',
+        incidentId: 'incident-1',
+        subjectStatus: 'FAILED_INTAKE',
+      },
+    });
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Mark as reviewed' }));
+
+    expect(screen.getByText('Confirm legal release and exit')).toBeInTheDocument();
+    expect(screen.getByText('When you confirm release and exit, the 849(b) will be sent to SFSO records and your e-mail.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm release and exit' })).toBeDisabled();
+  });
+
   it('shows fixed can-care-for-themselves reason when the person is in chair', async () => {
     mockDeflectionGet.mockResolvedValue({
       data: {

--- a/client/src/lesc/components/custody/LegalReleaseQuestions.test.js
+++ b/client/src/lesc/components/custody/LegalReleaseQuestions.test.js
@@ -51,4 +51,16 @@ describe('getPrefilledLegalReleaseState', () => {
       exitDestination: null,
     });
   });
+
+  it('prefills other release without an exit destination', () => {
+    const params = new URLSearchParams({
+      releaseReason: 'OTHER',
+      exitDestination: 'HOSPITAL',
+    });
+
+    expect(getPrefilledLegalReleaseState(params)).toEqual({
+      releaseReason: 'OTHER',
+      exitDestination: null,
+    });
+  });
 });


### PR DESCRIPTION
## Summary

This PR clarifies custody release/exit flows so the UI matches the actual behavior for people who are not following the standard in-chair legal release path.

### Changes

#### Changes to pre-`IN_CHAIR` person statuses release/exit flows 
- In overflow menu, renames "Legal release" to "Record exit to other": legal release in the standard "can care for themselves" flow should not be an option for these statuses. 
- Routes this new “Record exit to other” option through the existing release & exit flow with `Other` preselected and supplemental reason/destination fields visible.
- Removes “Can care for themselves” as a reason, since this should not be an option

#### Updates to `IN_CHAIR` happy-path “Start legal release” flow (main CTA)
  - Hides release reason chips (because "can care for themselves" is the default)
  - Shows fixed copy: “Release reason: can care for themselves”
  - Adds helper text directing users back to overflow actions for jail, hospital, or other exits

#### Updates to immediate release-and-exit flows:
  - Title changed to: “Confirm legal release and exit”
  - Helper text changed to: “When you confirm release and exit, the 849(b) will be sent to SFSO records and your e-mail.”

#### Updates to failed-intake behavior
  - Person card CTA: “Release and exit”
  - Detail primary CTA: “Release and exit”
  - Overflow menu only shows “Exit to jail”
  - Legal release view uses release-and-exit title/helper copy

Closes #886 