### PR TITLE
Changes button label for safety check (#936)

### DIFF
--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -721,7 +721,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                     }}
                   >
                     {isAwaitingSafetyCheck
-                      ? 'Record result'
+                      ? 'Safety check'
                       : (showPrimaryPrintCertificate ? 'Print release certificate' : 'Start legal release')}
                   </Button>
                 </Group>

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -327,7 +327,7 @@ describe('CustodyDetailContent', () => {
   it('renders the updated safety check modal copy in the footer action flow', () => {
     const html = render({ subjectStatus: 'AWAITING_INTAKE' });
 
-    expect(html).toContain('Record result');
+    expect(html).toContain('Safety check');
     expect(html).toContain('Record safety check');
     expect(html).toContain('Indicate a failed check if you have a safety concern that would require an exit to jail.');
     expect(html).toContain('Passed');


### PR DESCRIPTION
## Summary

Changes "Record result" button label to "Safety check", in person details view. Makes it consistent with the card on the Home Screen.

Closes #936 