### PR TITLE
Allows custody user to edit property (#893)

### DIFF
--- a/client/src/lesc/components/PropertyForm.jsx
+++ b/client/src/lesc/components/PropertyForm.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { useNavigate, useParams, useSearchParams } from 'react-router';
+import { useLocation, useNavigate, useParams, useSearchParams } from 'react-router';
 import { Head } from '@unhead/react';
 import { IconArrowLeft, IconX } from '@tabler/icons-react';
 import { Accordion, Anchor, Badge, Box, Button, CloseButton, Container, Divider, Fieldset, Group, Image, Stack, Text, Textarea, Title } from '@mantine/core';
@@ -13,6 +13,7 @@ import ChipInput from '@/components/ChipInput';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
 import PhotoInput from '@/components/PhotoInput';
+import { useToast } from '@/components/ToastContext';
 import { validateProperty } from '@/utils/validators';
 
 const initialValues = {
@@ -23,11 +24,14 @@ const maxPropertyPhotos = 5;
 
 function PropertyForm () {
   const navigate = useNavigate();
+  const location = useLocation();
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const isNew = searchParams.get('isNew') === 'true';
+  const isCustodyContext = location.pathname.startsWith('/custody');
   const queryClient = useQueryClient();
   const { facility } = useFacilityContext();
+  const { showToast } = useToast();
   const { t } = useTranslation();
   const [isLarge, setIsLarge] = useState(false);
   const autoSaveTimerRef = useRef(null);
@@ -42,7 +46,7 @@ function PropertyForm () {
     initialValues,
     onValuesChange: (values) => {
       setIsLarge(values.property === 'LARGE');
-      if (form.initialized) {
+      if (form.initialized && !isCustodyContext) {
         scheduleAutoSave(values);
       }
     },
@@ -89,6 +93,11 @@ function PropertyForm () {
   async function updateDeflectionCache (updatedDeflection) {
     await queryClient.setQueryData(['deflections', id], updatedDeflection);
     queryClient.invalidateQueries({ queryKey: ['facilities', facility.id, 'my-holds'] });
+    if (isCustodyContext) {
+      queryClient.invalidateQueries({ queryKey: ['deflections', String(id)] });
+      queryClient.invalidateQueries({ queryKey: ['deflections', facility.id] });
+      queryClient.invalidateQueries({ queryKey: ['deflections'] });
+    }
   }
 
   const autoSaveMutation = useMutation({
@@ -102,7 +111,17 @@ function PropertyForm () {
     mutationFn: (data) => Api.deflections.update(id, data),
     onSuccess: async (response) => {
       await updateDeflectionCache(response.data);
+      if (isCustodyContext) {
+        showToast('Property details saved', 'success', 4000, 'Property details have been saved.');
+        navigate(`/custody/${id}`);
+        return;
+      }
       navigate(isNew ? `/holds/${id}/certify?isNew=true` : `/holds/${id}`);
+    },
+    onError: () => {
+      if (!isCustodyContext) return;
+      showToast('We couldn’t save property details', 'error', 4000, 'Please try again.');
+      navigate(`/custody/${id}`);
     },
   });
 
@@ -151,13 +170,18 @@ function PropertyForm () {
   const propertyPhotos = deflection?.propertyPhotos ?? [];
 
   let header;
-  if (onSubmitMutation.isPending || autoSaveMutation.isPending) {
+  if (onSubmitMutation.isPending || (!isCustodyContext && autoSaveMutation.isPending)) {
     header = <Text c='dimmed' size='lg'>Saving...</Text>;
-  } else if (onSubmitMutation.isSuccess || autoSaveMutation.isSuccess) {
+  } else if (!isCustodyContext && (onSubmitMutation.isSuccess || autoSaveMutation.isSuccess)) {
     header = <Text c='teal.6' size='lg'>Changes saved</Text>;
-  } else if (onSubmitMutation.isError || autoSaveMutation.isError) {
+  } else if (!isCustodyContext && (onSubmitMutation.isError || autoSaveMutation.isError)) {
     header = <Text c='red.6' size='lg'>Save failed</Text>;
   }
+
+  const detailPath = isCustodyContext ? `/custody/${id}` : `/holds/${id}`;
+  const backPath = isCustodyContext ? detailPath : (isNew ? `/holds/${id}/deflection?isNew=true` : detailPath);
+  const closePath = isCustodyContext ? detailPath : '/holds';
+  const headerJustify = isCustodyContext ? 'flex-end' : 'space-between';
 
   return (
     <>
@@ -165,10 +189,10 @@ function PropertyForm () {
         <title>Personal property</title>
       </Head>
       <Header>
-        <Group w='100%' justify='space-between'>
-          <IconButtonLink icon={IconArrowLeft} to={isNew ? `/holds/${id}/deflection?isNew=true` : `/holds/${id}`} aria-label='Go back' />
+        <Group w='100%' justify={headerJustify}>
+          {!isCustodyContext && <IconButtonLink icon={IconArrowLeft} to={backPath} aria-label='Go back' />}
           {header}
-          <IconButtonLink icon={IconX} to='/holds' aria-label='Close' />
+          <IconButtonLink icon={IconX} to={closePath} aria-label='Close' />
         </Group>
       </Header>
       <Container>
@@ -181,14 +205,16 @@ function PropertyForm () {
           <Title order={2}>Personal property</Title>
           {isNew && <Badge variant='light' color='gray' size='lg' radius='xl'>4/5</Badge>}
         </Group>
-        <Text c='dimmed' size='md' mb='xl'>Document any personal property the person is bringing.</Text>
+        <Text c='dimmed' size='md' mb='xl'>
+          {isCustodyContext ? 'Record the amount of personal property.' : 'Document any personal property the person is bringing.'}
+        </Text>
         <form onSubmit={form.onSubmit(onSubmitMutation.mutateAsync)}>
           <Fieldset disabled={isLoading || onSubmitMutation.isPending} variant='unstyled'>
             <Stack gap='xl'>
               <ChipInput
                 {...form.getInputProps('property')}
                 key={form.key('property')}
-                label={<>How much property is the person bringing?<span>*</span></>}
+                label={<>{isCustodyContext ? 'How much personal property does the person have?' : 'How much property is the person bringing?'}<span>*</span></>}
                 options={['NONE', 'SMALL', 'MEDIUM', 'LARGE'].map(value => ({
                   value,
                   label: t(`property.${value}`),
@@ -259,7 +285,7 @@ function PropertyForm () {
                 </Accordion.Item>
               </Accordion>
               <Button type='submit' mb='xl'>
-                {isNew ? 'Next: Certify' : 'Save property'}
+                {isNew ? 'Next: Certify' : (isCustodyContext ? 'Save changes' : 'Save property')}
               </Button>
             </Stack>
           </Fieldset>

--- a/client/src/lesc/components/custody/CustodyDetailContent.jsx
+++ b/client/src/lesc/components/custody/CustodyDetailContent.jsx
@@ -37,6 +37,7 @@ const CUSTODY_ACTION_FOOTER_STATUSES = ['AWAITING_INTAKE', 'FAILED_INTAKE', 'REA
 const HOSPITAL_RELEASE_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
 const OTHER_EXIT_ELIGIBLE_STATUSES = ['AWAITING_INTAKE', 'READY_FOR_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR'];
 const PRE_TRANSFER_STATUSES = ['DETAINED', 'ONSITE_AWAITING_TRANSFER'];
+const CUSTODY_PROPERTY_EDIT_STATUSES = ['AWAITING_INTAKE', 'READY_FOR_INTAKE', 'FAILED_INTAKE', 'IN_MEDICAL_INTAKE', 'IN_CHAIR', 'RELEASED'];
 const PROPERTY_RETURN_TOAST_KEY = 'custodyPropertyReturnToast';
 
 function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = 'custody' }) {
@@ -66,6 +67,7 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
   const isArrived = deflection?.subjectStatus === 'ONSITE_AWAITING_TRANSFER';
   const isPostRelease = isLegallyReleased || isExited;
   const canEditCustodyDetails = !isCareView && !isPreTransfer && !isPostRelease;
+  const canEditCustodyProperty = !isCareView && isCustody && CUSTODY_PROPERTY_EDIT_STATUSES.includes(deflection?.subjectStatus);
   const now = useNow(1000, isPreTransfer && !isArrived && !!deflection?.expiresAt);
   const expiresIn = isPreTransfer && !isArrived && deflection?.expiresAt
     ? formatTimeRemaining(deflection.expiresAt, now)
@@ -465,7 +467,10 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                 </Accordion.Item>
                 <Accordion.Item value='property' id={propertySectionId}>
                   <Accordion.Control>
-                    <Title order={3}>Property details</Title>
+                    <Title order={3}>Personal property</Title>
+                    {deflection?.id && (
+                      <Text c='gray.5' size='sm'>Linked to Hold {deflection.id}.</Text>
+                    )}
                   </Accordion.Control>
                   <Accordion.Panel>
                     <Stack gap='sm'>
@@ -496,6 +501,11 @@ function CustodyDetailContent ({ deflection, backTo = '/custody', viewerMode = '
                       )}
                       {!!propertyReturnStatusText && (
                         <Text c={deflection?.propertyReturned ? 'teal.6' : 'yellow.8'}>{propertyReturnStatusText}</Text>
+                      )}
+                      {canEditCustodyProperty && (
+                        <Group mt='sm'>
+                          <Button variant='secondary' size='md' onClick={() => navigate(`/custody/${deflection?.id}/property`)}>Edit</Button>
+                        </Group>
                       )}
                     </Stack>
                   </Accordion.Panel>

--- a/client/src/lesc/components/custody/CustodyDetailContent.test.js
+++ b/client/src/lesc/components/custody/CustodyDetailContent.test.js
@@ -264,7 +264,8 @@ describe('CustodyDetailContent', () => {
     expect(html).toContain('Record exit to other');
     expect(html).toContain('Behavioral observations');
     expect(html).toContain('Substance-related details');
-    expect(html).toContain('Property details');
+    expect(html).toContain('Personal property');
+    expect(html).toContain('Linked to Hold 123456.');
     expect(html).toContain('Incident details');
     expect(html).toContain('CASE-456');
 
@@ -276,7 +277,7 @@ describe('CustodyDetailContent', () => {
 
     expect(html).toContain('849(b) release narrative');
     expect(html).toContain('Any narrative edits will automatically update the 849(b) document.');
-    expect((html.match(/>Edit</g) || [])).toHaveLength(2);
+    expect((html.match(/>Edit</g) || [])).toHaveLength(3);
     expect(html).not.toContain('<textarea');
   });
 
@@ -311,6 +312,29 @@ describe('CustodyDetailContent', () => {
 
     expect(html).toContain('849(b).pdf');
     expect(html).toContain('E-mail me the 849(b)');
+    expect(html).toContain('Edit narrative');
+  });
+
+  it('allows property edits after legal release until exit', () => {
+    const html = render({
+      subjectStatus: 'RELEASED',
+      releasedAt: '2026-01-01T11:00:00.000Z',
+    });
+
+    expect(html).toContain('Personal property');
+    expect((html.match(/>Edit</g) || [])).toHaveLength(1);
+    expect(html).toContain('Edit narrative');
+  });
+
+  it('does not allow property edits after exit', () => {
+    const html = render({
+      subjectStatus: 'EXITED',
+      releasedAt: '2026-01-01T11:00:00.000Z',
+      exitedAt: '2026-01-01T12:00:00.000Z',
+    });
+
+    expect(html).toContain('Personal property');
+    expect(html).not.toContain('>Edit</button>');
     expect(html).toContain('Edit narrative');
   });
 

--- a/client/src/lesc/routes/LESCRoutes.jsx
+++ b/client/src/lesc/routes/LESCRoutes.jsx
@@ -39,6 +39,7 @@ function LESCRoutes () {
       <Route path='incident' element={<IncidentForm />} />
       <Route path='incident/handoff' element={<HandoffScreen />} />
       <Route path='custody/:id/subject' element={<SubjectForm />} />
+      <Route path='custody/:id/property' element={<PropertyForm />} />
       <Route path='custody/:id/legal-release' element={<LegalReleaseQuestions />} />
       <Route path='custody/:id/property-return' element={<RecordPropertyReturn />} />
       <Route path='custody/:id/release-narrative' element={<CustodyReleaseNarrativeForm />} />

--- a/server/lib/incidentPermissions.js
+++ b/server/lib/incidentPermissions.js
@@ -4,7 +4,17 @@
  *   isIncidentDetailsComplete — are all required incident fields filled in?
  *   isDeflectionDetailsComplete — are all required deflection fields filled in?
  *   canModifyDeflection       — can this user modify a deflection?
+ *   canModifyDeflectionProperty — can this user modify personal property fields/photos?
  */
+
+const CUSTODY_PROPERTY_EDIT_STATUSES = [
+  'AWAITING_INTAKE',
+  'READY_FOR_INTAKE',
+  'FAILED_INTAKE',
+  'IN_MEDICAL_INTAKE',
+  'IN_CHAIR',
+  'RELEASED',
+];
 
 /**
  * Are all required incident fields filled in?
@@ -56,4 +66,20 @@ export function canModifyDeflection (deflection, user) {
   if (user.isAdmin) return true;
   if (user.isCustody) return true;
   return deflection.currentOfficerId === user.id;
+}
+
+/**
+ * Can this user modify a deflection's personal property fields or photos?
+ * Field users keep their existing hold-control access. Custody users can edit
+ * only after custody transfer and before the person exits.
+ */
+export function canModifyDeflectionProperty (deflection, user) {
+  if (user.isAdmin) return true;
+  if (deflection.currentOfficerId === user.id) return true;
+  return user.isCustody && CUSTODY_PROPERTY_EDIT_STATUSES.includes(deflection.subjectStatus);
+}
+
+export function isDeflectionPropertyUpdate (data) {
+  return Object.prototype.hasOwnProperty.call(data, 'property') ||
+    Object.prototype.hasOwnProperty.call(data, 'propertyDetails');
 }

--- a/server/routes/api/deflections/update.js
+++ b/server/routes/api/deflections/update.js
@@ -5,7 +5,7 @@ import Deflection from '#models/deflection.js';
 import DeflectionDocument from '#models/deflectionDocument.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
-import { canModifyDeflection } from '#lib/incidentPermissions.js';
+import { canModifyDeflection, canModifyDeflectionProperty, isDeflectionPropertyUpdate } from '#lib/incidentPermissions.js';
 import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
 
 export default async function (fastify, opts) {
@@ -35,7 +35,11 @@ export default async function (fastify, opts) {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      if (!canModifyDeflection(deflection, request.user)) {
+      const canModify = isDeflectionPropertyUpdate(data)
+        ? canModifyDeflectionProperty(deflection, request.user)
+        : canModifyDeflection(deflection, request.user);
+
+      if (!canModify) {
         return reply.code(StatusCodes.FORBIDDEN).send();
       }
 

--- a/server/routes/api/property-photos/create.js
+++ b/server/routes/api/property-photos/create.js
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 
 import PropertyPhoto from '#models/propertyPhoto.js';
-import { canModifyDeflection } from '#lib/incidentPermissions.js';
+import { canModifyDeflectionProperty } from '#lib/incidentPermissions.js';
 
 export default async function (fastify, opts) {
   fastify.post('/',
@@ -27,7 +27,7 @@ export default async function (fastify, opts) {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      if (!canModifyDeflection(deflection, request.user)) {
+      if (!canModifyDeflectionProperty(deflection, request.user)) {
         return reply.code(StatusCodes.FORBIDDEN).send();
       }
 

--- a/server/routes/api/property-photos/delete.js
+++ b/server/routes/api/property-photos/delete.js
@@ -2,6 +2,7 @@ import { StatusCodes } from 'http-status-codes';
 import { z } from 'zod';
 
 import PropertyPhoto from '#models/propertyPhoto.js';
+import { canModifyDeflectionProperty } from '#lib/incidentPermissions.js';
 
 export default async function (fastify, opts) {
   fastify.delete('/:id',
@@ -22,13 +23,14 @@ export default async function (fastify, opts) {
 
       const data = await fastify.prisma.propertyPhoto.findUnique({
         where: { id },
+        include: { deflection: true },
       });
 
       if (!data) {
         return reply.code(StatusCodes.NOT_FOUND).send();
       }
 
-      if (data.createdById !== request.user.id && !request.user.isAdmin) {
+      if (!canModifyDeflectionProperty(data.deflection, request.user)) {
         return reply.code(StatusCodes.FORBIDDEN).send();
       }
 

--- a/server/test/routes/api/deflections.test.js
+++ b/server/test/routes/api/deflections.test.js
@@ -369,6 +369,44 @@ test('/api/deflections', async (t) => {
       });
     });
 
+    await t.test('allows custody users to update property after release before exit', async () => {
+      await prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'RELEASED',
+          releasedAt: new Date(),
+          exitedAt: null,
+        },
+      });
+
+      const response = await app.inject().patch('/api/deflections/6').payload({
+        property: 'MEDIUM',
+        propertyDetails: 'Two standard bags',
+      }).headers(custodyUserHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+      const data = JSON.parse(response.body);
+      assert.deepStrictEqual(data.property, 'MEDIUM');
+      assert.deepStrictEqual(data.propertyDetails, 'Two standard bags');
+    });
+
+    await t.test('forbids custody users from updating property after exit', async () => {
+      await prisma.deflection.update({
+        where: { id: 6 },
+        data: {
+          subjectStatus: 'EXITED',
+          releasedAt: new Date(),
+          exitedAt: new Date(),
+        },
+      });
+
+      const response = await app.inject().patch('/api/deflections/6').payload({
+        property: 'SMALL',
+      }).headers(custodyUserHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.FORBIDDEN);
+    });
+
     await t.test('returns 404 for non-existent deflection', async () => {
       const nonExistentId = '0';
       const response = await app.inject().patch(`/api/deflections/${nonExistentId}`).payload({


### PR DESCRIPTION
## Summary

- Adds custody access to edit personal property details after custody transfer and before exit.
- Reuses the existing property edit form at a new `/custody/:id/property` route.
- Shows success/error toasts after custody property saves and returns users to the custody details overview.
- Tightens backend property permissions so custody property fields/photos follow the same after-transfer-before-exit window.

Closes #893 