### PR TITLE
Baked appearances and fonts to ensure fields print on mobile (#958)

### DIFF
--- a/server/lib/forms/849b/fill849b.js
+++ b/server/lib/forms/849b/fill849b.js
@@ -10,7 +10,7 @@
  *   const filledBytes = await fill849b(templatePdfBytes, data);
  */
 
-import { PDFDocument, PDFName, PDFBool } from 'pdf-lib';
+import { PDFDocument, PDFName, StandardFonts } from 'pdf-lib';
 
 // ═══════════════════════════════════════════════════════════════════
 //  1:1 TEXT FIELD MAPPINGS  { camelCaseKey → pdfFieldName }
@@ -334,9 +334,12 @@ export async function fill849b (pdfBytes, data) {
   applyDobAge(form, 'DOBAGE', data, 'subject');
   applyDobAge(form, 'DOBAGE_2', data, 'reportingParty');
 
-  // ── Preserve the form's native fonts: let the viewer render appearances ──
-  const acroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'));
-  acroForm.set(PDFName.of('NeedAppearances'), PDFBool.True);
+  // ── Bake printable appearances into the file instead of relying on the viewer ──
+  const appearanceFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  form.updateFieldAppearances(appearanceFont);
 
-  return pdfDoc.save({ updateFieldAppearances: false });
+  const acroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'));
+  acroForm.delete(PDFName.of('NeedAppearances'));
+
+  return pdfDoc.save();
 }

--- a/server/test/lib/forms/849b.test.js
+++ b/server/test/lib/forms/849b.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import * as assert from 'node:assert';
-import { PDFDocument } from 'pdf-lib';
+import { PDFDocument, PDFName } from 'pdf-lib';
 
 import form849b from '#lib/forms/849b/index.js';
 import {
@@ -236,6 +236,9 @@ test('849b PDF fills release reporting party fields and leaves citation text bla
   );
   assert.strictEqual(pdfForm.getTextField('ZIP CODE_4').getText(), '94107');
   assert.strictEqual(pdfForm.getTextField('Text4').getText() || '', '');
+
+  const acroForm = doc.catalog.lookup(PDFName.of('AcroForm'));
+  assert.strictEqual(acroForm.has(PDFName.of('NeedAppearances')), false);
 });
 
 test('849b PDF leaves prop 115 unchecked but checks post training when reporting deputy is not certified', async () => {


### PR DESCRIPTION
## Summary

This PR makes generated `849b` PDFs print-safe on mobile by baking field appearance streams into the PDF at generation time instead of relying on the viewer to render them.

### Details

- Updated `server/lib/forms/849b/fill849b.js` to:
  - embed `StandardFonts.Helvetica`
  - call `form.updateFieldAppearances(appearanceFont)`
  - remove `AcroForm.NeedAppearances`
  - save the PDF normally

- Added a regression assertion in `server/test/lib/forms/849b.test.js` to verify generated `849b` PDFs no longer depend on `NeedAppearances`.

### Why

The previous implementation filled form fields but saved with viewer-side appearance generation:

- `NeedAppearances = true`
- `save({ updateFieldAppearances: false })`

That can display correctly in desktop PDF viewers while still printing blank from mobile Outlook / mobile print pipelines, because the file depends on the client viewer to synthesize printable field appearances.

This change makes the generated PDF self-contained and more portable across mobile viewers and print paths.

Closes #958 
