### PR TITLE
Fix filled PDF fields not printing on iOS Outlook

### DIFF
--- a/server/lib/forms/5150/fill5150.js
+++ b/server/lib/forms/5150/fill5150.js
@@ -12,65 +12,43 @@
  *   const filledBytes = await fill5150(templatePdfBytes, data);
  */
 
-import { PDFDocument } from 'pdf-lib';
+import { fillPdf } from '#lib/forms/shared/fillPdf.js';
 
-// ═══════════════════════════════════════════════════════════════════
-//  TEXT FIELD MAPPINGS  { camelCaseKey → pdfFieldName }
-// ═══════════════════════════════════════════════════════════════════
-//
-// The pdfFieldName values come from `getFields()` on the template. Some
-// names are odd (truncated mid-sentence) because that's how the source PDF
-// labels its widgets — match them verbatim.
+const spec = {
+  text: {
+    // Advisement section (top of form)
+    advisementDate:           'Date of Advisement Attempt',
+    advisementText:           'Detainment Advisement',
+    advisementCompletedBy:    'Advisement CompletedAttempted By',
+    advisementPosition:       'Position',
 
-const TEXT = {
-  // Advisement section (top of form)
-  advisementDate:           'Date of Advisement Attempt',
-  advisementText:           'Detainment Advisement', // "My name is ___"
-  advisementCompletedBy:    'Advisement CompletedAttempted By',
-  advisementPosition:       'Position',
-  // 'Language or Modality Used' intentionally blank — the deputy fills it in.
+    // Application body
+    applicationSubjectName:   'Application is hereby made for the assessment and evaluation of',
+    detainmentStartTime:      'Detainment Start Time',
+    detainmentStartDate:      'Detainment Start Date',
+    subjectDOBLower:          'Date of birth',
+    subjectAddress:           'and residing at',
 
-  // Application body
-  applicationSubjectName:   'Application is hereby made for the assessment and evaluation of',
-  detainmentStartTime:      'Detainment Start Time',
-  detainmentStartDate:      'Detainment Start Date',
-  subjectDOBLower:          'Date of birth',          // appears alongside "and residing at"
-  subjectAddress:           'and residing at',
+    // Agency / officer block (bottom of form)
+    agencyName:               'Name of Law Enforcement Agency or Evaluation FacilityPerson',
+    agencyAddress:            'Address',
+    agencyCity:               'City',
+    agencyState:              'State',
+    agencyZip:                'Zip Code',
+    officerName:              'Name',
+    officerTitle:             'Title',
+    officerBadge:             'Badge Number',
+    officerPhone:             'Phone_3',
 
-  // Agency / officer block (bottom of form)
-  agencyName:               'Name of Law Enforcement Agency or Evaluation FacilityPerson',
-  agencyAddress:            'Address',
-  agencyCity:               'City',
-  agencyState:              'State',
-  agencyZip:                'Zip Code',
-  officerName:              'Name',
-  officerTitle:             'Title',
-  officerBadge:             'Badge Number',
-  officerPhone:             'Phone_3',
+    // Lower advisement block (date+time of this advisement)
+    advisementDateLower:      'Date',
+    advisementTimeLower:      'Time',
 
-  // Lower advisement block (date+time of this advisement)
-  advisementDateLower:      'Date',
-  advisementTimeLower:      'Time',
-
-  // Subject identifier block
-  subjectName:              'Individual Detained',
-  subjectDOBUpper:          'Date of Birth',
+    // Subject identifier block
+    subjectName:              'Individual Detained',
+    subjectDOBUpper:          'Date of Birth',
+  },
 };
-
-// ═══════════════════════════════════════════════════════════════════
-//  HELPERS
-// ═══════════════════════════════════════════════════════════════════
-
-function setTextField (form, pdfField, value) {
-  const field = form.getTextField(pdfField);
-  const text = String(value);
-  const maxLength = field.getMaxLength();
-  field.setText(maxLength == null ? text : text.slice(0, maxLength));
-}
-
-// ═══════════════════════════════════════════════════════════════════
-//  MAIN FILL FUNCTION
-// ═══════════════════════════════════════════════════════════════════
 
 /**
  * Fill a DHCS-1801 PDF template with the given data.
@@ -81,17 +59,5 @@ function setTextField (form, pdfField, value) {
  * @returns {Promise<Uint8Array>}       Filled PDF bytes.
  */
 export async function fill5150 (pdfBytes, data) {
-  const pdfDoc = await PDFDocument.load(pdfBytes);
-  const form = pdfDoc.getForm();
-
-  for (const [key, pdfField] of Object.entries(TEXT)) {
-    const val = data[key];
-    if (val != null && val !== '') {
-      setTextField(form, pdfField, val);
-    }
-  }
-
-  // Form stays fully editable — the deputy completes clinical observations,
-  // advisement narrative, history sources, and signs by hand.
-  return pdfDoc.save();
+  return fillPdf(pdfBytes, data, spec);
 }

--- a/server/lib/forms/647f/fill647f.js
+++ b/server/lib/forms/647f/fill647f.js
@@ -10,56 +10,49 @@
  *   const filledBytes = await fill647f(templatePdfBytes, data);
  */
 
-import { PDFDocument, PDFName, PDFBool } from 'pdf-lib';
+import { fillPdf } from '#lib/forms/shared/fillPdf.js';
 
-// ═══════════════════════════════════════════════════════════════════
-//  TEXT FIELD MAPPINGS  { camelCaseKey → pdfFieldName }
-// ═══════════════════════════════════════════════════════════════════
+const spec = {
+  text: {
+    // Subject
+    subjectLastName:               'Subject_Last_Name',
+    subjectFirstName:              'Subject_First_Name',
+    subjectMiddleInitial:          'Subject_Middle_Initial',
+    subjectRace:                   'Subject_Race',
+    subjectSex:                    'Subject_Sex',
+    subjectDOB:                    'Subject_DOB',
+    subjectAddress:                'Subject_Address',
+    subjectDL:                     'Subject_DL',
+    subjectLocalId:                'Subject_Local_ID',
 
-const TEXT = {
-  // Subject
-  subjectLastName:               'Subject_Last_Name',
-  subjectFirstName:              'Subject_First_Name',
-  subjectMiddleInitial:          'Subject_Middle_Initial',
-  subjectRace:                   'Subject_Race',
-  subjectSex:                    'Subject_Sex',
-  subjectDOB:                    'Subject_DOB',
-  subjectAddress:                'Subject_Address',
-  subjectDL:                     'Subject_DL',
-  subjectLocalId:                'Subject_Local_ID',
+    // Arrest
+    arrestedAt:                    'Arrest_DateTime',
+    arrestLocation:                'Arrest_Location',
+    charge:                        'Charge',
+    cadNumber:                     'CAD_Number',
+    caseNumber:                    'Case_Number',
 
-  // Arrest
-  arrestedAt:                    'Arrest_DateTime',
-  arrestLocation:                'Arrest_Location',
-  charge:                        'Charge',
-  cadNumber:                     'CAD_Number',
-  caseNumber:                    'Case_Number',
+    // Officer
+    arrestingOfficerDisplay:       'Arresting_Officer',
+    arrestingOfficerUnit:          'Arresting_Officer_Unit',
+    arrestingOfficerAgency:        'Arresting_Officer_Agency',
+    supervisorBadgeNumber:         'Supervisor_Star_Number',
+    custodyReleaseOfficerDisplay:  'Custody_Transfer_Officer',
+    officerDetails:                'officerDetails',
+    certifiedAt:                   'certifiedAt',
 
-  // Officer
-  arrestingOfficerDisplay:       'Arresting_Officer',
-  arrestingOfficerUnit:          'Arresting_Officer_Unit',
-  arrestingOfficerAgency:        'Arresting_Officer_Agency',
-  supervisorBadgeNumber:         'Supervisor_Star_Number',
-  custodyReleaseOfficerDisplay:  'Custody_Transfer_Officer',
-  officerDetails:                'officerDetails',
-  certifiedAt:                   'certifiedAt',
+    // Additional
+    deflectionId:                  'Hold_ID',
+    facilityName:                  'Facility_Name',
+    facilityAddress:               'Facility_Address',
 
-  // Additional
-  deflectionId:                  'Hold_ID',
-  facilityName:                  'Facility_Name',
-  facilityAddress:               'Facility_Address',
-
-  // Narrative (multi-line in template)
-  narrative:                     'Narrative',
+    // Narrative (multi-line in template)
+    narrative:                     'Narrative',
+  },
 };
 
-// Timestamp fields appear on both pages and are filled from data.generatedTimestamp
-// then locked read-only. Listed separately from TEXT to avoid duplicating the value.
+// Timestamp fields appear on both pages and are filled then locked read-only.
 const TIMESTAMP_FIELDS = ['Generated_Timestamp', 'Generated_Timestamp_Page2'];
-
-// ═══════════════════════════════════════════════════════════════════
-//  MAIN FILL FUNCTION
-// ═══════════════════════════════════════════════════════════════════
 
 /**
  * Fill a 647(f) PDF template with the given data.
@@ -69,25 +62,13 @@ const TIMESTAMP_FIELDS = ['Generated_Timestamp', 'Generated_Timestamp_Page2'];
  * @returns {Promise<Uint8Array>}       Filled PDF bytes, ready to write.
  */
 export async function fill647f (pdfBytes, data) {
-  const pdfDoc = await PDFDocument.load(pdfBytes);
-  const form = pdfDoc.getForm();
-
-  for (const [key, pdfField] of Object.entries(TEXT)) {
-    const val = data[key];
-    if (val != null && val !== '') {
-      form.getTextField(pdfField).setText(String(val));
-    }
-  }
-
-  for (const name of TIMESTAMP_FIELDS) {
-    const field = form.getTextField(name);
-    if (data.generatedTimestamp != null) field.setText(String(data.generatedTimestamp));
-    field.enableReadOnly();
-  }
-
-  // Preserve the form's native fonts: let the viewer render appearances
-  const acroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'));
-  acroForm.set(PDFName.of('NeedAppearances'), PDFBool.True);
-
-  return pdfDoc.save({ updateFieldAppearances: false });
+  return fillPdf(pdfBytes, data, spec, {
+    customize (form) {
+      for (const name of TIMESTAMP_FIELDS) {
+        const field = form.getTextField(name);
+        if (data.generatedTimestamp != null) field.setText(String(data.generatedTimestamp));
+        field.enableReadOnly();
+      }
+    },
+  });
 }

--- a/server/lib/forms/849b/fill849b.js
+++ b/server/lib/forms/849b/fill849b.js
@@ -10,246 +10,172 @@
  *   const filledBytes = await fill849b(templatePdfBytes, data);
  */
 
-import { PDFDocument, PDFName, StandardFonts } from 'pdf-lib';
+import { fillPdf } from '#lib/forms/shared/fillPdf.js';
 
-// ═══════════════════════════════════════════════════════════════════
-//  1:1 TEXT FIELD MAPPINGS  { camelCaseKey → pdfFieldName }
-// ═══════════════════════════════════════════════════════════════════
+const spec = {
+  text: {
+    // Header
+    incidentNumber:          'INCIDENT NUMBER',
+    cadNumber:               'CAD NUMBER',
+    relatedCaseNumber:       'RELATED CASE NUMBER',
+    totalPages:              'Text2',
 
-const TEXT = {
-  // Header
-  incidentNumber:          'INCIDENT NUMBER',
-  cadNumber:               'CAD NUMBER',
-  relatedCaseNumber:       'RELATED CASE NUMBER',
-  totalPages:              'Text2',    // shared across both pages (widgetCount: 2)
+    // Incident
+    primaryIncidentType:     'PRIMARY INCIDENT TYPE',
+    occurrenceDateTime:      'DATETIME OF OCCURRENCE',
+    reportedDateTime:        'DATETIME REPORTED TO SFSO',
+    additionalIncidentTypes: 'ADDITIONAL INCIDENT TYPES DDL  SEE NARRATIVE',
+    location:                'LOCATION OF OCCURRENCE',
+    premiseType:             'TYPE OF PREMISE',
+    reportedTo:              'REPORTED TO SFSO CRUCIUSOCSFPD OPS NAMESTARDATETIME',
+    dvWeaponUsed:            'DV INCIDENT WPN USED',
 
-  // Incident
-  primaryIncidentType:     'PRIMARY INCIDENT TYPE',
-  occurrenceDateTime:      'DATETIME OF OCCURRENCE',
-  reportedDateTime:        'DATETIME REPORTED TO SFSO',
-  additionalIncidentTypes: 'ADDITIONAL INCIDENT TYPES DDL  SEE NARRATIVE',
-  location:                'LOCATION OF OCCURRENCE',
-  premiseType:             'TYPE OF PREMISE',
-  reportedTo:              'REPORTED TO SFSO CRUCIUSOCSFPD OPS NAMESTARDATETIME',
-  dvWeaponUsed:            'DV INCIDENT WPN USED',
+    // Declaration
+    prop115Years:            'Text3',
 
-  // Declaration
-  prop115Years:            'Text3',
+    // Deputy
+    reportingDeputy:         'REPORTING DEPUTY PRINT',
+    star:                    'STAR',
+    divisionUnit:            'SFSO DIVISIONUNITIDENTIFIER',
+    supervisorApproval:      'SUPERVISOR APPROVING REPORT PRINT NAMESTAR',
+    watch:                   'WATCH',
+    assignTo:                'ASSIGN TO',
+    assignedBy:              'ASSIGNED BY INITALSSTAR',
+    copiesTo:                'COPIES TO DDL UNITSGENCIES',
 
-  // Deputy
-  reportingDeputy:         'REPORTING DEPUTY PRINT',
-  star:                    'STAR',
-  divisionUnit:            'SFSO DIVISIONUNITIDENTIFIER',
-  supervisorApproval:      'SUPERVISOR APPROVING REPORT PRINT NAMESTAR',
-  watch:                   'WATCH',
-  assignTo:                'ASSIGN TO',
-  assignedBy:              'ASSIGNED BY INITALSSTAR',
-  copiesTo:                'COPIES TO DDL UNITSGENCIES',
+    // Subject
+    'subject.code':             'CODE',
+    'subject.name':             'NAME LAST FIRST MIDDLE',
+    'subject.race':             'RACE',
+    'subject.sex':              'SEX',
+    'subject.height':           'HEIGHT',
+    'subject.weight':           'WEIGHT',
+    'subject.hair':             'HAIR',
+    'subject.eyes':             'EYES',
+    'subject.residenceAddress': 'RESIDENCE ADDRESSCITY IF NOT SAN FRANCISCO',
+    'subject.residenceZip':     'ZIP CODE',
+    'subject.contactPhone':     'CONTACT PHONE NUMBER',
+    'subject.businessAddress':  'BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO',
+    'subject.businessZip':      'ZIP CODE_2',
+    'subject.businessPhone':    'BUSINESS PHONE',
+    'subject.email':            'EMAIL',
+    'subject.knownAlias':       'KNOWN ALIAS',
+    'subject.idNumber':         'ID NO SOCSECOPLICFBICII',
+    'subject.sfNumber':         'SF NUMBER',
 
-  // Subject
-  'subject.code':             'CODE',
-  'subject.name':             'NAME LAST FIRST MIDDLE',
-  'subject.race':             'RACE',
-  'subject.sex':              'SEX',
-  'subject.height':           'HEIGHT',
-  'subject.weight':           'WEIGHT',
-  'subject.hair':             'HAIR',
-  'subject.eyes':             'EYES',
-  'subject.residenceAddress': 'RESIDENCE ADDRESSCITY IF NOT SAN FRANCISCO',
-  'subject.residenceZip':     'ZIP CODE',
-  'subject.contactPhone':     'CONTACT PHONE NUMBER',
-  'subject.businessAddress':  'BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO',
-  'subject.businessZip':      'ZIP CODE_2',
-  'subject.businessPhone':    'BUSINESS PHONE',
-  'subject.email':            'EMAIL',
-  'subject.knownAlias':       'KNOWN ALIAS',
-  'subject.idNumber':         'ID NO SOCSECOPLICFBICII',
-  'subject.sfNumber':         'SF NUMBER',
+    // Booking
+    'booking.whereBooked':        'WHERE BOOKED',
+    'booking.warrant':            'WARRANT',
+    'booking.court':              'COURT',
+    'booking.action':             'ACTION',
+    'booking.deptEnRouteTo':      'DEPTENROUTE TO',
+    'booking.cruCheck':           'CRU CHECK NAMESTAR',
+    'booking.warrantViolations':  'WARRANT VIOLATIONS',
+    'booking.bail':               'BAIL',
+    'booking.mirandizedStar':     'STAR_2',
+    'booking.citation':           'CITATION',
+    'booking.citationViolations': 'CITATION VIOLATIONS',
+    'booking.appearanceDateTime': 'DATETIME OF APPEARANCE',
+    'booking.appearanceLocation': 'LOCATION OF APPEARANCE',
+    'booking.mac':                'MAC',
 
-  // Booking
-  'booking.whereBooked':       'WHERE BOOKED',
-  'booking.warrant':           'WARRANT',
-  'booking.court':             'COURT',
-  'booking.action':            'ACTION',
-  'booking.deptEnRouteTo':     'DEPTENROUTE TO',
-  'booking.cruCheck':          'CRU CHECK NAMESTAR',
-  'booking.warrantViolations': 'WARRANT VIOLATIONS',
-  'booking.bail':              'BAIL',
-  'booking.mirandizedStar':    'STAR_2',
-  'booking.citation':          'CITATION',
-  'booking.citationViolations':'CITATION VIOLATIONS',
-  'booking.appearanceDateTime':'DATETIME OF APPEARANCE',
-  'booking.appearanceLocation':'LOCATION OF APPEARANCE',
-  'booking.mac':               'MAC',
+    // Subject other info
+    subjectOtherInfo: 'OTHER INFORMATION CITATIONWARRANTBOOKING CHARGESMISSING PERSONSUBJECT LAST SEEN WEARING',
 
-  // Subject other info
-  subjectOtherInfo: 'OTHER INFORMATION CITATIONWARRANTBOOKING CHARGESMISSING PERSONSUBJECT LAST SEEN WEARING',
+    // Reporting party
+    'reportingParty.code':                  'CODE_2',
+    'reportingParty.name':                  'NAME LAST FIRST MIDDLE_2',
+    'reportingParty.race':                  'RACE_2',
+    'reportingParty.sex':                   'SEX_2',
+    'reportingParty.height':                'HEIGHT_2',
+    'reportingParty.weight':                'WEIGHT_2',
+    'reportingParty.hair':                  'HAIR_2',
+    'reportingParty.eyes':                  'EYES_2',
+    'reportingParty.residenceAddress':      'RESIDENCE ADDRESSCITY IF NOT SAN FRANCISCO_2',
+    'reportingParty.residenceZip':          'ZIP CODE_3',
+    'reportingParty.contactPhone':          'CONTACT PHONE NUMBER_2',
+    'reportingParty.businessAddress':       'BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO_2',
+    'reportingParty.businessZip':           'ZIP CODE_4',
+    'reportingParty.businessPhone':         'BUSINESS PHONE_2',
+    'reportingParty.email':                 'EMAIL_2',
+    'reportingParty.idNumber':              'ID NO SOC SECOP LICFBICII',
+    'reportingParty.sfxNumber':             'SFX NUMBER',
+    'reportingParty.relationshipToSubject': 'RELATIONSHIP TO SUBJECT',
 
-  // Reporting party
-  'reportingParty.code':             'CODE_2',
-  'reportingParty.name':             'NAME LAST FIRST MIDDLE_2',
-  'reportingParty.race':             'RACE_2',
-  'reportingParty.sex':              'SEX_2',
-  'reportingParty.height':           'HEIGHT_2',
-  'reportingParty.weight':           'WEIGHT_2',
-  'reportingParty.hair':             'HAIR_2',
-  'reportingParty.eyes':             'EYES_2',
-  'reportingParty.residenceAddress': 'RESIDENCE ADDRESSCITY IF NOT SAN FRANCISCO_2',
-  'reportingParty.residenceZip':     'ZIP CODE_3',
-  'reportingParty.contactPhone':     'CONTACT PHONE NUMBER_2',
-  'reportingParty.businessAddress':  'BUSINESS ADDRESSNAME OF SCHOOL IF JUVENILECITY IF NOT SAN FRANCISCO_2',
-  'reportingParty.businessZip':      'ZIP CODE_4',
-  'reportingParty.businessPhone':    'BUSINESS PHONE_2',
-  'reportingParty.email':            'EMAIL_2',
-  'reportingParty.idNumber':         'ID NO SOC SECOP LICFBICII',
-  'reportingParty.sfxNumber':        'SFX NUMBER',
-  'reportingParty.relationshipToSubject': 'RELATIONSHIP TO SUBJECT',
+    // Victim notifications
+    victimNotificationStar:      'STAR_3',
+    victimCrimeNotificationStar: 'STAR_4',
+    extentOfInjury:              'EXTENT OF INJURYTREATMENT',
+    rpOtherInfo:                 'OTHER INFORMATION SUBJECT LAST SEEN WEARINGEMPLOYMENTACTIVITY AT TIME OF INCIDENT',
 
-  // Victim notifications
-  victimNotificationStar:      'STAR_3',
-  victimCrimeNotificationStar: 'STAR_4',
-  extentOfInjury:              'EXTENT OF INJURYTREATMENT',
-  rpOtherInfo:                 'OTHER INFORMATION SUBJECT LAST SEEN WEARINGEMPLOYMENTACTIVITY AT TIME OF INCIDENT',
-
-  // Narrative (page 2)
-  narrative:                   'PAGE',
-};
-
-// ═══════════════════════════════════════════════════════════════════
-//  1:1 CHECKBOX MAPPINGS  { camelCaseKey → pdfFieldName }
-// ═══════════════════════════════════════════════════════════════════
-
-const CHECKBOX = {
-  arrestMade:                'ARREST MADE',
-  addlTypesSeeNarrative:     'undefined',       // ADD'L – SEE NARRATIVE (incident types)
-  addlCodesSeeNarrative:     'DDL CODES',        // ADD'L CODES SEE NARRATIVE
-  dvIncident:                'undefined_2',      // DV INCIDENT (WPN USED) checkbox
-  elderAbuse:                'undefined_3',      // ELDER ABUSE
-  gangRelated:               'GANG',
-  juvenileRelated:           'JUVENILE',
-  prejudiceBased:            'PREJUDICE',
-  prop115Certified:          'BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED',
-  postTraining:              'POST TRAINING',
-
-  // Booking
-  'booking.addlWarrants':            'ADD\'L WARRANTS',       // ADD'L - SEE NARRATIVE (warrant row)
-  'booking.addlCharges':             'ADDL CHARGES',
-  'booking.addlCiteSections':        'ADDL CITE SECTIONS',
-  'booking.bookingApproved':         'BOOKING APPROVED BY PRINT NAMESTAR',
-  'booking.addlWarrantsSeeNarrative':'ADDL WARRANTS SEE NARRATIVE',
-  'booking.citationIssued':          'CITATION_2',
-};
-
-// ═══════════════════════════════════════════════════════════════════
-//  DROPDOWN MAPPINGS  { camelCaseKey → pdfFieldName }
-// ═══════════════════════════════════════════════════════════════════
-
-const DROPDOWN = {
-  locationSentTo:   'Dropdown2',   // 'Same' | 'Same/On View' | 'Other'
-  dispositionCode:  'Dropdown4',   // 'ADV' | 'ARR/F' | 'ARR/M' | etc.
-};
-
-// ═══════════════════════════════════════════════════════════════════
-//  BOOLEAN-PAIR MAPPINGS
-//  Two checkboxes that represent a single boolean value.
-//  { camelCaseKey → [yesField, noField] }
-// ═══════════════════════════════════════════════════════════════════
-
-const BOOLEAN_PAIR = {
-  'booking.mirandized':      ['MIRANDIZED YES', 'MIRANDIZED NO'],
-  'booking.sdcsEntry':       ['sdcs yes', 'sdcs no'],
-  'booking.xrays':           ['Y', 'N'],
-  'booking.addlSubjects':    ['Y_2', 'N_2'],
-  addlReportingParties:      ['Y_3', 'N_3'],
-};
-
-// ═══════════════════════════════════════════════════════════════════
-//  RADIO GROUP MAPPINGS
-//  { camelCaseKey → { field, yes, no, na? } }
-//  Value: true → yes, false → no, null → na (if available)
-// ═══════════════════════════════════════════════════════════════════
-
-const RADIO = {
-  'booking.statement':       { field: 'STATEMENT', yes: 'YES_2', no: 'NO_2' },
-  pcNotification:            { field: '293 PC NOTIFICATION', yes: 'YES_3', no: 'NO_3', na: 'NA' },
-  confidentialityRequested:  { field: 'CONFIDENTIALITY REQUESTED', yes: 'YES_4', no: 'NO_4' },
-  victimCrimeNotification:   { field: 'VICTIM OF CRIME NOTIFICATION', yes: 'YES_5', no: 'NO_5', na: 'NA_2' },
-  followUpForm:              { field: 'FOLLOW UP FORM', yes: 'YES_6', no: 'NO_6' },
-  rpStatement:               { field: 'STATEMENT_2', yes: 'YES_7', no: 'NO_7' },
-};
-
-// ═══════════════════════════════════════════════════════════════════
-//  ENUM CHECKBOX MAPPINGS
-//  A string value selects exactly one checkbox from a group.
-//  { camelCaseKey → { 'value': 'PDF_FIELD', ... } }
-// ═══════════════════════════════════════════════════════════════════
-
-const ENUM_CHECKBOX = {
-  suspectStatus: {
-    known:      'KNOWN',
-    unknown:    'UNKNOWN',
-    nonSuspect: 'NONSUSPECTSUBJECT INCIDENT',
+    // Narrative (page 2)
+    narrative:                   'PAGE',
   },
-  reportType: {
-    initial:      'INITIAL',
-    supplemental: 'SUPP',
+
+  checkbox: {
+    arrestMade:                         'ARREST MADE',
+    addlTypesSeeNarrative:              'undefined',
+    addlCodesSeeNarrative:              'DDL CODES',
+    dvIncident:                         'undefined_2',
+    elderAbuse:                         'undefined_3',
+    gangRelated:                        'GANG',
+    juvenileRelated:                    'JUVENILE',
+    prejudiceBased:                     'PREJUDICE',
+    prop115Certified:                   'BELIEF FOLLOWING AN INVESTIGATION OF THE EVENTS AND PARTIES INVOLVED',
+    postTraining:                       'POST TRAINING',
+    'booking.addlWarrants':             'ADD\'L WARRANTS',
+    'booking.addlCharges':              'ADDL CHARGES',
+    'booking.addlCiteSections':         'ADDL CITE SECTIONS',
+    'booking.bookingApproved':          'BOOKING APPROVED BY PRINT NAMESTAR',
+    'booking.addlWarrantsSeeNarrative': 'ADDL WARRANTS SEE NARRATIVE',
+    'booking.citationIssued':           'CITATION_2',
   },
+
+  dropdown: {
+    locationSentTo:   'Dropdown2',
+    dispositionCode:  'Dropdown4',
+  },
+
+  booleanPair: {
+    'booking.mirandized':      ['MIRANDIZED YES', 'MIRANDIZED NO'],
+    'booking.sdcsEntry':       ['sdcs yes', 'sdcs no'],
+    'booking.xrays':           ['Y', 'N'],
+    'booking.addlSubjects':    ['Y_2', 'N_2'],
+    addlReportingParties:      ['Y_3', 'N_3'],
+  },
+
+  radio: {
+    'booking.statement':       { field: 'STATEMENT', yes: 'YES_2', no: 'NO_2' },
+    pcNotification:            { field: '293 PC NOTIFICATION', yes: 'YES_3', no: 'NO_3', na: 'NA' },
+    confidentialityRequested:  { field: 'CONFIDENTIALITY REQUESTED', yes: 'YES_4', no: 'NO_4' },
+    victimCrimeNotification:   { field: 'VICTIM OF CRIME NOTIFICATION', yes: 'YES_5', no: 'NO_5', na: 'NA_2' },
+    followUpForm:              { field: 'FOLLOW UP FORM', yes: 'YES_6', no: 'NO_6' },
+    rpStatement:               { field: 'STATEMENT_2', yes: 'YES_7', no: 'NO_7' },
+  },
+
+  enumCheckbox: {
+    suspectStatus: {
+      known:      'KNOWN',
+      unknown:    'UNKNOWN',
+      nonSuspect: 'NONSUSPECTSUBJECT INCIDENT',
+    },
+    reportType: {
+      initial:      'INITIAL',
+      supplemental: 'SUPP',
+    },
+  },
+
+  array: {
+    incidentCodes:     ['INCIDENT CODE 1', 'INCIDENT CODE 2', 'INCIDENT CODE 3'],
+    'booking.charges': ['BOOKING SECTIONCHARGE 1', 'BOOKING SECTIONCHARGE 2',
+      'BOOKING SECTIONCHARGE 3', 'BOOKING SECTIONCHARGE 4'],
+  },
+
+  composite: [
+    { fields: ['subject.dob', 'subject.age'], pdfField: 'DOBAGE', join: ' / ' },
+    { fields: ['reportingParty.dob', 'reportingParty.age'], pdfField: 'DOBAGE_2', join: ' / ' },
+  ],
 };
-
-// ═══════════════════════════════════════════════════════════════════
-//  ARRAY FIELD MAPPINGS
-//  An array of values mapped to numbered PDF fields.
-//  { camelCaseKey → ['FIELD_1', 'FIELD_2', ...] }
-// ═══════════════════════════════════════════════════════════════════
-
-const ARRAY = {
-  incidentCodes:    ['INCIDENT CODE 1', 'INCIDENT CODE 2', 'INCIDENT CODE 3'],
-  'booking.charges':['BOOKING SECTIONCHARGE 1', 'BOOKING SECTIONCHARGE 2',
-    'BOOKING SECTIONCHARGE 3', 'BOOKING SECTIONCHARGE 4'],
-};
-
-// ═══════════════════════════════════════════════════════════════════
-//  COMPOSITE FIELD TRANSFORMS
-//  Fields that combine multiple data keys into one PDF field.
-// ═══════════════════════════════════════════════════════════════════
-
-function applyDobAge (form, pdfField, data, prefix) {
-  const dob = get(data, `${prefix}.dob`);
-  const age = get(data, `${prefix}.age`);
-  if (dob == null && age == null) return;
-
-  let value;
-  if (dob && age) value = `${dob} / ${age}`;
-  else value = dob || age;
-
-  setTextField(form, pdfField, value);
-}
-
-// ═══════════════════════════════════════════════════════════════════
-//  HELPERS
-// ═══════════════════════════════════════════════════════════════════
-
-/** Resolve a dot-path like 'booking.warrant' against a nested object. */
-function get (obj, path) {
-  const parts = path.split('.');
-  let cur = obj;
-  for (const p of parts) {
-    if (cur == null) return undefined;
-    cur = cur[p];
-  }
-  return cur;
-}
-
-function setTextField (form, pdfField, value) {
-  const field = form.getTextField(pdfField);
-  const text = String(value);
-  const maxLength = field.getMaxLength();
-  field.setText(maxLength == null ? text : text.slice(0, maxLength));
-}
-
-// ═══════════════════════════════════════════════════════════════════
-//  MAIN FILL FUNCTION
-// ═══════════════════════════════════════════════════════════════════
 
 /**
  * Fill a 849(b) PDF template with the given data.
@@ -259,87 +185,16 @@ function setTextField (form, pdfField, value) {
  * @returns {Promise<Uint8Array>}       Filled PDF bytes, ready to write.
  */
 export async function fill849b (pdfBytes, data) {
-  const pdfDoc = await PDFDocument.load(pdfBytes);
-  const form = pdfDoc.getForm();
-
-  // ── Text fields ──
-  for (const [key, pdfField] of Object.entries(TEXT)) {
-    const val = get(data, key);
-    if (val != null && val !== '') {
-      setTextField(form, pdfField, val);
-    }
-  }
-
-  // ── Page numbers (always 1 and 2) and totalPages default ──
-  setTextField(form, 'Text1', '1');
-  setTextField(form, 'Text1_2', '2');
-  if (get(data, 'totalPages') == null) {
-    setTextField(form, 'Text2', '2');
-  }
-
-  // ── Checkboxes ──
-  for (const [key, pdfField] of Object.entries(CHECKBOX)) {
-    const val = get(data, key);
-    if (val === true) form.getCheckBox(pdfField).check();
-    else if (val === false) form.getCheckBox(pdfField).uncheck();
-  }
-
-  // ── Dropdowns ──
-  for (const [key, pdfField] of Object.entries(DROPDOWN)) {
-    const val = get(data, key);
-    if (val != null) form.getDropdown(pdfField).select(val);
-  }
-
-  // ── Boolean pairs (two checkboxes → one boolean) ──
-  for (const [key, [yesField, noField]] of Object.entries(BOOLEAN_PAIR)) {
-    const val = get(data, key);
-    if (val === true) { form.getCheckBox(yesField).check(); form.getCheckBox(noField).uncheck(); }
-    if (val === false) { form.getCheckBox(yesField).uncheck(); form.getCheckBox(noField).check(); }
-  }
-
-  // ── Radio groups ──
-  for (const [key, { field, yes, no, na }] of Object.entries(RADIO)) {
-    const val = get(data, key);
-    if (val === true) form.getRadioGroup(field).select(yes);
-    else if (val === false) form.getRadioGroup(field).select(no);
-    else if (val === null && na) form.getRadioGroup(field).select(na);
-  }
-
-  // ── Enum checkboxes ──
-  for (const [key, mapping] of Object.entries(ENUM_CHECKBOX)) {
-    const val = get(data, key);
-    if (val != null) {
-      // Uncheck all options, then check the selected one
-      for (const pdfField of Object.values(mapping)) {
-        form.getCheckBox(pdfField).uncheck();
+  // Inject page numbers and default totalPages
+  const withPages = { ...data };
+  return fillPdf(pdfBytes, withPages, spec, {
+    customize (form) {
+      // Page numbers (always 1 and 2)
+      form.getTextField('Text1').setText('1');
+      form.getTextField('Text1_2').setText('2');
+      if (data.totalPages == null) {
+        form.getTextField('Text2').setText('2');
       }
-      const target = mapping[val];
-      if (target) form.getCheckBox(target).check();
-    }
-  }
-
-  // ── Array fields ──
-  for (const [key, pdfFields] of Object.entries(ARRAY)) {
-    const arr = get(data, key);
-    if (!Array.isArray(arr)) continue;
-    for (let i = 0; i < pdfFields.length; i++) {
-      const val = arr[i];
-      if (val != null && val !== '') {
-        setTextField(form, pdfFields[i], val);
-      }
-    }
-  }
-
-  // ── Composite: DOB/AGE ──
-  applyDobAge(form, 'DOBAGE', data, 'subject');
-  applyDobAge(form, 'DOBAGE_2', data, 'reportingParty');
-
-  // ── Bake printable appearances into the file instead of relying on the viewer ──
-  const appearanceFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  form.updateFieldAppearances(appearanceFont);
-
-  const acroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'));
-  acroForm.delete(PDFName.of('NeedAppearances'));
-
-  return pdfDoc.save();
+    },
+  });
 }

--- a/server/lib/forms/cert/fillCoR.js
+++ b/server/lib/forms/cert/fillCoR.js
@@ -11,33 +11,28 @@
  *   const filledBytes = await fillCoR(templatePdfBytes, data);
  */
 
-import { PDFDocument, PDFName, StandardFonts, rgb } from 'pdf-lib';
+import { rgb } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
+import { fillPdf } from '#lib/forms/shared/fillPdf.js';
 
-// ═══════════════════════════════════════════════════════════════════
-//  TEXT FIELD MAPPINGS  { camelCaseKey → pdfFieldName }
-// ═══════════════════════════════════════════════════════════════════
-
-const TEXT = {
-  subjectName:      'Subjects Name',
-  detentionMonth:   'Month',
-  detentionDate:    'Date',
-  detentionYear:    'Year1',
-  detentionTime:    'Time',
-  subjectName2:     'Subjects Name_2',
-  releaseMonth:     'Month_2',
-  releaseDate:      'Date_2',
-  releaseYear:      'Year2',
-  releaseTime:      'Time_2',
-  deputyPrint:      'Print',
-  unitIdentifier:   'Unit Identifier',
+const spec = {
+  text: {
+    subjectName:      'Subjects Name',
+    detentionMonth:   'Month',
+    detentionDate:    'Date',
+    detentionYear:    'Year1',
+    detentionTime:    'Time',
+    subjectName2:     'Subjects Name_2',
+    releaseMonth:     'Month_2',
+    releaseDate:      'Date_2',
+    releaseYear:      'Year2',
+    releaseTime:      'Time_2',
+    deputyPrint:      'Print',
+    unitIdentifier:   'Unit Identifier',
+  },
 };
-
-// ═══════════════════════════════════════════════════════════════════
-//  MAIN FILL FUNCTION
-// ═══════════════════════════════════════════════════════════════════
 
 /**
  * Fill a Certificate of Release PDF template with the given data.
@@ -47,53 +42,28 @@ const TEXT = {
  * @returns {Promise<Uint8Array>}       Filled PDF bytes, ready to write.
  */
 export async function fillCoR (pdfBytes, data) {
-  const pdfDoc = await PDFDocument.load(pdfBytes);
+  return fillPdf(pdfBytes, data, spec, {
+    async customize (form, pdfDoc) {
+      if (!data.signature) return;
 
-  // Register fontkit for custom font embedding
-  pdfDoc.registerFontkit(fontkit);
+      pdfDoc.registerFontkit(fontkit);
+      const fontPath = join(process.cwd(), 'lib/forms/shared/fonts/MeowScript-Regular.ttf');
+      const fontBytes = await readFile(fontPath);
+      const signatureFont = await pdfDoc.embedFont(fontBytes);
 
-  const form = pdfDoc.getForm();
+      const sigField = form.getTextField('Signature');
+      const widgets = sigField.acroField.getWidgets();
+      const rect = widgets[0].getRectangle();
+      sigField.setText('');
 
-  // ── Text fields ──
-  for (const [key, pdfField] of Object.entries(TEXT)) {
-    const val = data[key];
-    if (val != null && val !== '') {
-      form.getTextField(pdfField).setText(String(val));
-    }
-  }
-
-  // ── Signature: draw directly on page with cursive font ──
-  // We draw this as page content (not a form field) so the font is embedded
-  // and renders correctly on any system, regardless of installed fonts.
-  if (data.signature) {
-    const fontPath = join(process.cwd(), 'lib/forms/shared/fonts/MeowScript-Regular.ttf');
-    const fontBytes = await readFile(fontPath);
-    const signatureFont = await pdfDoc.embedFont(fontBytes);
-
-    // Get the signature field's position and clear it
-    const sigField = form.getTextField('Signature');
-    const widgets = sigField.acroField.getWidgets();
-    const widget = widgets[0];
-    const rect = widget.getRectangle();
-    sigField.setText('');
-
-    // Draw the signature text at the same position on the page
-    const page = pdfDoc.getPage(0);
-    page.drawText(data.signature, {
-      x: rect.x,
-      y: rect.y + 4,
-      size: 16,
-      font: signatureFont,
-      color: rgb(0, 0, 0),
-    });
-  }
-
-  // ── Generate printable appearances while preserving fillable fields ──
-  const appearanceFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
-  form.updateFieldAppearances(appearanceFont);
-
-  const acroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'));
-  acroForm.delete(PDFName.of('NeedAppearances'));
-
-  return pdfDoc.save();
+      const page = pdfDoc.getPage(0);
+      page.drawText(data.signature, {
+        x: rect.x,
+        y: rect.y + 4,
+        size: 16,
+        font: signatureFont,
+        color: rgb(0, 0, 0),
+      });
+    },
+  });
 }

--- a/server/lib/forms/shared/fillPdf.js
+++ b/server/lib/forms/shared/fillPdf.js
@@ -1,0 +1,201 @@
+/**
+ * fillPdf.js
+ *
+ * Shared utility for filling PDF form templates with pdf-lib.
+ *
+ * Generates baked appearance streams so filled fields print correctly on
+ * renderers that ignore NeedAppearances (e.g. iOS Outlook), while preserving
+ * auto-size (font size 0) in the DA string so users can still edit fields
+ * in Chrome/Acrobat with shrink-to-fit behavior.
+ */
+
+import { PDFDocument, PDFName, PDFString, StandardFonts } from 'pdf-lib';
+
+// PDF field flag for multiline text (bit 13, 1-indexed → bit 12 zero-indexed)
+const MULTILINE_FLAG = 1 << 12;
+
+/**
+ * Load a PDF, fill fields from a declarative spec, bake appearances, and return bytes.
+ *
+ * @param {Uint8Array|Buffer} pdfBytes   Raw template PDF bytes.
+ * @param {object}            data       Data object (camelCase keys, may be nested).
+ * @param {object}            spec       Field specification — see below.
+ * @param {object}            [options]  Extra options.
+ * @param {Function}          [options.customize]  Called with (form, pdfDoc, font) after
+ *                                        standard fields are filled but before appearances
+ *                                        are baked. Use for one-off logic like signatures.
+ * @returns {Promise<Uint8Array>}        Filled PDF bytes.
+ *
+ * ## spec shape
+ *
+ * ```js
+ * {
+ *   text:         { camelKey: 'PDF Field Name', ... },
+ *   checkbox:     { camelKey: 'PDF Field Name', ... },
+ *   dropdown:     { camelKey: 'PDF Field Name', ... },
+ *   booleanPair:  { camelKey: ['YES_FIELD', 'NO_FIELD'], ... },
+ *   radio:        { camelKey: { field, yes, no, na? }, ... },
+ *   enumCheckbox: { camelKey: { value: 'FIELD', ... }, ... },
+ *   array:        { camelKey: ['FIELD_1', 'FIELD_2', ...], ... },
+ *   composite:    [{ fields: [...keys], pdfField: 'NAME', join: ' / ' }, ...],
+ * }
+ * ```
+ */
+export async function fillPdf (pdfBytes, data, spec, options = {}) {
+  const pdfDoc = await PDFDocument.load(pdfBytes);
+  const form = pdfDoc.getForm();
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+  // ── Text fields ──
+  if (spec.text) {
+    for (const [key, pdfField] of Object.entries(spec.text)) {
+      const val = get(data, key);
+      if (val != null && val !== '') {
+        const field = form.getTextField(pdfField);
+        setFieldDA(field, String(val), font);
+        setTextField(field, val);
+      }
+    }
+  }
+
+  // ── Checkboxes ──
+  if (spec.checkbox) {
+    for (const [key, pdfField] of Object.entries(spec.checkbox)) {
+      const val = get(data, key);
+      if (val === true) form.getCheckBox(pdfField).check();
+      else if (val === false) form.getCheckBox(pdfField).uncheck();
+    }
+  }
+
+  // ── Dropdowns ──
+  if (spec.dropdown) {
+    for (const [key, pdfField] of Object.entries(spec.dropdown)) {
+      const val = get(data, key);
+      if (val != null) form.getDropdown(pdfField).select(val);
+    }
+  }
+
+  // ── Boolean pairs (two checkboxes → one boolean) ──
+  if (spec.booleanPair) {
+    for (const [key, [yesField, noField]] of Object.entries(spec.booleanPair)) {
+      const val = get(data, key);
+      if (val === true) { form.getCheckBox(yesField).check(); form.getCheckBox(noField).uncheck(); }
+      if (val === false) { form.getCheckBox(yesField).uncheck(); form.getCheckBox(noField).check(); }
+    }
+  }
+
+  // ── Radio groups ──
+  if (spec.radio) {
+    for (const [key, { field, yes, no, na }] of Object.entries(spec.radio)) {
+      const val = get(data, key);
+      if (val === true) form.getRadioGroup(field).select(yes);
+      else if (val === false) form.getRadioGroup(field).select(no);
+      else if (val === null && na) form.getRadioGroup(field).select(na);
+    }
+  }
+
+  // ── Enum checkboxes (string value selects one from a group) ──
+  if (spec.enumCheckbox) {
+    for (const [key, mapping] of Object.entries(spec.enumCheckbox)) {
+      const val = get(data, key);
+      if (val != null) {
+        for (const pdfField of Object.values(mapping)) form.getCheckBox(pdfField).uncheck();
+        const target = mapping[val];
+        if (target) form.getCheckBox(target).check();
+      }
+    }
+  }
+
+  // ── Array fields (array of values → numbered PDF fields) ──
+  if (spec.array) {
+    for (const [key, pdfFields] of Object.entries(spec.array)) {
+      const arr = get(data, key);
+      if (!Array.isArray(arr)) continue;
+      for (let i = 0; i < pdfFields.length; i++) {
+        if (arr[i] != null && arr[i] !== '') {
+          const field = form.getTextField(pdfFields[i]);
+          setFieldDA(field, String(arr[i]), font);
+          setTextField(field, arr[i]);
+        }
+      }
+    }
+  }
+
+  // ── Composite fields (multiple data keys → one PDF field) ──
+  if (spec.composite) {
+    for (const { fields, pdfField, join: sep } of spec.composite) {
+      const parts = fields.map(k => get(data, k)).filter(v => v != null && v !== '');
+      if (parts.length) {
+        const field = form.getTextField(pdfField);
+        const text = parts.join(sep || ' / ');
+        setFieldDA(field, text, font);
+        setTextField(field, text);
+      }
+    }
+  }
+
+  // ── Custom logic (signatures, timestamp fields, etc.) ──
+  if (options.customize) {
+    await options.customize(form, pdfDoc, font);
+  }
+
+  // ── Bake printable appearances ──
+  form.updateFieldAppearances(font);
+
+  // Reset DA to font size 0 on all text fields so viewers auto-size on future edits
+  const autoSizeDA = PDFString.of('/Helvetica 0 Tf 0 g');
+  for (const field of form.getFields()) {
+    if (field.constructor.name === 'PDFTextField') {
+      field.acroField.dict.set(PDFName.of('DA'), autoSizeDA);
+    }
+  }
+
+  const acroForm = pdfDoc.catalog.lookup(PDFName.of('AcroForm'));
+  acroForm.delete(PDFName.of('NeedAppearances'));
+
+  return pdfDoc.save();
+}
+
+/**
+ * Set the DA string on a text field with a calculated font size that fits
+ * the text. Single-line fields shrink to fit width; multiline fields use
+ * a height-based default.
+ */
+function setFieldDA (field, text, font) {
+  const widgets = field.acroField.getWidgets();
+  if (!widgets.length) return;
+  const rect = widgets[0].getRectangle();
+  const padding = 4;
+  const maxHeight = rect.height - padding;
+  const heightBasedSize = Math.max(4, Math.min(maxHeight, 12));
+
+  let size = heightBasedSize;
+  const isMultiline = field.acroField.hasFlag(MULTILINE_FLAG);
+  if (text && !isMultiline) {
+    const textWidth = font.widthOfTextAtSize(text, heightBasedSize);
+    const fieldWidth = rect.width - padding * 2;
+    if (textWidth > fieldWidth) {
+      size = Math.max(4, heightBasedSize * (fieldWidth / textWidth));
+    }
+  }
+
+  const da = PDFString.of(`/Helvetica ${size.toFixed(2)} Tf 0 g`);
+  field.acroField.dict.set(PDFName.of('DA'), da);
+}
+
+function setTextField (field, value) {
+  const text = String(value);
+  const maxLength = field.getMaxLength();
+  field.setText(maxLength == null ? text : text.slice(0, maxLength));
+}
+
+/** Resolve a dot-path like 'booking.warrant' against a nested object. */
+function get (obj, path) {
+  const parts = path.split('.');
+  let cur = obj;
+  for (const p of parts) {
+    if (cur == null) return undefined;
+    cur = cur[p];
+  }
+  return cur;
+}


### PR DESCRIPTION
## Summary
- pdf-lib's `updateFieldAppearances()` generates appearance streams that Apple's CoreGraphics renderer (used by iOS Outlook) can't render, causing filled fields to print blank
- The fix writes explicit `/DA` (default appearance) strings with calculated font sizes before baking, producing AP streams with proper font references that CoreGraphics renders correctly
- After baking, DA strings are reset to font size 0 to preserve auto-size behavior when users edit fields in Chrome/Acrobat
- Extracts a shared `fillPdf()` utility in `server/lib/forms/shared/fillPdf.js` so all four form fillers (849b, 647f, 5150, CoR) use the same appearance-baking logic

**Printed from iOS Outlook:**

<img width="1352" height="862" alt="image" src="https://github.com/user-attachments/assets/bea01cb5-8dbb-4a55-b008-f71e5b4a6d9a" />


## Test plan
- [ ] Generate a filled 849b PDF via the app
- [ ] Email the PDF and print from iOS Outlook — filled fields should be visible
- [ ] Open the PDF in Chrome/Acrobat — verify existing filled fields render correctly
- [ ] Edit a field in Chrome — verify auto-size shrink-to-fit still works
- [ ] Test 647f, 5150, and CoR form generation to confirm no regressions
- [ ] Run `npm test --workspace server` — all 849b tests pass
