### PR TITLE
Add Web Push notification support for PWA installs

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,6 +1,7 @@
 import neostandard from 'neostandard';
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
 import storybook from 'eslint-plugin-storybook';
+import globals from 'globals';
 
 export default [
   ...neostandard({
@@ -12,4 +13,18 @@ export default [
     semi: true
   }),
   ...storybook.configs['flat/recommended'],
+  // Browser globals for all client source files
+  {
+    files: ['src/**/*.{js,jsx}'],
+    languageOptions: {
+      globals: globals.browser,
+    },
+  },
+  // Service worker globals for sw.js
+  {
+    files: ['src/sw.js'],
+    languageOptions: {
+      globals: globals.serviceworker,
+    },
+  },
 ];

--- a/client/src/Api.js
+++ b/client/src/Api.js
@@ -508,6 +508,15 @@ const Api = {
       return instance.delete(`/api/property-photos/${id}`).catch(handleError);
     },
   },
+  push: {
+    subscribe (subscription) {
+      const { endpoint, keys } = subscription;
+      return instance.post('/api/push/subscribe', { endpoint, keys });
+    },
+    unsubscribe (endpoint) {
+      return instance.delete('/api/push/subscribe', { data: { endpoint } });
+    },
+  },
   ai: {
     transcribe (audio, mediaType) {
       return instance.post('/api/ai/transcribe', { audio, mediaType });

--- a/client/src/AppLayout.jsx
+++ b/client/src/AppLayout.jsx
@@ -1,23 +1,47 @@
 import { useEffect } from 'react';
-import { AppShell } from '@mantine/core';
+import { AppShell, Button, CloseButton, Group, Paper, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { matchPath, useLocation, useNavigate } from 'react-router';
 import { useQueryClient } from '@tanstack/react-query';
+import { IconBell } from '@tabler/icons-react';
 
 import Header from './Header';
 
 import Api from './Api';
 import AppRoutes from './AppRoutes';
 import { useFacilityContext } from './FacilityContext';
+import { useAuthContext } from './AuthContext';
+import { usePushNotifications } from './hooks/usePushNotifications';
+
+function PushPromptBanner ({ onAllow, onDismiss }) {
+  return (
+    <Paper shadow='sm' p='sm' withBorder style={{ position: 'sticky', top: 0, zIndex: 200 }}>
+      <Group justify='space-between' wrap='nowrap'>
+        <Group gap='sm' wrap='nowrap'>
+          <IconBell size={20} />
+          <Text size='sm'>Enable notifications to get alerts for hold cancellations and facility updates.</Text>
+        </Group>
+        <Group gap='xs' wrap='nowrap'>
+          <Button size='xs' onClick={onAllow}>Allow</Button>
+          <CloseButton size='sm' onClick={onDismiss} aria-label='Dismiss notification prompt' />
+        </Group>
+      </Group>
+    </Paper>
+  );
+}
 
 function AppLayout () {
   const [opened, { close, toggle }] = useDisclosure();
   const navigate = useNavigate();
   const { facility, setFacility } = useFacilityContext();
   const queryClient = useQueryClient();
+  const { user } = useAuthContext();
+
+  const { promptVisible, requestPermission, dismissPrompt, unsubscribe } = usePushNotifications(user);
 
   async function logout (event) {
     event.preventDefault();
+    await unsubscribe();
     await Api.auth.logout();
     queryClient.setQueryData(['users', 'me'], null);
     close();
@@ -54,6 +78,9 @@ function AppLayout () {
         </AppShell.Header>
       )}
       <AppShell.Main px={0}>
+        {promptVisible && !isHeaderHidden && (
+          <PushPromptBanner onAllow={requestPermission} onDismiss={dismissPrompt} />
+        )}
         <AppRoutes />
       </AppShell.Main>
     </AppShell>

--- a/client/src/AppLayout.jsx
+++ b/client/src/AppLayout.jsx
@@ -15,15 +15,15 @@ import { usePushNotifications } from './hooks/usePushNotifications';
 
 function PushPromptBanner ({ onAllow, onDismiss }) {
   return (
-    <Paper shadow='sm' p='sm' withBorder style={{ position: 'sticky', top: 0, zIndex: 200 }}>
+    <Paper shadow='sm' p='md' withBorder style={{ position: 'sticky', top: 0, zIndex: 200 }}>
       <Group justify='space-between' wrap='nowrap'>
         <Group gap='sm' wrap='nowrap'>
-          <IconBell size={20} />
+          <IconBell size={28} />
           <Text size='sm'>Enable notifications to get alerts for hold cancellations and facility updates.</Text>
         </Group>
-        <Group gap='xs' wrap='nowrap'>
-          <Button size='xs' onClick={onAllow}>Allow</Button>
-          <CloseButton size='sm' onClick={onDismiss} aria-label='Dismiss notification prompt' />
+        <Group gap='sm' wrap='nowrap'>
+          <Button size='sm' onClick={onAllow}>Allow</Button>
+          <CloseButton size='lg' onClick={onDismiss} aria-label='Dismiss notification prompt' />
         </Group>
       </Group>
     </Paper>

--- a/client/src/hooks/useFeatureFlag.js
+++ b/client/src/hooks/useFeatureFlag.js
@@ -29,14 +29,12 @@ export function useFeatureFlag (flagName, { defaultValue = false } = {}) {
 
   const posthogConfigured = Boolean(import.meta.env.VITE_POSTHOG_KEY);
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [value, setValue] = useState(() => {
     if (!posthogConfigured) return defaultValue;
     const ph = typeof window !== 'undefined' ? window.posthog : null;
     return ph ? (ph.isFeatureEnabled(flagName) ?? null) : null;
   });
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useEffect(() => {
     if (!posthogConfigured) {
       setValue(defaultValue);

--- a/client/src/hooks/useFeatureFlag.js
+++ b/client/src/hooks/useFeatureFlag.js
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Returns the boolean value of a PostHog feature flag, with two escape hatches:
+ *
+ *  1. If VITE_POSTHOG_KEY is not set (most dev environments), PostHog never
+ *     initialises and window.posthog is absent. In that case the hook returns
+ *     `defaultValue` immediately, so the feature behaves as if the flag were
+ *     set to that value — no PostHog account needed for local work.
+ *
+ *  2. Each flag can be overridden per-environment via a matching VITE_ env var,
+ *     e.g. VITE_FLAG_PUSH_NOTIFICATIONS=true overrides the 'push-notifications'
+ *     flag. The env var takes precedence over both PostHog and defaultValue.
+ *     Set it in server/.env (the dev script copies this to client/.env).
+ *
+ * Return values:
+ *   true  — flag is on
+ *   false — flag is off
+ *   null  — PostHog is configured but flags haven't loaded yet (treat as off)
+ */
+export function useFeatureFlag (flagName, { defaultValue = false } = {}) {
+  const envVarName = 'VITE_FLAG_' + flagName.toUpperCase().replace(/-/g, '_');
+  const envOverride = import.meta.env[envVarName];
+
+  // Env var override takes precedence over everything.
+  if (envOverride !== undefined) {
+    return envOverride === 'true' || envOverride === true;
+  }
+
+  const posthogConfigured = Boolean(import.meta.env.VITE_POSTHOG_KEY);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const [value, setValue] = useState(() => {
+    if (!posthogConfigured) return defaultValue;
+    const ph = typeof window !== 'undefined' ? window.posthog : null;
+    return ph ? (ph.isFeatureEnabled(flagName) ?? null) : null;
+  });
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  useEffect(() => {
+    if (!posthogConfigured) {
+      setValue(defaultValue);
+      return;
+    }
+
+    function sync () {
+      const ph = window.posthog;
+      setValue(ph ? (ph.isFeatureEnabled(flagName) ?? false) : false);
+    }
+
+    // onFeatureFlags fires when flags first load and after each identify() call.
+    const unsubscribe = window.posthog?.onFeatureFlags(sync);
+    sync();
+
+    return () => unsubscribe?.();
+  }, [flagName, posthogConfigured, defaultValue]);
+
+  return value;
+}

--- a/client/src/hooks/usePushNotifications.js
+++ b/client/src/hooks/usePushNotifications.js
@@ -66,7 +66,7 @@ export function usePushNotifications (user) {
         setPromptVisible(true);
       }
     });
-  }, [user?.id, pushEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [user?.id, pushEnabled]);
 
   async function requestPermission () {
     if (!supported) return;

--- a/client/src/hooks/usePushNotifications.js
+++ b/client/src/hooks/usePushNotifications.js
@@ -1,0 +1,95 @@
+import { useEffect, useState } from 'react';
+import Api from '../Api';
+
+const DISMISSED_KEY = 'push:dismissed';
+
+function urlBase64ToUint8Array (base64String) {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const rawData = atob(base64);
+  return Uint8Array.from([...rawData].map((c) => c.charCodeAt(0)));
+}
+
+async function registerSubscription (registration) {
+  const vapidKey = import.meta.env.VITE_VAPID_PUBLIC_KEY;
+  if (!vapidKey) return null;
+
+  const existing = await registration.pushManager.getSubscription();
+  const subscription = existing ?? await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(vapidKey),
+  });
+
+  await Api.push.subscribe(subscription.toJSON());
+  return subscription;
+}
+
+/**
+ * Manages the push notification subscription lifecycle for the current user.
+ *
+ * Returns:
+ *   - promptVisible: boolean — true when the opt-in banner should be shown
+ *   - permission: NotificationPermission string
+ *   - requestPermission(): ask the browser and subscribe on grant
+ *   - dismissPrompt(): hide the banner without granting permission
+ */
+export function usePushNotifications (user) {
+  const [permission, setPermission] = useState(() =>
+    typeof Notification !== 'undefined' ? Notification.permission : 'denied'
+  );
+  const [promptVisible, setPromptVisible] = useState(false);
+
+  const supported =
+    typeof window !== 'undefined' &&
+    'PushManager' in window &&
+    'serviceWorker' in navigator;
+
+  // When the user logs in, either silently re-register an existing subscription
+  // or surface the opt-in prompt.
+  useEffect(() => {
+    if (!user || !supported) return;
+
+    navigator.serviceWorker.ready.then(async (registration) => {
+      const currentPermission = Notification.permission;
+      setPermission(currentPermission);
+
+      if (currentPermission === 'granted') {
+        // Silently re-register (handles returning users and shared devices).
+        await registerSubscription(registration).catch(() => {});
+      } else if (
+        currentPermission === 'default' &&
+        localStorage.getItem(DISMISSED_KEY) !== 'true'
+      ) {
+        setPromptVisible(true);
+      }
+    });
+  }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function requestPermission () {
+    if (!supported) return;
+    const result = await Notification.requestPermission();
+    setPermission(result);
+    setPromptVisible(false);
+
+    if (result === 'granted') {
+      const registration = await navigator.serviceWorker.ready;
+      await registerSubscription(registration).catch(() => {});
+    }
+  }
+
+  function dismissPrompt () {
+    localStorage.setItem(DISMISSED_KEY, 'true');
+    setPromptVisible(false);
+  }
+
+  async function unsubscribe () {
+    if (!supported) return;
+    const registration = await navigator.serviceWorker.ready;
+    const sub = await registration.pushManager.getSubscription();
+    if (sub) {
+      await Api.push.unsubscribe(sub.endpoint).catch(() => {});
+    }
+  }
+
+  return { permission, promptVisible, requestPermission, dismissPrompt, unsubscribe };
+}

--- a/client/src/hooks/usePushNotifications.js
+++ b/client/src/hooks/usePushNotifications.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import Api from '../Api';
+import { useFeatureFlag } from './useFeatureFlag';
 
 const DISMISSED_KEY = 'push:dismissed';
 
@@ -34,6 +35,8 @@ async function registerSubscription (registration) {
  *   - dismissPrompt(): hide the banner without granting permission
  */
 export function usePushNotifications (user) {
+  const pushEnabled = useFeatureFlag('push-notifications', { defaultValue: false });
+
   const [permission, setPermission] = useState(() =>
     typeof Notification !== 'undefined' ? Notification.permission : 'denied'
   );
@@ -47,7 +50,7 @@ export function usePushNotifications (user) {
   // When the user logs in, either silently re-register an existing subscription
   // or surface the opt-in prompt.
   useEffect(() => {
-    if (!user || !supported) return;
+    if (!user || !supported || pushEnabled !== true) return;
 
     navigator.serviceWorker.ready.then(async (registration) => {
       const currentPermission = Notification.permission;
@@ -63,7 +66,7 @@ export function usePushNotifications (user) {
         setPromptVisible(true);
       }
     });
-  }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [user?.id, pushEnabled]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function requestPermission () {
     if (!supported) return;
@@ -91,5 +94,11 @@ export function usePushNotifications (user) {
     }
   }
 
-  return { permission, promptVisible, requestPermission, dismissPrompt, unsubscribe };
+  return {
+    permission,
+    promptVisible: promptVisible && pushEnabled === true,
+    requestPermission,
+    dismissPrompt,
+    unsubscribe,
+  };
 }

--- a/client/src/sw.js
+++ b/client/src/sw.js
@@ -7,15 +7,8 @@ import { NavigationRoute, registerRoute } from 'workbox-routing';
 self.skipWaiting();
 clientsClaim();
 
-// Injected by vite-plugin-pwa at build time
-precacheAndRoute(self.__WB_MANIFEST);
-
-registerRoute(
-  new NavigationRoute(navigateFallback({ fallbackURL: '/index.html' }), {
-    denylist: [/^\/api\//, /^\/static-data\//],
-  })
-);
-
+// Push and notification handlers are registered first so a precaching error
+// can never prevent them from running.
 self.addEventListener('push', (event) => {
   const data = event.data?.json() ?? {};
   const title = data.title ?? 'Care Connect';
@@ -25,7 +18,6 @@ self.addEventListener('push', (event) => {
     badge: '/icons/icon-192.png',
     data: { url: data.data?.url ?? '/', tag: data.data?.tag },
     tag: data.data?.tag,
-    // Keep notification visible until the user acts on it (desktop only).
     requireInteraction: true,
   };
 
@@ -49,3 +41,13 @@ self.addEventListener('notificationclick', (event) => {
       })
   );
 });
+
+// self.__WB_MANIFEST is injected by vite-plugin-pwa at build time.
+// Fall back to [] in dev mode so a missing injection doesn't crash the SW.
+precacheAndRoute(self.__WB_MANIFEST ?? []);
+
+registerRoute(
+  new NavigationRoute(navigateFallback({ fallbackURL: '/index.html' }), {
+    denylist: [/^\/api\//, /^\/static-data\//],
+  })
+);

--- a/client/src/sw.js
+++ b/client/src/sw.js
@@ -1,5 +1,5 @@
 import { clientsClaim } from 'workbox-core';
-import { precacheAndRoute, navigateFallback } from 'workbox-precaching';
+import { precacheAndRoute, createHandlerBoundToURL } from 'workbox-precaching';
 import { NavigationRoute, registerRoute } from 'workbox-routing';
 
 // Activate immediately and claim all clients so deploys land quickly
@@ -47,7 +47,7 @@ self.addEventListener('notificationclick', (event) => {
 precacheAndRoute(self.__WB_MANIFEST ?? []);
 
 registerRoute(
-  new NavigationRoute(navigateFallback({ fallbackURL: '/index.html' }), {
+  new NavigationRoute(createHandlerBoundToURL('/index.html'), {
     denylist: [/^\/api\//, /^\/static-data\//],
   })
 );

--- a/client/src/sw.js
+++ b/client/src/sw.js
@@ -1,0 +1,51 @@
+import { clientsClaim } from 'workbox-core';
+import { precacheAndRoute, navigateFallback } from 'workbox-precaching';
+import { NavigationRoute, registerRoute } from 'workbox-routing';
+
+// Activate immediately and claim all clients so deploys land quickly
+// on long-lived tablet sessions.
+self.skipWaiting();
+clientsClaim();
+
+// Injected by vite-plugin-pwa at build time
+precacheAndRoute(self.__WB_MANIFEST);
+
+registerRoute(
+  new NavigationRoute(navigateFallback({ fallbackURL: '/index.html' }), {
+    denylist: [/^\/api\//, /^\/static-data\//],
+  })
+);
+
+self.addEventListener('push', (event) => {
+  const data = event.data?.json() ?? {};
+  const title = data.title ?? 'Care Connect';
+  const options = {
+    body: data.body,
+    icon: '/icons/icon-192.png',
+    badge: '/icons/icon-192.png',
+    data: { url: data.data?.url ?? '/', tag: data.data?.tag },
+    tag: data.data?.tag,
+    // Keep notification visible until the user acts on it (desktop only).
+    requireInteraction: true,
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url ?? '/';
+
+  event.waitUntil(
+    clients
+      .matchAll({ type: 'window', includeUncontrolled: true })
+      .then((clientList) => {
+        const existing = clientList.find((c) => 'focus' in c);
+        if (existing) {
+          existing.navigate(url);
+          return existing.focus();
+        }
+        return clients.openWindow(url);
+      })
+  );
+});

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -73,7 +73,7 @@ export default defineConfig(({ command, ssrBuild, mode }) => {
               description: 'San Francisco law-enforcement processing tool for specialized treatment centers.',
               theme_color: '#4c6ef5',
               background_color: '#ffffff',
-              display: 'minimal-ui',
+              display: 'standalone',
               orientation: 'portrait',
               scope: '/',
               start_url: '/',

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -60,6 +60,11 @@ export default defineConfig(({ command, ssrBuild, mode }) => {
       ...(isSSRBuild
         ? []
         : [VitePWA({
+            // injectManifest lets us maintain a hand-written sw.js that gets
+            // the Workbox precache manifest injected at build time.
+            strategies: 'injectManifest',
+            srcDir: 'src',
+            filename: 'sw.js',
             registerType: 'autoUpdate',
             includeAssets: ['icons/apple-touch-icon.png', 'icons/favicon-32.png'],
             manifest: {
@@ -78,13 +83,8 @@ export default defineConfig(({ command, ssrBuild, mode }) => {
                 { src: '/icons/icon-maskable-512.png', sizes: '512x512', type: 'image/png', purpose: 'maskable' },
               ],
             },
-            workbox: {
-              navigateFallback: '/index.html',
-              navigateFallbackDenylist: [/^\/api\//, /^\/static-data\//],
-              // Aggressive update propagation: new SW activates and claims clients
-              // immediately so deploys land within minutes on long-lived tablet sessions.
-              skipWaiting: true,
-              clientsClaim: true,
+            injectManifest: {
+              globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
             },
             devOptions: {
               // Serve manifest + SW in vite dev so DevTools → Application shows them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11326,6 +11326,18 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "license": "MIT",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -11786,6 +11798,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/bn.js": {
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -11949,6 +11967,12 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -14292,6 +14316,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -17477,6 +17510,15 @@
         "entities": "^4.4.0"
       }
     },
+    "node_modules/http_ece": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-1.2.0.tgz",
+      "integrity": "sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -18844,6 +18886,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.25",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.25.tgz",
@@ -19566,6 +19629,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "5.1.6",
@@ -26548,6 +26617,25 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-push": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/web-push/-/web-push-3.6.7.tgz",
+      "integrity": "sha512-OpiIUe8cuGjrj3mMBFWY+e4MMIkW3SVT+7vEIjvD9kejGUypv8GPDf84JdPWskK8zMRIJ6xYGm+Kxr8YkPyA0A==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "asn1.js": "^5.3.0",
+        "http_ece": "1.2.0",
+        "https-proxy-agent": "^7.0.0",
+        "jws": "^4.0.0",
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "web-push": "src/cli.js"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/web-resource-inliner": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-6.0.1.tgz",
@@ -27659,6 +27747,7 @@
         "puppeteer-core": "^24.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "web-push": "^3.6.7",
         "wellknown": "^0.5.0",
         "zod": "^4.1.11",
         "zod-openapi": "^5.4.1"

--- a/server/bin/send-test-push.js
+++ b/server/bin/send-test-push.js
@@ -51,7 +51,7 @@ for (const sub of subscriptions) {
   try {
     await webpush.sendNotification(
       { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-      payload,
+      payload
     );
     console.log(`  ✓ ${sub.user.email} (${sub.endpoint.slice(0, 60)}…)`);
   } catch (err) {

--- a/server/bin/send-test-push.js
+++ b/server/bin/send-test-push.js
@@ -44,7 +44,7 @@ console.log(`Sending to ${subscriptions.length} subscription(s)…`);
 const payload = JSON.stringify({
   title,
   body,
-  data: { url: '/lesc', tag: 'test-push' },
+  data: { url: '/holds', tag: 'test-push' },
 });
 
 for (const sub of subscriptions) {

--- a/server/bin/send-test-push.js
+++ b/server/bin/send-test-push.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+/**
+ * Sends a test push notification to all subscriptions for a given user email,
+ * or to the most recently created subscription if no email is given.
+ *
+ * Usage:
+ *   node server/bin/send-test-push.js
+ *   node server/bin/send-test-push.js officer@sfpd.gov
+ *   node server/bin/send-test-push.js officer@sfpd.gov "Custom title" "Custom body"
+ */
+
+import '../config.js';
+import prisma from '#prisma/client.js';
+import webpush from '#lib/webpush.js';
+
+const [, , email, title = 'Test notification', body = 'Push notifications are working.'] = process.argv;
+
+if (!process.env.VAPID_PUBLIC_KEY || !process.env.VAPID_PRIVATE_KEY) {
+  console.error('VAPID_PUBLIC_KEY and VAPID_PRIVATE_KEY must be set in .env');
+  process.exit(1);
+}
+
+const where = email
+  ? { user: { email } }
+  : {};
+
+const subscriptions = await prisma.pushSubscription.findMany({
+  where,
+  include: { user: { select: { email: true } } },
+  orderBy: { createdAt: 'desc' },
+  take: email ? undefined : 1,
+});
+
+if (subscriptions.length === 0) {
+  console.error(email
+    ? `No push subscriptions found for ${email}`
+    : 'No push subscriptions found. Grant notification permission in the app first.'
+  );
+  process.exit(1);
+}
+
+console.log(`Sending to ${subscriptions.length} subscription(s)…`);
+
+const payload = JSON.stringify({
+  title,
+  body,
+  data: { url: '/lesc', tag: 'test-push' },
+});
+
+for (const sub of subscriptions) {
+  try {
+    await webpush.sendNotification(
+      { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+      payload,
+    );
+    console.log(`  ✓ ${sub.user.email} (${sub.endpoint.slice(0, 60)}…)`);
+  } catch (err) {
+    if (err.statusCode === 410) {
+      console.log(`  ✗ ${sub.user.email} — subscription expired (410), removing`);
+      await prisma.pushSubscription.delete({ where: { id: sub.id } });
+    } else {
+      console.error(`  ✗ ${sub.user.email} — ${err.message}`);
+    }
+  }
+}
+
+await prisma.$disconnect();

--- a/server/example.env
+++ b/server/example.env
@@ -58,6 +58,9 @@ VAPID_EMAIL=mailto:admin@example.com
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VITE_VAPID_PUBLIC_KEY=
+# Set to true to enable push notification UI locally without a PostHog flag.
+# In production the 'push-notifications' PostHog feature flag controls this.
+VITE_FLAG_PUSH_NOTIFICATIONS=
 VITE_FEATURE_REGISTRATION=true
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=https://app.posthog.com

--- a/server/example.env
+++ b/server/example.env
@@ -49,6 +49,12 @@ EMAIL_FROM_NAME="CareConnect"
 EMAIL_SUBJECT_TITLE="CareConnect"
 EMAIL_SITE_TITLE="City and County of San Francisco: CareConnect"
 EMAIL_BASE_URL=https://careconnect.sf.gov
+# Web Push (VAPID). Generate with: cd server && npx web-push generate-vapid-keys
+# VAPID_PUBLIC_KEY is also exposed to the client as VITE_VAPID_PUBLIC_KEY.
+VAPID_EMAIL=mailto:admin@example.com
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VITE_VAPID_PUBLIC_KEY=
 VITE_FEATURE_REGISTRATION=true
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=https://app.posthog.com

--- a/server/example.env
+++ b/server/example.env
@@ -49,8 +49,11 @@ EMAIL_FROM_NAME="CareConnect"
 EMAIL_SUBJECT_TITLE="CareConnect"
 EMAIL_SITE_TITLE="City and County of San Francisco: CareConnect"
 EMAIL_BASE_URL=https://careconnect.sf.gov
-# Web Push (VAPID). Generate with: cd server && npx web-push generate-vapid-keys
-# VAPID_PUBLIC_KEY is also exposed to the client as VITE_VAPID_PUBLIC_KEY.
+# Web Push (VAPID). Generate the key pair with: cd server && npx web-push generate-vapid-keys
+# Set VAPID_EMAIL to a mailto: address for your org (required by the VAPID spec).
+# Copy the generated public key into BOTH VAPID_PUBLIC_KEY (used server-side to sign pushes)
+# and VITE_VAPID_PUBLIC_KEY (baked into the client bundle by Vite — VITE_ prefix required).
+# The private key is server-only; never expose it to the client.
 VAPID_EMAIL=mailto:admin@example.com
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=

--- a/server/jobs/pushNotification.js
+++ b/server/jobs/pushNotification.js
@@ -27,7 +27,7 @@ export default async function pushNotification ({ userIds, title, body, url, tag
       try {
         await webpush.sendNotification(
           { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-          payload,
+          payload
         );
       } catch (err) {
         if (err.statusCode === 410) {
@@ -37,6 +37,6 @@ export default async function pushNotification ({ userIds, title, body, url, tag
           throw err;
         }
       }
-    }),
+    })
   );
 }

--- a/server/jobs/pushNotification.js
+++ b/server/jobs/pushNotification.js
@@ -1,0 +1,42 @@
+import prisma from '#prisma/client.js';
+import webpush from '#lib/webpush.js';
+
+/**
+ * Send a push notification to all subscribed devices for one or more users.
+ *
+ * @param {object} data
+ * @param {string|string[]} data.userIds - One or more user IDs to notify
+ * @param {string} data.title - Notification title
+ * @param {string} data.body - Notification body text
+ * @param {string} [data.url] - Deep link opened when the notification is tapped
+ * @param {string} [data.tag] - Replaces earlier notifications with the same tag
+ */
+export default async function pushNotification ({ userIds, title, body, url, tag }) {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+
+  const subscriptions = await prisma.pushSubscription.findMany({
+    where: { userId: { in: ids } },
+  });
+
+  if (subscriptions.length === 0) return;
+
+  const payload = JSON.stringify({ title, body, data: { url, tag } });
+
+  await Promise.allSettled(
+    subscriptions.map(async (sub) => {
+      try {
+        await webpush.sendNotification(
+          { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
+          payload,
+        );
+      } catch (err) {
+        if (err.statusCode === 410) {
+          // Subscription has expired or been revoked — remove the stale record.
+          await prisma.pushSubscription.delete({ where: { id: sub.id } }).catch(() => {});
+        } else {
+          throw err;
+        }
+      }
+    }),
+  );
+}

--- a/server/lib/jobQueue/queueConfig.js
+++ b/server/lib/jobQueue/queueConfig.js
@@ -1,4 +1,5 @@
 import inviteEmail from '../../jobs/inviteEmail.js';
+import pushNotification from '../../jobs/pushNotification.js';
 import expireHolds from '../../jobs/expireHolds.js';
 import generateForms from '../../jobs/generateForms.js';
 import formsEmail from '../../jobs/formsEmail.js';
@@ -6,7 +7,7 @@ import anonymizeSubjects from '../../jobs/anonymizeSubjects.js';
 import canary from '../../jobs/canary.js';
 import { LIVE_EMAIL_FORM_IDS } from '#lib/forms/liveEmailForms.js';
 import { captureException } from '#lib/posthog.js';
-import { QUEUE_INVITE_EMAIL, QUEUE_EXPIRE_HOLDS, QUEUE_GENERATE_FORMS, QUEUE_FORMS_EMAIL, QUEUE_ANONYMIZE_SUBJECTS, QUEUE_CANARY } from './queueNames.js';
+import { QUEUE_INVITE_EMAIL, QUEUE_EXPIRE_HOLDS, QUEUE_GENERATE_FORMS, QUEUE_FORMS_EMAIL, QUEUE_ANONYMIZE_SUBJECTS, QUEUE_CANARY, QUEUE_PUSH_NOTIFICATION } from './queueNames.js';
 
 function normalizeGenerateFormsResult (result) {
   if (Array.isArray(result)) {
@@ -104,6 +105,12 @@ const queues = [
     options: { retryLimit: 1 },
     handler: async ([job]) => anonymizeSubjects(job.data),
     cron: '0 * * * *',
+  },
+  {
+    name: QUEUE_PUSH_NOTIFICATION,
+    options: { retryLimit: 2, retryBackoff: true },
+    handler: async ([job]) => pushNotification(job.data),
+    deadLetterData: (data) => ({ userIds: data?.userIds }),
   },
   {
     name: QUEUE_CANARY,

--- a/server/lib/jobQueue/queueNames.js
+++ b/server/lib/jobQueue/queueNames.js
@@ -5,3 +5,4 @@ export const QUEUE_GENERATE_FORMS = 'generate-forms';
 export const QUEUE_FORMS_EMAIL = 'forms-email';
 export const QUEUE_ANONYMIZE_SUBJECTS = 'anonymize-subjects';
 export const QUEUE_CANARY = 'canary';
+export const QUEUE_PUSH_NOTIFICATION = 'push-notification';

--- a/server/lib/webpush.js
+++ b/server/lib/webpush.js
@@ -4,7 +4,7 @@ if (process.env.VAPID_EMAIL && process.env.VAPID_PUBLIC_KEY && process.env.VAPID
   webpush.setVapidDetails(
     process.env.VAPID_EMAIL,
     process.env.VAPID_PUBLIC_KEY,
-    process.env.VAPID_PRIVATE_KEY,
+    process.env.VAPID_PRIVATE_KEY
   );
 }
 

--- a/server/lib/webpush.js
+++ b/server/lib/webpush.js
@@ -1,0 +1,11 @@
+import webpush from 'web-push';
+
+if (process.env.VAPID_EMAIL && process.env.VAPID_PUBLIC_KEY && process.env.VAPID_PRIVATE_KEY) {
+  webpush.setVapidDetails(
+    process.env.VAPID_EMAIL,
+    process.env.VAPID_PUBLIC_KEY,
+    process.env.VAPID_PRIVATE_KEY,
+  );
+}
+
+export default webpush;

--- a/server/package.json
+++ b/server/package.json
@@ -68,6 +68,7 @@
     "puppeteer-core": "^24.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "web-push": "^3.6.7",
     "wellknown": "^0.5.0",
     "zod": "^4.1.11",
     "zod-openapi": "^5.4.1"

--- a/server/prisma/ERD.md
+++ b/server/prisma/ERD.md
@@ -304,6 +304,17 @@ DEPARTURE DEPARTURE
     }
   
 
+  "PushSubscription" {
+    String id "🗝️"
+    String userId 
+    String endpoint 
+    String p256dh 
+    String auth 
+    DateTime createdAt 
+    DateTime updatedAt 
+    }
+  
+
   "Invite" {
     String id "🗝️"
     String firstName 
@@ -687,6 +698,7 @@ DEPARTURE DEPARTURE
     "User" o|--|o "Unit" : "unit"
     "User" o{--}o "AdminSecurityEvent" : ""
     "User" o{--}o "AdminSecurityEvent" : ""
+    "User" o{--}o "PushSubscription" : ""
     "User" o{--}o "BedType" : ""
     "User" o{--}o "BedType" : ""
     "User" o{--}o "BedTypeUpdate" : ""
@@ -715,6 +727,7 @@ DEPARTURE DEPARTURE
     "User" o{--}o "DeflectionDocument" : ""
     "User" o{--}o "PropertyPhoto" : ""
     "User" o{--}o "PropertyPhoto" : ""
+    "PushSubscription" o|--|| "User" : "user"
     "Invite" o|--|o "Organization" : "organization"
     "Invite" o|--|o "Title" : "title"
     "Invite" o|--|| "User" : "createdBy"

--- a/server/prisma/migrations/20260526000000_add_push_subscriptions/migration.sql
+++ b/server/prisma/migrations/20260526000000_add_push_subscriptions/migration.sql
@@ -1,0 +1,18 @@
+CREATE TABLE "PushSubscription" (
+    "id"        TEXT         NOT NULL,
+    "userId"    UUID         NOT NULL,
+    "endpoint"  TEXT         NOT NULL,
+    "p256dh"    TEXT         NOT NULL,
+    "auth"      TEXT         NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PushSubscription_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "PushSubscription_endpoint_key" ON "PushSubscription"("endpoint");
+CREATE INDEX "PushSubscription_userId_idx" ON "PushSubscription"("userId");
+
+ALTER TABLE "PushSubscription"
+    ADD CONSTRAINT "PushSubscription_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -298,6 +298,8 @@ model User {
   adminSecurityEventsPerformed AdminSecurityEvent[]    @relation("AdminSecurityEventActor")
   adminSecurityEventsTargeting AdminSecurityEvent[]    @relation("AdminSecurityEventTarget")
 
+  pushSubscriptions                    PushSubscription[]
+
   bedTypesCreated                      BedType[]                     @relation("CreatedBy")
   bedTypesUpdated                      BedType[]                     @relation("UpdatedBy")
   bedTypeUpdatesCreated                BedTypeUpdate[]
@@ -329,6 +331,19 @@ model User {
   propertyPhotosUpdated                PropertyPhoto[]               @relation("UpdatedBy")
   titlesCreated                        Title[]                       @relation("CreatedBy")
   unitsCreated                         Unit[]                        @relation("CreatedBy")
+}
+
+model PushSubscription {
+  id        String   @id @default(cuid())
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId    String   @db.Uuid
+  endpoint  String   @unique
+  p256dh    String
+  auth      String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
 }
 
 model Invite {

--- a/server/routes/api/deflections/cancel.js
+++ b/server/routes/api/deflections/cancel.js
@@ -176,7 +176,7 @@ export default async function (fastify, opts) {
               userIds: [deflection.createdById],
               title: 'Hold cancelled',
               body: `Your hold at ${facility.name} has been cancelled.`,
-              url: `/lesc/holds/${deflection.id}`,
+              url: `/holds/${deflection.id}`,
               tag: `hold-cancelled-${deflection.id}`,
             }),
           ]);

--- a/server/routes/api/deflections/cancel.js
+++ b/server/routes/api/deflections/cancel.js
@@ -6,7 +6,7 @@ import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionForUser } from '#lib/deflectionVisibility.js';
 import { sendHoldCancelledEmails } from '#lib/holdNotifications.js';
 import { canModifyDeflection } from '#lib/incidentPermissions.js';
-import { QUEUE_GENERATE_FORMS } from '#lib/jobQueue/queueNames.js';
+import { QUEUE_GENERATE_FORMS, QUEUE_PUSH_NOTIFICATION } from '#lib/jobQueue/queueNames.js';
 import {
   hasCompleteHospitalCancellationDetails,
   HOSPITAL_CANCELLATION_INCOMPLETE_DETAILS_ERROR,
@@ -159,18 +159,27 @@ export default async function (fastify, opts) {
         });
       }
 
-      // Send email if cancelled by someone other than the creator
+      // Notify the creating officer if cancelled by someone else
       if (deflection.status === Deflection.HoldStatus.CANCELLED && deflection.createdById !== request.user.id) {
         const [creator, facility] = await Promise.all([
           fastify.prisma.user.findUnique({ where: { id: deflection.createdById } }),
           fastify.prisma.facility.findUnique({ where: { id: deflection.facilityId } }),
         ]);
         if (creator && facility) {
-          await sendHoldCancelledEmails(
-            [{ ...deflection, createdBy: creator }],
-            facility.name,
-            request.user.id
-          );
+          await Promise.all([
+            sendHoldCancelledEmails(
+              [{ ...deflection, createdBy: creator }],
+              facility.name,
+              request.user.id
+            ),
+            fastify.backgroundJobs.send(QUEUE_PUSH_NOTIFICATION, {
+              userIds: [deflection.createdById],
+              title: 'Hold cancelled',
+              body: `Your hold at ${facility.name} has been cancelled.`,
+              url: `/lesc/holds/${deflection.id}`,
+              tag: `hold-cancelled-${deflection.id}`,
+            }),
+          ]);
         }
       }
 

--- a/server/routes/api/facilities/status.js
+++ b/server/routes/api/facilities/status.js
@@ -6,6 +6,7 @@ import FacilityUpdate from '#models/facilityUpdate.js';
 import Deflection from '#models/deflection.js';
 import BedType from '#models/bedType.js';
 import { sendHoldCancelledEmails, sendFacilityReopenedEmails } from '#lib/holdNotifications.js';
+import { QUEUE_PUSH_NOTIFICATION } from '#lib/jobQueue/queueNames.js';
 
 export default async function (fastify, opts) {
   fastify.post('/:id/status',
@@ -150,7 +151,27 @@ export default async function (fastify, opts) {
           },
         });
         if (cancelledHolds.length > 0) {
-          await sendHoldCancelledEmails(cancelledHolds, facility.name, userId);
+          // Group by officer for push (one notification per officer covering all their holds)
+          const byOfficer = {};
+          for (const hold of cancelledHolds) {
+            if (hold.createdById !== userId && hold.createdById) {
+              byOfficer[hold.createdById] = (byOfficer[hold.createdById] ?? 0) + 1;
+            }
+          }
+          await Promise.all([
+            sendHoldCancelledEmails(cancelledHolds, facility.name, userId),
+            ...Object.entries(byOfficer).map(([officerId, count]) =>
+              fastify.backgroundJobs.send(QUEUE_PUSH_NOTIFICATION, {
+                userIds: [officerId],
+                title: 'Holds cancelled',
+                body: count === 1
+                  ? `Your hold at ${facility.name} was cancelled because the facility closed.`
+                  : `${count} of your holds at ${facility.name} were cancelled because the facility closed.`,
+                url: '/lesc',
+                tag: `facility-closed-${id}`,
+              })
+            ),
+          ]);
         }
       } else if (data.status === Facility.Status.OPEN_ACCEPTING) {
         // Notify officers whose holds were cancelled during the closure
@@ -181,7 +202,16 @@ export default async function (fastify, opts) {
           }
           const uniqueOfficers = Object.values(officerMap);
           if (uniqueOfficers.length > 0) {
-            await sendFacilityReopenedEmails(uniqueOfficers, facility.name);
+            await Promise.all([
+              sendFacilityReopenedEmails(uniqueOfficers, facility.name),
+              fastify.backgroundJobs.send(QUEUE_PUSH_NOTIFICATION, {
+                userIds: uniqueOfficers.map((o) => o.id),
+                title: `${facility.name} is open again`,
+                body: 'The facility has reopened and is accepting holds.',
+                url: '/lesc',
+                tag: `facility-reopened-${id}`,
+              }),
+            ]);
           }
         }
       }

--- a/server/routes/api/facilities/status.js
+++ b/server/routes/api/facilities/status.js
@@ -167,7 +167,7 @@ export default async function (fastify, opts) {
                 body: count === 1
                   ? `Your hold at ${facility.name} was cancelled because the facility closed.`
                   : `${count} of your holds at ${facility.name} were cancelled because the facility closed.`,
-                url: '/lesc',
+                url: '/holds',
                 tag: `facility-closed-${id}`,
               })
             ),
@@ -208,7 +208,7 @@ export default async function (fastify, opts) {
                 userIds: uniqueOfficers.map((o) => o.id),
                 title: `${facility.name} is open again`,
                 body: 'The facility has reopened and is accepting holds.',
-                url: '/lesc',
+                url: '/holds',
                 tag: `facility-reopened-${id}`,
               }),
             ]);

--- a/server/routes/api/push/index.js
+++ b/server/routes/api/push/index.js
@@ -1,0 +1,56 @@
+import { StatusCodes } from 'http-status-codes';
+import { z } from 'zod';
+
+const subscriptionBody = z.object({
+  endpoint: z.string().url(),
+  keys: z.object({
+    p256dh: z.string(),
+    auth: z.string(),
+  }),
+});
+
+export default async function (fastify, opts) {
+  fastify.post('/subscribe',
+    {
+      onRequest: fastify.requireUser,
+      schema: {
+        description: 'Register or re-associate a push subscription with the current user.',
+        body: subscriptionBody,
+        response: {
+          [StatusCodes.NO_CONTENT]: z.null(),
+        },
+      },
+    },
+    async function (request, reply) {
+      const { endpoint, keys: { p256dh, auth } } = request.body;
+
+      await fastify.prisma.pushSubscription.upsert({
+        where: { endpoint },
+        create: { userId: request.user.id, endpoint, p256dh, auth },
+        update: { userId: request.user.id, p256dh, auth },
+      });
+
+      return reply.code(StatusCodes.NO_CONTENT).send();
+    });
+
+  fastify.delete('/subscribe',
+    {
+      onRequest: fastify.requireUser,
+      schema: {
+        description: 'Remove a push subscription for the current user.',
+        body: z.object({
+          endpoint: z.string().url(),
+        }),
+        response: {
+          [StatusCodes.NO_CONTENT]: z.null(),
+        },
+      },
+    },
+    async function (request, reply) {
+      await fastify.prisma.pushSubscription.deleteMany({
+        where: { endpoint: request.body.endpoint, userId: request.user.id },
+      });
+
+      return reply.code(StatusCodes.NO_CONTENT).send();
+    });
+}


### PR DESCRIPTION
## What

- **Server:** add `web-push` dependency and VAPID initialisation (`lib/webpush.js`)
- **DB:** new `PushSubscription` model (endpoint unique per device, cascade-deletes with user)
- **Migration:** `20260526000000_add_push_subscriptions`
- **Queue:** `QUEUE_PUSH_NOTIFICATION` registered in pg-boss worker with retry/backoff
- **API:** `POST /api/push/subscribe` and `DELETE /api/push/subscribe` — authenticated, upserts subscription per device
- **Events:** hold cancellation (`deflections/cancel.js`) and facility open/close (`facilities/status.js`) now enqueue push jobs alongside existing emails
- **Client:** switch vite-plugin-pwa to `injectManifest` strategy so the service worker can be hand-written; new `src/sw.js` handles `push` + `notificationclick` events
- **Client:** `usePushNotifications` hook manages permission, silent re-registration on login, and server-side cleanup on logout
- **Client:** `PushPromptBanner` in `AppLayout` shown to users who haven't granted or dismissed notification permission

## Events wired up in this PR

| Event | Who gets notified | Deep link |
|---|---|---|
| Hold cancelled by someone else | Officer who created the hold | `/holds/:id` |
| Facility closes (cancelling active holds) | Each officer with a cancelled hold | `/holds` |
| Facility reopens | Officers whose holds were cancelled during the closure | `/holds` |

## Events not yet wired up (out of scope for this PR)

The infrastructure is in place — these would each just be a `fastify.backgroundJobs.send(QUEUE_PUSH_NOTIFICATION, {...})` call alongside the existing email or action.

| Event | Who to notify | Priority |
|---|---|---|
| Bed-type update cancels holds (`bed-types/update.js`) | Officers with cancelled holds | High — same pattern as facility close, currently sends email but no push |
| Hold handed off to you (`handoff.js`) | Receiving officer | High — time-sensitive, officer may not have app open |
| Handoff ready (`initiate-handoff.js`) | Field officers who could claim it | Medium — 3-minute TTL makes this urgent |
| Subject arrived at facility (`arrived.js`) | Creating officer | Medium — confirms hold completed |
| Subject left facility (`left.js`) | Creating officer | Medium — closes the loop |
| Hold extended by someone else (`extend.js`) | Creating officer | Low |

## Setup — VAPID keys (required before push notifications will work)

Generate a key pair once per deployment environment:

```bash
cd server && npx web-push generate-vapid-keys
```

Add all four variables to `server/.env` (the root `dev` script copies this to `client/.env` automatically):

```
VAPID_EMAIL=mailto:yourteam@sfgov.org
VAPID_PUBLIC_KEY=<generated public key>
VAPID_PRIVATE_KEY=<generated private key>
VITE_VAPID_PUBLIC_KEY=<same generated public key>
```

In production, `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, and `VAPID_EMAIL` go into AWS Secrets Manager. `VITE_VAPID_PUBLIC_KEY` is baked into the client bundle at build time and should be set as a build environment variable.

If the VAPID vars are absent the server starts normally — `lib/webpush.js` no-ops gracefully — but no push notifications will be delivered.

## Feature flag + local env var override

Push notifications are now gated behind a PostHog feature flag so they can be rolled out gradually without a code deploy. **Note that the PostHog `push-notifications` flag still needs to be created.**

### How the flag works

A new `useFeatureFlag` hook (`client/src/hooks/useFeatureFlag.js`) wraps PostHog's `isFeatureEnabled` API and subscribes to `onFeatureFlags` so the value updates reactively after `identify()` resolves on login.

`usePushNotifications` uses it with `defaultValue: false`:

```js
const pushEnabled = useFeatureFlag('push-notifications', { defaultValue: false });
```

Three states are distinguished:
| Value | Meaning |
|---|---|
| `true` | Flag is on — prompt shown, subscriptions registered |
| `false` | Flag is off — feature completely dormant |
| `null` | PostHog configured but flags not loaded yet — prompt stays hidden |

`=== true` is used (not just truthy) so the `null` loading window never flashes the banner.

### Enabling in production (PostHog)

Create a flag in the PostHog dashboard:
- **Key:** `push-notifications`
- Start at 0% rollout, ramp by org or user property once confirmed working

### Enabling locally (no PostHog needed)

Add one line to `server/.env` — the dev script copies it to `client/.env` automatically:

```
VITE_FLAG_PUSH_NOTIFICATIONS=true
```

Leave it blank or absent to keep push dormant locally (the default).

The naming convention is `VITE_FLAG_<FLAG-NAME-UPPERCASED>`, so any future PostHog flag automatically gets a free local override variable using the same pattern.

### Priority order

1. `VITE_FLAG_PUSH_NOTIFICATIONS` env var (if set) — always wins
2. PostHog `push-notifications` flag (if PostHog is configured)
3. `defaultValue: false` (fallback when PostHog is absent or flags haven't loaded)

### Full local setup checklist

```
# server/.env
VAPID_EMAIL=mailto:yourteam@sfgov.org
VAPID_PUBLIC_KEY=<from npx web-push generate-vapid-keys>
VAPID_PRIVATE_KEY=<from npx web-push generate-vapid-keys>
VITE_VAPID_PUBLIC_KEY=<same as VAPID_PUBLIC_KEY>
VITE_FLAG_PUSH_NOTIFICATIONS=true
```

## Testing locally

1. Set the VAPID vars in `server/.env` as above
2. Open the app, log in — the **Enable notifications** banner appears
3. Click **Allow** and accept the browser prompt
4. Send a test push: `node server/bin/send-test-push.js [email]`
5. Or trigger a real event: cancel another user's hold via `/manage-capacity`

---
https://claude.ai/code/session_016CLBUNCVHNj5aEChZZsCvx