### PR TITLE
[Closes #933] Forms email override

### DIFF
--- a/aws/ecs.json
+++ b/aws/ecs.json
@@ -16,6 +16,10 @@
       "NoEcho": true,
       "Description": "The API key for fetching facility status"
     },
+    "EmailFormsRecipientOverride": {
+      "Type": "String",
+      "Description": "Recipient override for forms emails"
+    },
     "EmailFromName": {
       "Type": "String",
       "Description": "The display name used in email from and reply-to headers"
@@ -431,6 +435,12 @@
                       "?sslmode=no-verify"
                     ]
                   ]
+                }
+              },
+              {
+                "Name": "EMAIL_FORMS_RECIPIENT_OVERRIDE",
+                "Value": {
+                  "Ref": "EmailFormsRecipientOverride"
                 }
               },
               {
@@ -956,6 +966,12 @@
                       "?sslmode=no-verify"
                     ]
                   ]
+                }
+              },
+              {
+                "Name": "EMAIL_FORMS_RECIPIENT_OVERRIDE",
+                "Value": {
+                  "Ref": "EmailFormsRecipientOverride"
                 }
               },
               {

--- a/aws/ecs.sh
+++ b/aws/ecs.sh
@@ -13,6 +13,7 @@ set +a
 
 echo "ARRESTS_API_KEY: $ARRESTS_API_KEY"
 echo "CAPACITY_API_KEY: $CAPACITY_API_KEY"
+echo "EMAIL_FORMS_RECIPIENT_OVERRIDE: $EMAIL_FORMS_RECIPIENT_OVERRIDE"
 echo "EMAIL_FROM_NAME: $EMAIL_FROM_NAME"
 echo "EMAIL_SITE_TITLE: $EMAIL_SITE_TITLE"
 echo "EMAIL_SUBJECT_TITLE: $EMAIL_SUBJECT_TITLE"
@@ -28,4 +29,4 @@ if [[ "$CONT" != "y" ]]; then
     exit 1
 fi
 
-aws cloudformation create-stack --capabilities CAPABILITY_NAMED_IAM --stack-name ${BASE_NAME}-ecs --template-body file://./ecs.json --parameters ParameterKey=ArrestsApiKey,ParameterValue=$ARRESTS_API_KEY ParameterKey=BaseName,ParameterValue=$BASE_NAME ParameterKey=CapacityApiKey,ParameterValue=$CAPACITY_API_KEY "ParameterKey=EmailFromName,ParameterValue=$EMAIL_FROM_NAME" "ParameterKey=EmailSiteTitle,ParameterValue=$EMAIL_SITE_TITLE" "ParameterKey=EmailSubjectTitle,ParameterValue=$EMAIL_SUBJECT_TITLE" ParameterKey=ImageURL,ParameterValue=$IMAGE_URL ParameterKey=SessionSecret,ParameterValue=$SESSION_SECRET ParameterKey=GeocodeRateLimitMs,ParameterValue=$GEOCODE_RATE_LIMIT_MS ParameterKey=SmtpReplyToEmailAddress,ParameterValue=$SMTP_REPLY_TO_EMAIL_ADDRESS ParameterKey=PosthogKey,ParameterValue=$VITE_POSTHOG_KEY ParameterKey=PosthogHost,ParameterValue=$VITE_POSTHOG_HOST "ParameterKey=SiteTitle,ParameterValue=$VITE_SITE_TITLE" --output text
+aws cloudformation create-stack --capabilities CAPABILITY_NAMED_IAM --stack-name ${BASE_NAME}-ecs --template-body file://./ecs.json --parameters ParameterKey=ArrestsApiKey,ParameterValue=$ARRESTS_API_KEY ParameterKey=BaseName,ParameterValue=$BASE_NAME ParameterKey=CapacityApiKey,ParameterValue=$CAPACITY_API_KEY "ParameterKey=EmailFormsRecipientOverride,ParameterValue=$EMAIL_FORMS_RECIPIENT_OVERRIDE" "ParameterKey=EmailFromName,ParameterValue=$EMAIL_FROM_NAME" "ParameterKey=EmailSiteTitle,ParameterValue=$EMAIL_SITE_TITLE" "ParameterKey=EmailSubjectTitle,ParameterValue=$EMAIL_SUBJECT_TITLE" ParameterKey=ImageURL,ParameterValue=$IMAGE_URL ParameterKey=SessionSecret,ParameterValue=$SESSION_SECRET ParameterKey=GeocodeRateLimitMs,ParameterValue=$GEOCODE_RATE_LIMIT_MS ParameterKey=SmtpReplyToEmailAddress,ParameterValue=$SMTP_REPLY_TO_EMAIL_ADDRESS ParameterKey=PosthogKey,ParameterValue=$VITE_POSTHOG_KEY ParameterKey=PosthogHost,ParameterValue=$VITE_POSTHOG_HOST "ParameterKey=SiteTitle,ParameterValue=$VITE_SITE_TITLE" --output text

--- a/server/example.env
+++ b/server/example.env
@@ -49,6 +49,7 @@ EMAIL_FROM_NAME="CareConnect"
 EMAIL_SUBJECT_TITLE="CareConnect"
 EMAIL_SITE_TITLE="City and County of San Francisco: CareConnect"
 EMAIL_BASE_URL=https://careconnect.sf.gov
+EMAIL_FORMS_RECIPIENT_OVERRIDE=
 VITE_FEATURE_REGISTRATION=true
 VITE_POSTHOG_KEY=
 VITE_POSTHOG_HOST=https://app.posthog.com

--- a/server/jobs/formsEmail.js
+++ b/server/jobs/formsEmail.js
@@ -5,12 +5,14 @@ import { generateLive5150Pdf, storeLive5150Pdf } from '#lib/forms/5150/livePdf.j
 import DeflectionDocument from '#models/deflectionDocument.js';
 import { captureException } from '#lib/posthog.js';
 
-const EMAIL_RECIPIENT = 'careconnect@sfgov.org';
-const SWAPSUPS_RECIPIENT = 'sfso-swapsups@sfgov.org';
-const TRANSFER_RECIPIENTS = [
-  'SFPD.Data.Transfer.Authorized@sfgov.org',
-  'Andrew.bley@sfgov.org',
-];
+const EMAIL_RECIPIENT = process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE || 'careconnect@sfgov.org';
+const SWAPSUPS_RECIPIENT = process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE || 'sfso-swapsups@sfgov.org';
+const TRANSFER_RECIPIENTS = process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE
+  ? [process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE]
+  : [
+      'SFPD.Data.Transfer.Authorized@sfgov.org',
+      'Andrew.bley@sfgov.org',
+    ];
 
 export default async function formsEmail (data, prismaClient = prisma) {
   const { deflectionId, formIds, template, recipientEmail, userId, regeneratedFormIds = [] } = data;

--- a/server/routes/api/deflections/cancel.js
+++ b/server/routes/api/deflections/cancel.js
@@ -152,10 +152,12 @@ export default async function (fastify, opts) {
           userId: request.user.id,
           formIds: ['647f'],
           emailTemplate: 'transfer-form',
-          recipientEmail: [
-            'SFPD.Data.Transfer.Authorized@sfgov.org',
-            'Andrew.bley@sfgov.org',
-          ],
+          recipientEmail: process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE
+            ? [process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE]
+            : [
+                'SFPD.Data.Transfer.Authorized@sfgov.org',
+                'Andrew.bley@sfgov.org',
+              ],
         });
       }
 

--- a/server/routes/api/deflections/transfer.js
+++ b/server/routes/api/deflections/transfer.js
@@ -139,10 +139,12 @@ export default async function (fastify, opts) {
         userId: request.user.id,
         formIds: ['647f'],
         emailTemplate: 'transfer-form',
-        recipientEmail: [
-          'SFPD.Data.Transfer.Authorized@sfgov.org',
-          'Andrew.bley@sfgov.org',
-        ],
+        recipientEmail: process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE
+          ? [process.env.EMAIL_FORMS_RECIPIENT_OVERRIDE]
+          : [
+              'SFPD.Data.Transfer.Authorized@sfgov.org',
+              'Andrew.bley@sfgov.org',
+            ],
       });
 
       return reply.send(redactDeflectionForUser(deflection, request.user));


### PR DESCRIPTION
This PR defines a new ENV var for overriding the hard-coded @sfgov.org email recipients used when emailing forms.

