### PR TITLE
need to restrict API to SFPD arrests only per Sheriff

### DIFF
--- a/server/routes/api/arrests.js
+++ b/server/routes/api/arrests.js
@@ -6,6 +6,7 @@ import { firstInitialLastName, streetCityState } from '#lib/forms/shared/formUti
 
 const TIMEZONE = 'America/Los_Angeles';
 const FACILITY_NAME = 'RESET';
+const SFPD_ORGANIZATION_ID = 'sfpd';
 
 const QuerySchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'date must be YYYY-MM-DD'),
@@ -38,8 +39,8 @@ export default async function (fastify) {
       onRequest: [fastify.requireArrestsApiKey],
       schema: {
         description:
-          'List arrests at the RESET facility for the given day (interpreted in Pacific time). ' +
-          'Excludes incidents whose deflections are all cancelled.',
+          'List SFPD-initiated arrests at the RESET facility for the given day (interpreted in Pacific time). ' +
+          'Excludes incidents created by other organizations and incidents whose deflections are all cancelled.',
         querystring: QuerySchema,
         response: {
           [StatusCodes.OK]: ArrestsResponseSchema,
@@ -60,6 +61,7 @@ export default async function (fastify) {
         where: {
           arrestedAt: { gte: start, lt: end },
           facility: { name: FACILITY_NAME },
+          createdByOrganizationId: SFPD_ORGANIZATION_ID,
           deflections: { some: { cancelledAt: null } },
         },
         select: {

--- a/server/test/routes/api/arrests.test.js
+++ b/server/test/routes/api/arrests.test.js
@@ -74,6 +74,7 @@ test('/api/arrests', async (t) => {
     createdByBadgeNumber = null,
     chargeType = null,
     drugType = null,
+    createdByOrganizationId = 'sfpd',
   }) {
     const incident = await prisma.incident.create({
       data: {
@@ -86,6 +87,7 @@ test('/api/arrests', async (t) => {
         caseNumber,
         createdById: user.id,
         createdByBadgeNumber,
+        createdByOrganizationId,
         updatedById: user.id,
       },
     });
@@ -219,6 +221,34 @@ test('/api/arrests', async (t) => {
     // LESC Facility 1 has its own bedType from the shared fixtures
     const otherBedType = await prisma.bedType.findFirst({ where: { facilityId: otherFacility.id } });
     await seedArrest({ facility: otherFacility, bedTypeId: otherBedType.id, arrestedAt: inDayMorning, addressLine1: '999 Other St' });
+
+    const response = await app.inject()
+      .get(`/api/arrests?date=${TARGET_DATE}`)
+      .headers({ authorization: `Bearer ${TEST_API_KEY}` });
+    assert.strictEqual(response.statusCode, StatusCodes.OK);
+
+    const body = JSON.parse(response.body);
+    assert.strictEqual(body.length, 1);
+    assert.strictEqual(body[0].address, '100 Market St, San Francisco, CA');
+  });
+
+  await t.test('excludes incidents created by another organization (SFSO)', async () => {
+    await seedArrest({ facility: resetFacility, bedTypeId: resetBedType.id, arrestedAt: inDayMorning, addressLine1: '100 Market St' });
+    await seedArrest({ facility: resetFacility, bedTypeId: resetBedType.id, arrestedAt: inDayEvening, addressLine1: '900 Sheriff St', createdByOrganizationId: 'sfso' });
+
+    const response = await app.inject()
+      .get(`/api/arrests?date=${TARGET_DATE}`)
+      .headers({ authorization: `Bearer ${TEST_API_KEY}` });
+    assert.strictEqual(response.statusCode, StatusCodes.OK);
+
+    const body = JSON.parse(response.body);
+    assert.strictEqual(body.length, 1);
+    assert.strictEqual(body[0].address, '100 Market St, San Francisco, CA');
+  });
+
+  await t.test('excludes incidents with no creating organization (null org)', async () => {
+    await seedArrest({ facility: resetFacility, bedTypeId: resetBedType.id, arrestedAt: inDayMorning, addressLine1: '100 Market St' });
+    await seedArrest({ facility: resetFacility, bedTypeId: resetBedType.id, arrestedAt: inDayEvening, addressLine1: '000 No Org Ave', createdByOrganizationId: null });
 
     const response = await app.inject()
       .get(`/api/arrests?date=${TARGET_DATE}`)
@@ -380,6 +410,7 @@ test('/api/arrests', async (t) => {
         arrestedAt: inDayMorning,
         encounteredVia: 'ON_VIEW',
         createdById: user.id,
+        createdByOrganizationId: 'sfpd',
         updatedById: user.id,
       },
     });


### PR DESCRIPTION
Sheriff clarified that the API provided to SFPD should not include any arrests they did not initiate. Most arrests will be initiated by SFPD but Sheriff could initiate arrests as well.