### PR TITLE
[Closes #980] Extend visibility of exited records to 72 hours

### DIFF
--- a/client/src/lesc/components/EmptyState.stories.jsx
+++ b/client/src/lesc/components/EmptyState.stories.jsx
@@ -24,7 +24,7 @@ export const NoneInCustody = {
 export const NoneReleased = {
   args: {
     title: 'No persons in Released',
-    description: "Released persons appear here, but those who exit the facility will disappear from view after 24 hours. They're retained in legal records.",
+    description: "Released persons appear here, but those who exit the facility will disappear from view after 72 hours. They're retained in legal records.",
     updatedAt: Date.now(),
   },
 };

--- a/client/src/lesc/components/custody/Custody.jsx
+++ b/client/src/lesc/components/custody/Custody.jsx
@@ -454,7 +454,7 @@ function Custody () {
                 : (
                   <EmptyState
                     title='No persons in Released'
-                    description="Released persons appear here, but those who exit the facility will disappear from view after 24 hours. They're retained in legal records."
+                    description="Released persons appear here, but those who exit the facility will disappear from view after 72 hours. They're retained in legal records."
                     updatedAt={releasedDataUpdatedAt}
                   />
                   )}

--- a/server/lib/retention.js
+++ b/server/lib/retention.js
@@ -1,9 +1,5 @@
-// PII retention windows.
-//
-// EXITED deflections remain visible in list results for this long after exit
-// so staff can use the data for auditing (issue #980). The anonymization job
-// (prisma/client.js) also waits for this window to close before redacting a
-// subject with an exited deflection, so records never disappear mid-window.
+// How long EXITED deflections stay visible in list results, measured from
+// exitedAt. The anonymization job also waits for this window to close.
 export const EXITED_VISIBILITY_HOURS = 72;
 
 export function exitedVisibilityCutoff (now = new Date()) {

--- a/server/lib/retention.js
+++ b/server/lib/retention.js
@@ -1,0 +1,11 @@
+// PII retention windows.
+//
+// EXITED deflections remain visible in list results for this long after exit
+// so staff can use the data for auditing (issue #980). The anonymization job
+// (prisma/client.js) also waits for this window to close before redacting a
+// subject with an exited deflection, so records never disappear mid-window.
+export const EXITED_VISIBILITY_HOURS = 72;
+
+export function exitedVisibilityCutoff (now = new Date()) {
+  return new Date(now.getTime() - EXITED_VISIBILITY_HOURS * 60 * 60 * 1000);
+}

--- a/server/prisma/client.js
+++ b/server/prisma/client.js
@@ -137,9 +137,8 @@ const prisma = new PrismaClient({
         const parsed = parseFloat(process.env.ANONYMIZE_CUTOFF_HOURS);
         const hours = Number.isFinite(parsed) ? parsed : 96;
         const cutoff = new Date(now.getTime() - hours * 60 * 60 * 1000);
-        // Stays longer than 24h push exit + 72h past the creation backstop, so
-        // also hold anonymization until every exit's visibility window (issue
-        // #980) has closed. Never-exited subjects still fall to the backstop.
+        // Hold redaction until every exit's visibility window has closed;
+        // never-exited subjects still fall to the createdAt backstop.
         const visibilityCutoff = exitedVisibilityCutoff(now);
         const eligible = await prisma.$queryRaw`
           SELECT s."id"

--- a/server/prisma/client.js
+++ b/server/prisma/client.js
@@ -5,6 +5,7 @@ import Deflection from '#models/deflection.js';
 import DeflectionDocument from '#models/deflectionDocument.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { PII_FIELDS } from '#models/subject.js';
+import { exitedVisibilityCutoff } from '#lib/retention.js';
 import User from '#models/user.js';
 const { Prisma, PrismaClient } = prismaPkg;
 
@@ -132,15 +133,25 @@ const prisma = new PrismaClient({
     },
     subject: {
       async anonymize (now = new Date()) {
-        // 96h = 24h max stay at RESET + 72h buffer for slippage
+        // 96h = 24h max stay at RESET + 72h post-exit visibility window
         const parsed = parseFloat(process.env.ANONYMIZE_CUTOFF_HOURS);
         const hours = Number.isFinite(parsed) ? parsed : 96;
         const cutoff = new Date(now.getTime() - hours * 60 * 60 * 1000);
+        // Stays longer than 24h push exit + 72h past the creation backstop, so
+        // also hold anonymization until every exit's visibility window (issue
+        // #980) has closed. Never-exited subjects still fall to the backstop.
+        const visibilityCutoff = exitedVisibilityCutoff(now);
         const eligible = await prisma.$queryRaw`
           SELECT s."id"
           FROM "Subject" s
           WHERE s."anonymizedAt" IS NULL
             AND s."createdAt" <= ${cutoff}
+            AND NOT EXISTS (
+              SELECT 1
+              FROM "Deflection" d
+              WHERE d."subjectId" = s."id"
+                AND d."exitedAt" > ${visibilityCutoff}
+            )
         `;
         if (eligible.length === 0) return;
         const ids = eligible.map((row) => row.id);

--- a/server/routes/api/deflections/list.js
+++ b/server/routes/api/deflections/list.js
@@ -64,7 +64,7 @@ export default async function (fastify) {
           { status: Deflection.HoldStatus.ACTIVE },
           { subject: { isNot: null } },
         ]);
-        // Cap visibility of EXITED rows to the retention window (issue #980).
+        // Cap visibility of EXITED rows to the retention window.
         addOrGroup([
           { subjectStatus: { not: Deflection.SubjectStatus.EXITED } },
           { exitedAt: { gte: exitedVisibilityCutoff() } },

--- a/server/routes/api/deflections/list.js
+++ b/server/routes/api/deflections/list.js
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import Deflection from '#models/deflection.js';
 import PropertyPhoto from '#models/propertyPhoto.js';
 import { redactDeflectionsForUser } from '#lib/deflectionVisibility.js';
+import { exitedVisibilityCutoff } from '#lib/retention.js';
 
 export default async function (fastify) {
   fastify.get('/',
@@ -63,11 +64,10 @@ export default async function (fastify) {
           { status: Deflection.HoldStatus.ACTIVE },
           { subject: { isNot: null } },
         ]);
-        // Preserve the existing 24-hour cap on EXITED rows.
-        const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        // Cap visibility of EXITED rows to the retention window (issue #980).
         addOrGroup([
           { subjectStatus: { not: Deflection.SubjectStatus.EXITED } },
-          { exitedAt: { gte: twentyFourHoursAgo } },
+          { exitedAt: { gte: exitedVisibilityCutoff() } },
         ]);
       } else if (handedOff === 'true') {
         // Holds the user created but no longer controls (handed off to another officer)
@@ -104,17 +104,17 @@ export default async function (fastify) {
         const hasExited = statuses.includes('EXITED');
 
         if (hasExited) {
-          const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+          const visibilityCutoff = exitedVisibilityCutoff();
           const otherStatuses = statuses.filter(s => s !== 'EXITED');
 
           if (otherStatuses.length > 0) {
             addOrGroup([
               { subjectStatus: otherStatuses.length > 1 ? { in: otherStatuses } : otherStatuses[0] },
-              { subjectStatus: 'EXITED', exitedAt: { gte: twentyFourHoursAgo } },
+              { subjectStatus: 'EXITED', exitedAt: { gte: visibilityCutoff } },
             ]);
           } else {
             where.subjectStatus = 'EXITED';
-            where.exitedAt = { gte: twentyFourHoursAgo };
+            where.exitedAt = { gte: visibilityCutoff };
           }
         } else {
           where.subjectStatus = statuses.length > 1 ? { in: statuses } : statuses[0];

--- a/server/test/jobs/anonymizeSubjects.test.js
+++ b/server/test/jobs/anonymizeSubjects.test.js
@@ -132,6 +132,73 @@ test('anonymizeSubjects job', async (t) => {
     assert.strictEqual(updated.firstName, 'Fresh');
   });
 
+  await t.test('defers anonymization until 72 hours after exit (issue #980)', async () => {
+    // A stay longer than 24h pushes exit + 72h past the 96h creation backstop.
+    // The exited record must stay intact until its 72h visibility window ends.
+    const { subject } = await createSubjectWithDeflection({
+      exitedAt: DateTime.now().minus({ hours: 71 }).toJSDate(),
+    });
+
+    await prisma.$executeRawUnsafe(
+      'UPDATE "Subject" SET "createdAt" = $1 WHERE "id" = $2::uuid',
+      DateTime.now().minus({ hours: 97 }).toJSDate(),
+      subject.id
+    );
+
+    await anonymizeSubjects({}, prisma);
+
+    const updated = await prisma.subject.findUnique({ where: { id: subject.id } });
+    assert.strictEqual(updated.anonymizedAt, null, 'subject exited 71h ago should keep PII');
+    assert.strictEqual(updated.firstName, 'John');
+  });
+
+  await t.test('anonymizes once 72 hours have passed since exit', async () => {
+    const { subject } = await createSubjectWithDeflection({
+      exitedAt: DateTime.now().minus({ hours: 73 }).toJSDate(),
+    });
+
+    await prisma.$executeRawUnsafe(
+      'UPDATE "Subject" SET "createdAt" = $1 WHERE "id" = $2::uuid',
+      DateTime.now().minus({ hours: 97 }).toJSDate(),
+      subject.id
+    );
+
+    await anonymizeSubjects({}, prisma);
+
+    const updated = await prisma.subject.findUnique({ where: { id: subject.id } });
+    assert.ok(updated.anonymizedAt, 'subject exited 73h ago should be anonymized');
+    assert.strictEqual(updated.firstName, null);
+  });
+
+  await t.test('most recent exit governs subjects with multiple deflections', async () => {
+    const { subject, incident, user } = await createSubjectWithDeflection({
+      exitedAt: DateTime.now().minus({ hours: 100 }).toJSDate(),
+    });
+    await prisma.deflection.create({
+      data: {
+        incidentId: incident.id,
+        facilityId,
+        bedTypeId,
+        subjectId: subject.id,
+        createdById: user.id,
+        status: 'ACTIVE',
+        subjectStatus: 'EXITED',
+        exitedAt: DateTime.now().minus({ hours: 10 }).toJSDate(),
+      },
+    });
+
+    await prisma.$executeRawUnsafe(
+      'UPDATE "Subject" SET "createdAt" = $1 WHERE "id" = $2::uuid',
+      DateTime.now().minus({ hours: 200 }).toJSDate(),
+      subject.id
+    );
+
+    await anonymizeSubjects({}, prisma);
+
+    const updated = await prisma.subject.findUnique({ where: { id: subject.id } });
+    assert.strictEqual(updated.anonymizedAt, null, 'a recent exit on any deflection should defer anonymization');
+  });
+
   await t.test('clears file references and deletes S3 objects for anonymized subjects', async () => {
     const { subject, deflection } = await createSubjectWithDeflection();
 

--- a/server/test/jobs/anonymizeSubjects.test.js
+++ b/server/test/jobs/anonymizeSubjects.test.js
@@ -132,9 +132,8 @@ test('anonymizeSubjects job', async (t) => {
     assert.strictEqual(updated.firstName, 'Fresh');
   });
 
-  await t.test('defers anonymization until 72 hours after exit (issue #980)', async () => {
+  await t.test('defers anonymization until 72 hours after exit', async () => {
     // A stay longer than 24h pushes exit + 72h past the 96h creation backstop.
-    // The exited record must stay intact until its 72h visibility window ends.
     const { subject } = await createSubjectWithDeflection({
       exitedAt: DateTime.now().minus({ hours: 71 }).toJSDate(),
     });

--- a/server/test/routes/api/deflections-visibility.test.js
+++ b/server/test/routes/api/deflections-visibility.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+import { StatusCodes } from 'http-status-codes';
+import { DateTime } from 'luxon';
+
+import { authenticate, build } from '#test/helper.js';
+
+// Issue #980: EXITED deflections must remain visible in list results for
+// 72 hours after exit (previously 24 hours).
+test('/api/deflections EXITED visibility window', async (t) => {
+  const app = await build(t);
+  const { prisma } = app;
+  const userHeaders = await authenticate(app, 'regular.user@test.com', 'test');
+  const regularUser = await prisma.user.findUniqueOrThrow({
+    where: { email: 'regular.user@test.com' },
+  });
+
+  const facilityId = '6d123d8f-edd5-4d14-9220-0508eb30b47b';
+  const bedTypeId = '2347510d-5fd0-4c5c-8a14-82bfd3ef2c76';
+
+  async function createExitedDeflection (exitedAt) {
+    const subject = await prisma.subject.create({
+      data: { firstName: 'Window', lastName: 'Boundary' },
+    });
+    const incident = await prisma.incident.create({
+      data: {
+        facilityId,
+        encounteredVia: 'ON_VIEW',
+        createdById: regularUser.id,
+        updatedById: regularUser.id,
+      },
+    });
+    return prisma.deflection.create({
+      data: {
+        incidentId: incident.id,
+        facilityId,
+        bedTypeId,
+        subjectId: subject.id,
+        createdById: regularUser.id,
+        status: 'COMPLETED',
+        subjectStatus: 'EXITED',
+        exitedAt,
+      },
+    });
+  }
+
+  async function listIds (query) {
+    const response = await app.inject().get(`/api/deflections?${query}`).headers(userHeaders);
+    assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+    return JSON.parse(response.body).map((d) => d.id);
+  }
+
+  // The helper resets the database after each subtest, so each one creates
+  // its own boundary rows.
+  async function createBoundaryRows () {
+    return {
+      insideWindow: await createExitedDeflection(DateTime.now().minus({ hours: 71 }).toJSDate()),
+      outsideWindow: await createExitedDeflection(DateTime.now().minus({ hours: 73 }).toJSDate()),
+    };
+  }
+
+  await t.test('scope=history keeps EXITED rows visible for 72 hours after exit', async () => {
+    const { insideWindow, outsideWindow } = await createBoundaryRows();
+    const ids = await listIds('scope=history');
+    assert.ok(ids.includes(insideWindow.id), 'deflection exited 71h ago should be visible');
+    assert.ok(!ids.includes(outsideWindow.id), 'deflection exited 73h ago should be hidden');
+  });
+
+  await t.test('subjectStatus=EXITED filter honors the 72-hour window', async () => {
+    const { insideWindow, outsideWindow } = await createBoundaryRows();
+    const ids = await listIds('subjectStatus=EXITED');
+    assert.ok(ids.includes(insideWindow.id), 'deflection exited 71h ago should be visible');
+    assert.ok(!ids.includes(outsideWindow.id), 'deflection exited 73h ago should be hidden');
+  });
+
+  await t.test('mixed subjectStatus filter honors the 72-hour window for EXITED rows', async () => {
+    const { insideWindow, outsideWindow } = await createBoundaryRows();
+    const ids = await listIds('subjectStatus=RELEASED,EXITED');
+    assert.ok(ids.includes(insideWindow.id), 'deflection exited 71h ago should be visible');
+    assert.ok(!ids.includes(outsideWindow.id), 'deflection exited 73h ago should be hidden');
+  });
+});

--- a/server/test/routes/api/deflections-visibility.test.js
+++ b/server/test/routes/api/deflections-visibility.test.js
@@ -5,8 +5,8 @@ import { DateTime } from 'luxon';
 
 import { authenticate, build } from '#test/helper.js';
 
-// Issue #980: EXITED deflections must remain visible in list results for
-// 72 hours after exit (previously 24 hours).
+// EXITED deflections must remain visible in list results for 72 hours
+// after exit.
 test('/api/deflections EXITED visibility window', async (t) => {
   const app = await build(t);
   const { prisma } = app;


### PR DESCRIPTION
## Summary

Extends visibility of exited patient records from 24 to 72 hours after exit, so staff can use the data for auditing (#980).

- Adds `server/lib/retention.js` with a shared `EXITED_VISIBILITY_HOURS = 72` constant and `exitedVisibilityCutoff()` helper, replacing the two inline `24 * 60 * 60 * 1000` literals in the deflections list endpoint. The window is still measured from `exitedAt`.
- Guards the anonymization job against the >24h-stay edge case: with a 72h window, a long stay pushes `exit + 72h` past the 96h-from-creation redaction backstop, which could have redacted PII (and hidden the record) while it was still supposed to be visible. `subject.anonymize()` now defers redaction until every deflection's exit is older than 72h — effectively `max(createdAt + 96h, latestExit + 72h)`. Never-exited subjects still redact at the 96h backstop, so stuck records can't retain PII indefinitely.
- Updates the custody empty-state copy (and its story) from 24 to 72 hours.

## Testing

- New `server/test/routes/api/deflections-visibility.test.js` pins the 72h boundary (71h visible / 73h hidden) across all three list branches: `scope=history`, `subjectStatus=EXITED`, and mixed `subjectStatus=RELEASED,EXITED`. Verified these fail when the window is set back to 24h.
- Three new subtests in `anonymizeSubjects.test.js`: defers redaction at exit+71h, redacts at exit+73h, and the most recent exit governs subjects with multiple deflections.
- Full server suite passes (610 tests); lint clean on changed files.

## Note for reviewers

The `ANONYMIZE_CUTOFF_HOURS` env override still controls the creation-time backstop, but the new exit guard can defer redaction past it for long stays. If any environment sets this variable with different expectations, worth confirming before merge.