### PR TITLE
SMS UX QA Updates

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^19.1.1",
     "react-dropzone-esm": "^15.2.0",
     "react-i18next": "^16.5.1",
+    "react-imask": "^7.6.1",
     "react-leaflet": "^5.0.0",
     "react-router": "^7.9.1",
     "uuid": "^13.0.0",

--- a/client/src/UserProfile/EditContactDetailsPage.jsx
+++ b/client/src/UserProfile/EditContactDetailsPage.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { Button, Container, Group, Stack, TextInput, Title } from '@mantine/core';
+import { Button, Container, Group, InputBase, Stack, TextInput, Title } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
+import { IMaskInput } from 'react-imask';
 import { Head } from '@unhead/react';
 
 import Api from '@/Api';
@@ -73,11 +74,13 @@ function EditContactDetailsPage () {
           <Stack>
             <Title order={2}>Edit contact details</Title>
             <TextInput label='Email address' value={user?.email ?? ''} disabled />
-            <TextInput
+            <InputBase
               label='Mobile number'
               placeholder='000-000-0000'
+              component={IMaskInput}
+              mask='000-000-0000'
               value={phone}
-              onChange={(e) => { setPhone(e.currentTarget.value); setPhoneError(null); }}
+              onAccept={(value) => { setPhone(value); setPhoneError(null); }}
               error={phoneError}
               inputMode='tel'
             />

--- a/client/src/UserProfile/NotificationSettingsPage.jsx
+++ b/client/src/UserProfile/NotificationSettingsPage.jsx
@@ -158,8 +158,6 @@ function NotificationSettingsPage () {
                   </Group>
                 )}
               />
-              {/* Preferences stay visible and editable while paused — pausing only
-                  stops delivery, it doesn't discard the saved event selection. */}
               <NotificationPreferenceToggles selected={selected} onToggle={toggle} facilityName={facilityName} />
             </>
           )}

--- a/client/src/UserProfile/NotificationSettingsPage.jsx
+++ b/client/src/UserProfile/NotificationSettingsPage.jsx
@@ -158,9 +158,9 @@ function NotificationSettingsPage () {
                   </Group>
                 )}
               />
-              {notifEnabled
-                ? <NotificationPreferenceToggles selected={selected} onToggle={toggle} facilityName={facilityName} />
-                : <Text size='sm' c='dimmed'>SMS notifications are paused. Set them to Active to start receiving live text updates again.</Text>}
+              {/* Preferences stay visible and editable while paused — pausing only
+                  stops delivery, it doesn't discard the saved event selection. */}
+              <NotificationPreferenceToggles selected={selected} onToggle={toggle} facilityName={facilityName} />
             </>
           )}
         </Stack>

--- a/client/src/UserProfile/NotificationSettingsPage.test.jsx
+++ b/client/src/UserProfile/NotificationSettingsPage.test.jsx
@@ -130,7 +130,7 @@ describe('NotificationSettingsPage (auto-apply)', () => {
     );
   });
 
-  it('when muted, hides the toggles and shows the paused message with Paused selected', async () => {
+  it('when muted, still shows the toggles (with Paused selected and no paused message)', async () => {
     mockUserRef.current = {
       id: 'user-1',
       phoneVerifiedAt: '2026-01-01T00:00:00.000Z',
@@ -139,12 +139,28 @@ describe('NotificationSettingsPage (auto-apply)', () => {
     };
     renderPage();
 
-    expect(await screen.findByText(/SMS notifications are paused/i)).toBeInTheDocument();
-    expect(screen.queryByRole('switch')).toBeNull();
+    expect(await screen.findByRole('switch', { name: /Person in transit/i })).toBeChecked();
+    expect(screen.getAllByRole('switch')).toHaveLength(3);
+    expect(screen.queryByText(/SMS notifications are paused/i)).toBeNull();
     expect(screen.getByDisplayValue('Paused')).toBeInTheDocument(); // dropdown shows Paused
   });
 
-  it('muting persists notificationsEnabled:false and hides the toggles', async () => {
+  it('keeps subscriptions editable while muted', async () => {
+    const user = userEvent.setup();
+    mockUserRef.current = {
+      id: 'user-1',
+      phoneVerifiedAt: '2026-01-01T00:00:00.000Z',
+      subscribedEvents: ['NEW_HOLD'],
+      notificationsEnabled: false,
+    };
+    renderPage();
+
+    await user.click(await screen.findByRole('switch', { name: /Person has arrived/i }));
+
+    await waitFor(() => expect(mockUsersUpdate).toHaveBeenCalledWith('user-1', { subscribedEvents: ['NEW_HOLD', 'ARRIVAL'] }));
+  });
+
+  it('muting persists notificationsEnabled:false and keeps the toggles visible', async () => {
     const user = userEvent.setup();
     renderPage(); // beforeEach user is unmuted, toggles visible
     await screen.findByRole('switch', { name: /Person in transit/i });
@@ -153,11 +169,11 @@ describe('NotificationSettingsPage (auto-apply)', () => {
     await user.click(await screen.findByText('Paused'));
 
     await waitFor(() => expect(mockUsersUpdate).toHaveBeenCalledWith('user-1', { notificationsEnabled: false }));
-    expect(await screen.findByText(/SMS notifications are paused/i)).toBeInTheDocument();
-    expect(screen.queryByRole('switch')).toBeNull();
+    expect(screen.getAllByRole('switch')).toHaveLength(3);
+    expect(screen.queryByText(/SMS notifications are paused/i)).toBeNull();
   });
 
-  it('unmuting persists notificationsEnabled:true and reveals the toggles', async () => {
+  it('unmuting persists notificationsEnabled:true', async () => {
     const user = userEvent.setup();
     mockUserRef.current = {
       id: 'user-1',
@@ -166,13 +182,13 @@ describe('NotificationSettingsPage (auto-apply)', () => {
       notificationsEnabled: false,
     };
     renderPage();
-    await screen.findByText(/SMS notifications are paused/i);
+    await screen.findByRole('switch', { name: /Person in transit/i });
 
     await user.click(screen.getByDisplayValue('Paused')); // open the dropdown
     await user.click(await screen.findByText('Active'));
 
     await waitFor(() => expect(mockUsersUpdate).toHaveBeenCalledWith('user-1', { notificationsEnabled: true }));
-    expect(await screen.findByRole('switch', { name: /Person in transit/i })).toBeInTheDocument();
+    expect(screen.getAllByRole('switch')).toHaveLength(3);
   });
 
   it('shows the opt-out banner when the user is carrier-opted-out (STOP)', async () => {

--- a/client/src/UserProfile/SmsEnrollmentPage.jsx
+++ b/client/src/UserProfile/SmsEnrollmentPage.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import { Anchor, Button, Checkbox, Container, Group, Stack, Text, TextInput } from '@mantine/core';
+import { Anchor, Button, Checkbox, Container, Group, InputBase, Stack, Text } from '@mantine/core';
 import { IconArrowLeft, IconX } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useLocation, useNavigate } from 'react-router';
+import { IMaskInput } from 'react-imask';
 import { Head } from '@unhead/react';
 
 import Api from '@/Api';
@@ -105,11 +106,13 @@ function SmsEnrollmentPage () {
         {step === 'phone' && (
           <Stack>
             <ScreenHeading label='Subscribe to SMS notifications' message='Enter your mobile number to get notified on important status changes.' />
-            <TextInput
+            <InputBase
               label='Mobile number'
               placeholder='000-000-0000'
+              component={IMaskInput}
+              mask='000-000-0000'
               value={phone}
-              onChange={(e) => { setPhone(e.currentTarget.value); setPhoneError(null); }}
+              onAccept={(value) => { setPhone(value); setPhoneError(null); }}
               error={phoneError}
               inputMode='tel'
             />

--- a/client/src/UserProfile/SmsEnrollmentPage.jsx
+++ b/client/src/UserProfile/SmsEnrollmentPage.jsx
@@ -115,6 +115,7 @@ function SmsEnrollmentPage () {
               onAccept={(value) => { setPhone(value); setPhoneError(null); }}
               error={phoneError}
               inputMode='tel'
+              size='lg'
             />
             <Checkbox
               checked={consent}

--- a/client/src/UserProfile/SmsEnrollmentPage.jsx
+++ b/client/src/UserProfile/SmsEnrollmentPage.jsx
@@ -11,7 +11,7 @@ import { useAuthContext } from '@/AuthContext';
 import { useFacilityContext } from '@/FacilityContext';
 import Header from '@/components/Header';
 import IconButtonLink from '@/components/IconButtonLink';
-import NotificationPreferenceToggles from '@/components/NotificationPreferenceToggles';
+import NotificationPreferenceToggles, { NOTIFICATION_EVENTS } from '@/components/NotificationPreferenceToggles';
 import PhoneVerificationView from '@/components/PhoneVerificationView';
 import ScreenHeading from '@/components/ScreenHeading';
 import { useToast } from '@/components/ToastContext';
@@ -36,7 +36,12 @@ function SmsEnrollmentPage () {
   const [phoneError, setPhoneError] = useState(null);
   const [e164, setE164] = useState('');
   const [initialResend, setInitialResend] = useState(30);
-  const [selected, setSelected] = useState(new Set(user?.subscribedEvents ?? []));
+  // First-time enrollment opts into everything by default. A user who already has
+  // subscriptions (they land straight on this step with a verified phone) keeps
+  // their existing choices rather than having them reset to all-on.
+  const [selected, setSelected] = useState(() => new Set(
+    user?.subscribedEvents?.length ? user.subscribedEvents : NOTIFICATION_EVENTS.map((e) => e.value)
+  ));
 
   const startMutation = useMutation({
     mutationFn: (number) => Api.users.startPhoneVerification({ phoneNumber: number, consent, acceptedTerms }),
@@ -155,7 +160,7 @@ function SmsEnrollmentPage () {
             <NotificationPreferenceToggles selected={selected} onToggle={toggleEvent} facilityName={facilityName} />
             <Group>
               <Button
-                variant='secondary'
+                variant='primary'
                 onClick={() => subscribeMutation.mutate()}
                 disabled={selected.size === 0}
                 loading={subscribeMutation.isPending}

--- a/client/src/UserProfile/SmsEnrollmentPage.jsx
+++ b/client/src/UserProfile/SmsEnrollmentPage.jsx
@@ -132,7 +132,7 @@ function SmsEnrollmentPage () {
               }
             />
             <Group>
-              <Button variant='secondary' onClick={onContinue} disabled={!canContinue} loading={startMutation.isPending}>Continue</Button>
+              <Button variant='primary' onClick={onContinue} disabled={!canContinue} loading={startMutation.isPending}>Continue</Button>
             </Group>
           </Stack>
         )}

--- a/client/src/UserProfile/SmsEnrollmentPage.jsx
+++ b/client/src/UserProfile/SmsEnrollmentPage.jsx
@@ -36,9 +36,6 @@ function SmsEnrollmentPage () {
   const [phoneError, setPhoneError] = useState(null);
   const [e164, setE164] = useState('');
   const [initialResend, setInitialResend] = useState(30);
-  // First-time enrollment opts into everything by default. A user who already has
-  // subscriptions (they land straight on this step with a verified phone) keeps
-  // their existing choices rather than having them reset to all-on.
   const [selected, setSelected] = useState(() => new Set(
     user?.subscribedEvents?.length ? user.subscribedEvents : NOTIFICATION_EVENTS.map((e) => e.value)
   ));

--- a/client/src/UserProfile/UserProfilePage.jsx
+++ b/client/src/UserProfile/UserProfilePage.jsx
@@ -110,7 +110,8 @@ function UserProfilePage () {
                   <>
                     {smsOptedOut && <SmsOptOutBanner />}
                     <Field label='Status' value={smsUnmuted ? 'Active' : 'Paused'} />
-                    {smsUnmuted && <Field label='Subscriptions' value={subscriptionsSummary || 'None'} />}
+                    {/* Shown whether Active or Paused — pausing only stops delivery. */}
+                    <Field label='Subscriptions' value={subscriptionsSummary || 'None'} />
                   </>
                 )}
               </Section>

--- a/client/src/components/PhoneVerificationView.jsx
+++ b/client/src/components/PhoneVerificationView.jsx
@@ -30,7 +30,7 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
       queryClient.invalidateQueries({ queryKey: ['users', 'me'] });
       onVerified?.();
     },
-    onError: (err) => setCodeError(err.response?.data?.error || 'That code is incorrect. Try again.'),
+    onError: (err) => setCodeError(err.response?.data?.error || 'Invalid code. Check the code and try again.'),
   });
 
   const resendMutation = useMutation({

--- a/client/src/components/PhoneVerificationView.jsx
+++ b/client/src/components/PhoneVerificationView.jsx
@@ -42,8 +42,6 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
     onError: (err) => setCodeError(err.response?.data?.error || 'Could not resend the code.'),
   });
 
-  // Submitting is explicit (button or Enter) — never on the 6th keystroke, so a
-  // mistyped digit doesn't burn a verification attempt.
   const canSubmit = code.length === 6 && !verifyMutation.isPending;
 
   function submitCode () {

--- a/client/src/components/PhoneVerificationView.jsx
+++ b/client/src/components/PhoneVerificationView.jsx
@@ -42,6 +42,15 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
     onError: (err) => setCodeError(err.response?.data?.error || 'Could not resend the code.'),
   });
 
+  // Submitting is explicit (button or Enter) — never on the 6th keystroke, so a
+  // mistyped digit doesn't burn a verification attempt.
+  const canSubmit = code.length === 6 && !verifyMutation.isPending;
+
+  function submitCode () {
+    if (!canSubmit) return;
+    verifyMutation.mutate(code);
+  }
+
   return (
     <Stack>
       <ScreenHeading label='Enter verification code' message={`We’ve sent a 6-digit code to ${formatUSPhone(phoneNumber)}`} />
@@ -49,9 +58,12 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
         length={6}
         type='number'
         oneTimeCode
+        autoFocus
         value={code}
         onChange={(v) => { setCode(v); setCodeError(null); }}
-        onComplete={(v) => verifyMutation.mutate(v)}
+        // PinInput preventDefaults Enter on the cells (non-digit key), so implicit
+        // form submission can't work here — but the event still bubbles to the root.
+        onKeyDown={(e) => { if (e.key === 'Enter') submitCode(); }}
         placeholder=''
         error={!!codeError}
         aria-label='Verification code'
@@ -73,8 +85,8 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
       <Stack gap='sm' align='flex-start'>
         <Button
           variant='primary'
-          onClick={() => verifyMutation.mutate(code)}
-          disabled={code.length !== 6}
+          onClick={submitCode}
+          disabled={!canSubmit}
           loading={verifyMutation.isPending}
         >
           Verify and continue

--- a/client/src/components/PhoneVerificationView.jsx
+++ b/client/src/components/PhoneVerificationView.jsx
@@ -55,6 +55,19 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
         placeholder=''
         error={!!codeError}
         aria-label='Verification code'
+        // Spec: 48x48 cells with Text/lg (18/28). Mantine's size scale has
+        // no 48px step (sm 36 / md 42 / lg 50), so the cell is sized explicitly.
+        // Each cell is a wrapper (`pinInput`, sets the box width) around the
+        // bordered `input` (sets its own height/type), so both need setting.
+        styles={{
+          pinInput: { width: '48px', height: '48px' },
+          input: {
+            height: '48px',
+            minHeight: '48px',
+            fontSize: 'var(--mantine-font-size-lg)',
+            lineHeight: 'var(--mantine-line-height-lg)',
+          },
+        }}
       />
       {codeError && <Text c='red' size='sm'>{codeError}</Text>}
       <Stack gap='sm' align='flex-start'>

--- a/client/src/components/PhoneVerificationView.jsx
+++ b/client/src/components/PhoneVerificationView.jsx
@@ -59,7 +59,7 @@ function PhoneVerificationView ({ phoneNumber, initialResendSeconds = 0, onVerif
       {codeError && <Text c='red' size='sm'>{codeError}</Text>}
       <Stack gap='sm' align='flex-start'>
         <Button
-          variant='secondary'
+          variant='primary'
           onClick={() => verifyMutation.mutate(code)}
           disabled={code.length !== 6}
           loading={verifyMutation.isPending}

--- a/client/src/components/PhoneVerificationView.test.jsx
+++ b/client/src/components/PhoneVerificationView.test.jsx
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MantineProvider } from '@mantine/core';
+
+import theme from '@/AppTheme';
+import PhoneVerificationView from './PhoneVerificationView';
+
+const { mockVerify } = vi.hoisted(() => ({ mockVerify: vi.fn() }));
+
+vi.mock('@/Api', () => ({
+  default: { users: { verifyPhone: mockVerify, resendPhoneCode: vi.fn() } },
+}));
+
+function setup () {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MantineProvider theme={theme}>
+        <PhoneVerificationView phoneNumber='+14155550199' />
+      </MantineProvider>
+    </QueryClientProvider>
+  );
+}
+
+const pinCells = () => [...document.querySelectorAll('.mantine-PinInput-input')];
+
+describe('PhoneVerificationView', () => {
+  beforeEach(() => mockVerify.mockReset().mockResolvedValue({ data: {} }));
+  afterEach(cleanup);
+
+  it('focuses the first pin cell on mount, so typing goes straight in', () => {
+    setup();
+    expect(document.activeElement).toBe(pinCells()[0]);
+  });
+
+  // Submitting is explicit by design: auto-submitting on the 6th keystroke spends
+  // one of the 5 server-side attempts on a typo the user hasn't seen yet.
+  it('does not submit on the 6th digit', async () => {
+    setup();
+    await userEvent.keyboard('123456');
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+
+  it('submits on Enter once 6 digits are entered', async () => {
+    setup();
+    await userEvent.keyboard('123456{Enter}');
+    expect(mockVerify).toHaveBeenCalledTimes(1);
+    expect(mockVerify).toHaveBeenCalledWith('123456');
+  });
+
+  it('ignores Enter before 6 digits are entered', async () => {
+    setup();
+    await userEvent.keyboard('12345{Enter}');
+    expect(mockVerify).not.toHaveBeenCalled();
+  });
+
+  it('enables the button only at 6 digits, and submits on click', async () => {
+    setup();
+    const button = screen.getByRole('button', { name: /verify and continue/i });
+    expect(button).toBeDisabled();
+    await userEvent.keyboard('123456');
+    expect(button).toBeEnabled();
+    await userEvent.click(button);
+    expect(mockVerify).toHaveBeenCalledWith('123456');
+  });
+});

--- a/client/src/components/SmsSubscriptionBanner.jsx
+++ b/client/src/components/SmsSubscriptionBanner.jsx
@@ -50,9 +50,9 @@ function SmsSubscriptionBanner () {
       styles={{ root: { backgroundColor: 'var(--mantine-color-gray-1)' } }}
     >
       <Stack gap='xs'>
-        <Text size='sm'>Subscribe to SMS notifications for CareConnect status updates.</Text>
+        <Text size='md'>Subscribe to SMS notifications for CareConnect status updates.</Text>
         <Group gap='md'>
-          <Anchor component='button' type='button' onClick={() => bannerActionMutation.mutate('remind')}>
+          <Anchor size = 'sm' component='button' type='button' onClick={() => bannerActionMutation.mutate('remind')}>
             Remind me later
           </Anchor>
           <Button variant='secondary' size='sm' onClick={onSubscribe}>

--- a/client/src/components/SmsSubscriptionBanner.jsx
+++ b/client/src/components/SmsSubscriptionBanner.jsx
@@ -52,7 +52,7 @@ function SmsSubscriptionBanner () {
       <Stack gap='xs'>
         <Text size='md'>Subscribe to SMS notifications for CareConnect status updates.</Text>
         <Group gap='md'>
-          <Anchor size = 'sm' component='button' type='button' onClick={() => bannerActionMutation.mutate('remind')}>
+          <Anchor size='sm' component='button' type='button' onClick={() => bannerActionMutation.mutate('remind')}>
             Remind me later
           </Anchor>
           <Button variant='secondary' size='sm' onClick={onSubscribe}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react-dom": "^19.1.1",
         "react-dropzone-esm": "^15.2.0",
         "react-i18next": "^16.5.1",
+        "react-imask": "^7.6.1",
         "react-leaflet": "^5.0.0",
         "react-router": "^7.9.1",
         "uuid": "^13.0.0",
@@ -3368,6 +3369,18 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -11950,6 +11963,20 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.50.0.tgz",
+      "integrity": "sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -16812,6 +16839,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/imask": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/imask/-/imask-7.6.1.tgz",
+      "integrity": "sha512-sJlIFM7eathUEMChTh9Mrfw/IgiWgJqBKq2VNbyXvBZ7ev/IlO6/KQTKlV/Fm+viQMLrFLG/zCuudrLIwgK2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime-corejs3": "^7.24.4"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
       }
     },
     "node_modules/immer": {
@@ -21964,6 +22003,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-imask": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/react-imask/-/react-imask-7.6.1.tgz",
+      "integrity": "sha512-vLNfzcCz62Yzx/GRGh5tiCph9Gbh2cZu+Tz8OiO5it2eNuuhpA0DWhhSlOtVtSJ80+Bx+vFK5De8eQ9AmbkXzA==",
+      "license": "MIT",
+      "dependencies": {
+        "imask": "^7.6.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "npm": ">=4.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0"
       }
     },
     "node_modules/react-is": {

--- a/server/lib/smsOtp.js
+++ b/server/lib/smsOtp.js
@@ -63,7 +63,7 @@ export async function checkVerificationCode (prisma, user, code) {
       where: { id: user.id },
       data: { smsOtpAttempts: { increment: 1 } },
     });
-    return { status: 422, error: 'That code is incorrect. Try again.' };
+    return { status: 422, error: 'Invalid code. Check the code and try again.' };
   }
   return { ok: true };
 }


### PR DESCRIPTION
In this PR:

- Updated text size in several places to match Figma
- Changed button style to `primary` for several buttons (in SMS enrollment flow)
- During first-time enrollment, all subscriptions types are now toggled on by default (instead of off by default)
- We no longer automatically submit the OTP when the user enters 6 digits. User must manually tap Verify (or press enter, on desktop)
- Added input-masking for phone number input
- Tweaked visual display of pin input (48x48px)
- Updated copy for error message displayed when phone verification code is incorrect
- No longer hide subscription preferences when notifs are paused

Based on QA feedback here: https://www.figma.com/design/Q8kS4FJXh1TbbM8eDR7Z6Y/CareConnect?node-id=19385-16094&t=QlVsUSJbaePlAtEQ-0

CC @uxuichelsea 