### PR TITLE
SMS UX QA, Round 2

### DIFF
--- a/client/src/AppTheme.js
+++ b/client/src/AppTheme.js
@@ -1,4 +1,4 @@
-import { createTheme, Accordion, Alert, Anchor, Autocomplete, Badge, Burger, Button, Card, Checkbox, Chip, Container, FileInput, Input, Menu, Modal, Notification, SegmentedControl, Stack, Select, Textarea, TextInput } from '@mantine/core';
+import { createTheme, Accordion, Alert, Anchor, Autocomplete, Badge, Burger, Button, Card, Checkbox, Chip, Container, FileInput, Input, InputBase, Menu, Modal, Notification, SegmentedControl, Stack, Select, Textarea, TextInput } from '@mantine/core';
 
 import { IconCheck } from '@tabler/icons-react';
 
@@ -162,6 +162,15 @@ const AppTheme = createTheme({
       }
     }),
     FileInput: FileInput.extend({
+      defaultProps: {
+        size: 'lg',
+        radius: 'md'
+      },
+      classNames: inputClasses
+    }),
+    // Matches the other input-family components so a masked InputBase sits flush
+    // beside a TextInput (same type size, height, radius and label treatment).
+    InputBase: InputBase.extend({
       defaultProps: {
         size: 'lg',
         radius: 'md'

--- a/client/src/UserProfile/EditContactDetailsPage.jsx
+++ b/client/src/UserProfile/EditContactDetailsPage.jsx
@@ -23,8 +23,10 @@ function EditContactDetailsPage () {
   const { showToast } = useToast();
 
   const [step, setStep] = useState('form');
-  // Pre-fill only a VERIFIED number; UI ignores an unverified number
-  const [phone, setPhone] = useState(user?.phoneVerifiedAt ? (formatUSPhone(user.phoneNumber) || '') : '');
+  // Pre-fill only a VERIFIED number; UI ignores an unverified number. Frozen at
+  // mount so it can double as the baseline for the "has anything changed?" check.
+  const [initialPhone] = useState(() => (user?.phoneVerifiedAt ? (formatUSPhone(user.phoneNumber) || '') : ''));
+  const [phone, setPhone] = useState(initialPhone);
   const [phoneError, setPhoneError] = useState(null);
   const [e164, setE164] = useState('');
   const [initialResend, setInitialResend] = useState(30);
@@ -53,6 +55,10 @@ function EditContactDetailsPage () {
     setE164(number);
     startMutation.mutate(number);
   }
+
+  // Save is only offered once the number both differs from what was there and is a
+  // complete 10-digit US number — mid-typing is a normal state, not an error.
+  const canSave = phone !== initialPhone && !!toE164US(phone);
 
   function handleBack () {
     if (step === 'verify') setStep('form');
@@ -85,8 +91,8 @@ function EditContactDetailsPage () {
               inputMode='tel'
             />
             <Group>
-              <Button variant='light' color='red' onClick={() => navigate('/profile')}>Cancel</Button>
-              <Button variant='secondary' onClick={onSave} loading={startMutation.isPending}>Save changes</Button>
+              <Button variant='light' onClick={() => navigate('/profile')}>Cancel</Button>
+              <Button variant='primary' onClick={onSave} disabled={!canSave} loading={startMutation.isPending}>Save changes</Button>
             </Group>
           </Stack>
         )}

--- a/client/src/UserProfile/EditContactDetailsPage.jsx
+++ b/client/src/UserProfile/EditContactDetailsPage.jsx
@@ -24,7 +24,7 @@ function EditContactDetailsPage () {
 
   const [step, setStep] = useState('form');
   // Pre-fill only a VERIFIED number; UI ignores an unverified number. Frozen at
-  // mount so it can double as the baseline for the "has anything changed?" check.
+  // mount so we can check for user edits.
   const [initialPhone] = useState(() => (user?.phoneVerifiedAt ? (formatUSPhone(user.phoneNumber) || '') : ''));
   const [phone, setPhone] = useState(initialPhone);
   const [phoneError, setPhoneError] = useState(null);
@@ -56,8 +56,7 @@ function EditContactDetailsPage () {
     startMutation.mutate(number);
   }
 
-  // Save is only offered once the number both differs from what was there and is a
-  // complete 10-digit US number — mid-typing is a normal state, not an error.
+  // Only enable save button when there's a meaningful (and valid) change
   const canSave = phone !== initialPhone && !!toE164US(phone);
 
   function handleBack () {

--- a/client/src/UserProfile/EditContactDetailsPage.test.jsx
+++ b/client/src/UserProfile/EditContactDetailsPage.test.jsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MantineProvider } from '@mantine/core';
+import { MemoryRouter } from 'react-router';
+
+import EditContactDetailsPage from './EditContactDetailsPage';
+
+const { mockStartVerification, mockNavigate, mockUserRef } = vi.hoisted(() => ({
+  mockStartVerification: vi.fn(),
+  mockNavigate: vi.fn(),
+  mockUserRef: { current: null },
+}));
+
+vi.mock('@/Api', () => ({
+  default: {
+    users: {
+      startPhoneVerification: mockStartVerification,
+      verifyPhone: vi.fn(),
+      resendPhoneCode: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@/AuthContext', () => ({
+  useAuthContext: () => ({ user: mockUserRef.current }),
+}));
+
+vi.mock('@/components/ToastContext', () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
+vi.mock('react-router', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@unhead/react', () => ({
+  Head: ({ children }) => <>{children}</>,
+}));
+
+function renderPage () {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <MantineProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <EditContactDetailsPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MantineProvider>
+  );
+}
+
+const saveButton = () => screen.getByRole('button', { name: /save changes/i });
+const phoneField = () => screen.getByLabelText(/mobile number/i);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUserRef.current = {
+    id: 'user-1',
+    email: 'deputy@careconnectsf.org',
+    phoneNumber: '+14155550199',
+    phoneVerifiedAt: '2026-01-01T00:00:00.000Z',
+  };
+  mockStartVerification.mockResolvedValue({ data: { resendAvailableInSeconds: 30 } });
+});
+
+afterEach(cleanup);
+
+describe('EditContactDetailsPage', () => {
+  it('pre-fills the verified number and disables Save until something changes', () => {
+    renderPage();
+
+    expect(phoneField()).toHaveValue('415-555-0199');
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('keeps Save disabled while the new number is incomplete', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.clear(phoneField());
+    await user.type(phoneField(), '41555');
+
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('keeps Save disabled when the field is cleared entirely', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.clear(phoneField());
+
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('keeps Save disabled when the same number is retyped', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.clear(phoneField());
+    await user.type(phoneField(), '4155550199');
+
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('enables Save for a different, complete number and starts verification', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.clear(phoneField());
+    await user.type(phoneField(), '2025551234');
+    expect(saveButton()).toBeEnabled();
+
+    await user.click(saveButton());
+
+    await waitFor(() => expect(mockStartVerification).toHaveBeenCalledWith({ phoneNumber: '+12025551234' }));
+  });
+
+  it('enables Save when the user has no verified number on file', async () => {
+    const user = userEvent.setup();
+    mockUserRef.current = { id: 'user-1', email: 'deputy@careconnectsf.org', phoneNumber: null, phoneVerifiedAt: null };
+    renderPage();
+
+    expect(phoneField()).toHaveValue('');
+    expect(saveButton()).toBeDisabled();
+
+    await user.type(phoneField(), '4155550199');
+
+    expect(saveButton()).toBeEnabled();
+  });
+});

--- a/server/lib/smsInbound.js
+++ b/server/lib/smsInbound.js
@@ -1,5 +1,6 @@
 import prisma from '#prisma/client.js';
 import sms from '#lib/sms.js';
+import * as templates from '#lib/smsTemplates.js';
 import { restoreDelivery, recordOptOut, OPT_IN_OUTCOME } from '#lib/smsOptIn.js';
 
 // Handles inbound SMS replies:
@@ -62,12 +63,12 @@ export async function handleInboundSms ({ fromNumber, body }, prismaClient = pri
 
   if (MUTE_WORDS.includes(keyword)) {
     await prismaClient.user.update({ where: { id: user.id }, data: { notificationsEnabled: false } });
-    await reply(fromNumber, 'CareConnect: SMS notifications paused. Reply RESUME to receive live updates again.');
+    await reply(fromNumber, templates.pausedBody());
     return { action: 'mute' };
   }
   if (UNMUTE_WORDS.includes(keyword)) {
     await prismaClient.user.update({ where: { id: user.id }, data: { notificationsEnabled: true } });
-    await reply(fromNumber, 'CareConnect: SMS notifications resumed. Reply PAUSE to pause live updates.');
+    await reply(fromNumber, templates.resumedBody());
     return { action: 'unmute' };
   }
   if (OPTOUT_WORDS.includes(keyword)) {

--- a/server/lib/smsNotifications.js
+++ b/server/lib/smsNotifications.js
@@ -132,4 +132,17 @@ export async function maybeSendWelcome (fastify, user) {
   return 1;
 }
 
-export default { notifyNewHold, notifyArrival, notifyExit, maybeNotifyExit, maybeNotifyReadyHolds, maybeSendWelcome };
+// Confirm an in-app pause/resume over SMS, so a change made in the UI lands on the
+// phone exactly as one made by replying PAUSE/RESUME. Call only when
+// notificationsEnabled actually changed. Skipped for users we can't text: no
+// verified number, or carrier opt-out (AWS blocks those sends anyway).
+export async function maybeConfirmNotificationState (fastify, user) {
+  if (!user?.phoneVerifiedAt) return 0;
+  if (user.smsOptedOutAt) return 0;
+  if (user.deactivatedAt || user.deletedAt) return 0;
+  const body = user.notificationsEnabled ? templates.resumedBody() : templates.pausedBody();
+  await sms.sendText({ to: user.phoneNumber, body });
+  return 1;
+}
+
+export default { notifyNewHold, notifyArrival, notifyExit, maybeNotifyExit, maybeNotifyReadyHolds, maybeSendWelcome, maybeConfirmNotificationState };

--- a/server/lib/smsTemplates.js
+++ b/server/lib/smsTemplates.js
@@ -39,6 +39,16 @@ export function exitBody (facility, { deflectionId } = {}) {
   return `CareConnect: Hold ${deflectionId} exited ${facility.name}. View details: ${linkTo(facility, `/custody/${deflectionId}`)}`;
 }
 
+// Pause/resume confirmations. Shared by the inbound keyword handler and the
+// in-app toggle so a change made either way reads identically on the phone.
+export function pausedBody () {
+  return 'CareConnect: SMS notifications paused. Reply RESUME to receive live updates again.';
+}
+
+export function resumedBody () {
+  return 'CareConnect: SMS notifications resumed. Reply PAUSE to pause live updates.';
+}
+
 // First-time enrollment welcome message
 export function welcomeBody (facility) {
   return `CareConnect: You're now subscribed to SMS notifications. You can manage your preferences here: ${linkTo(facility, '/profile/notifications')}. Reply STOP to unsubscribe at any time.`;

--- a/server/routes/api/users/patch.js
+++ b/server/routes/api/users/patch.js
@@ -124,6 +124,7 @@ export default async function (fastify, opts) {
       let data;
       let lockedMissing = false;
       let lockedForbidden = false;
+      let notificationStateChanged = false;
       await fastify.prisma.$transaction(async (tx) => {
         data = await tx.user.findByIdForUpdate(tx, id);
         if (!data) {
@@ -177,6 +178,10 @@ export default async function (fastify, opts) {
           }
         }
 
+        // Recorded only when the value actually differs from what's stored, so a
+        // no-op PATCH doesn't trigger a confirmation text.
+        notificationStateChanged = user.changes.has('notificationsEnabled');
+
         const pictureHandler = user.setAsset('picture', picture);
 
         if (request.body.unitName && data.organizationId) {
@@ -206,11 +211,16 @@ export default async function (fastify, opts) {
       if (lockedForbidden) {
         return reply.code(StatusCodes.FORBIDDEN).send();
       }
-      // Send the one-time welcome SMS if this user just subscribed
-      // for the first time.
+      // Send the one-time welcome SMS if this user just subscribed for the first
+      // time; otherwise confirm a pause/resume they just made in the app. The
+      // welcome wins — enrolling flips notificationsEnabled to true, and a new
+      // subscriber shouldn't get "notifications resumed" on top of the welcome.
       smsNotifications
         .maybeSendWelcome(fastify, data)
-        .catch((err) => fastify.log.error({ err }, 'SMS welcome notification failed'));
+        .then((sent) => (sent || !notificationStateChanged
+          ? 0
+          : smsNotifications.maybeConfirmNotificationState(fastify, data)))
+        .catch((err) => fastify.log.error({ err }, 'SMS state notification failed'));
       return reply.send(new User(data));
     });
 }

--- a/server/routes/api/users/phone.js
+++ b/server/routes/api/users/phone.js
@@ -46,7 +46,7 @@ export default async function (fastify, opts) {
         select: { id: true },
       });
       if (takenBy) {
-        return reply.code(StatusCodes.CONFLICT).send({ error: 'That number is already in use on another account. Please enter a different number.' });
+        return reply.code(StatusCodes.CONFLICT).send({ error: 'This mobile number is already in use with another account. Enter a different mobile number.' });
       }
 
       const remaining = resendCooldownRemaining(request.user.smsOtpLastSentAt);
@@ -69,7 +69,7 @@ export default async function (fastify, opts) {
           return reply.code(StatusCodes.UNPROCESSABLE_ENTITY).send({ error: 'We couldn’t send a verification code to that number. Check that it’s correct and try again.' });
         }
         if (err?.code === 'P2002') {
-          return reply.code(StatusCodes.CONFLICT).send({ error: 'That number is already in use on another account. Please enter a different number.' });
+          return reply.code(StatusCodes.CONFLICT).send({ error: 'This mobile number is already in use with another account. Enter a different mobile number.' });
         }
         throw err;
       }

--- a/server/test/routes/api/users/sms-mute-confirmation.test.js
+++ b/server/test/routes/api/users/sms-mute-confirmation.test.js
@@ -1,0 +1,138 @@
+import { test, mock } from 'node:test';
+import * as assert from 'node:assert';
+import { StatusCodes } from 'http-status-codes';
+
+import { build, authenticate } from '#test/helper.js';
+
+// Changing the pause/resume state in the app confirms over SMS, so it lands on the
+// phone exactly like a change made by replying PAUSE/RESUME. The one-time welcome
+// takes precedence: enrolling flips notificationsEnabled to true, and a brand-new
+// subscriber must not get "notifications resumed" stacked on the welcome.
+const sendText = mock.fn(async () => {});
+mock.module('#lib/sms.js', {
+  defaultExport: {
+    sendText,
+    describeOptOutStatus: async () => ({ available: true, optedOut: false }),
+    attemptOptIn: async () => ({ outcome: 'restored' }),
+    resolveTransport: () => 'log',
+    reset: () => {},
+  },
+});
+
+const LESC1 = '6d123d8f-edd5-4d14-9220-0508eb30b47b';
+
+// The PATCH fires the SMS without awaiting it (fire-and-forget, so a failed text
+// never fails the request), so give the microtask queue a beat to settle.
+const settle = () => new Promise((resolve) => setTimeout(resolve, 50));
+
+test('PATCH /api/users/:id — pause/resume confirmation SMS', async (t) => {
+  const app = await build(t);
+  const { prisma } = app;
+
+  const adminHeaders = await authenticate(app, 'admin.user@test.com', 'test');
+
+  let seq = 0;
+  async function makeUser (overrides = {}) {
+    seq += 1;
+    return prisma.user.create({
+      data: {
+        email: `muteconf-${seq}@test.com`,
+        firstName: 'Mute',
+        lastName: 'Conf',
+        hashedPassword: 'x',
+        roles: ['CUSTODY'],
+        currentFacilityId: LESC1,
+        phoneNumber: `+1555333${1000 + seq}`,
+        phoneVerifiedAt: new Date(),
+        notificationsEnabled: true,
+        subscribedEvents: ['ARRIVAL'],
+        smsWelcomedAt: new Date(), // already welcomed unless a test says otherwise
+        ...overrides,
+      },
+    });
+  }
+
+  async function patch (id, payload) {
+    const response = await app
+      .inject()
+      .patch(`/api/users/${id}`)
+      .headers(adminHeaders)
+      .payload(payload);
+    await settle();
+    return response;
+  }
+
+  await t.test('pausing in the app texts the paused confirmation', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser({ notificationsEnabled: true });
+
+    const response = await patch(user.id, { notificationsEnabled: false });
+
+    assert.strictEqual(response.statusCode, StatusCodes.OK);
+    assert.strictEqual(sendText.mock.callCount(), 1);
+    const { to, body } = sendText.mock.calls[0].arguments[0];
+    assert.strictEqual(to, user.phoneNumber);
+    assert.match(body, /notifications paused\. Reply RESUME/);
+  });
+
+  await t.test('resuming in the app texts the resumed confirmation', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser({ notificationsEnabled: false });
+
+    await patch(user.id, { notificationsEnabled: true });
+
+    assert.strictEqual(sendText.mock.callCount(), 1);
+    assert.match(sendText.mock.calls[0].arguments[0].body, /notifications resumed\. Reply PAUSE/);
+  });
+
+  await t.test('a no-op PATCH (same value) sends nothing', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser({ notificationsEnabled: true });
+
+    await patch(user.id, { notificationsEnabled: true });
+
+    assert.strictEqual(sendText.mock.callCount(), 0);
+  });
+
+  await t.test('a PATCH that changes something else sends nothing', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser();
+
+    await patch(user.id, { subscribedEvents: ['ARRIVAL', 'EXIT'] });
+
+    assert.strictEqual(sendText.mock.callCount(), 0);
+  });
+
+  await t.test('first-time subscribe sends only the welcome, not "resumed"', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser({
+      notificationsEnabled: false,
+      subscribedEvents: [],
+      smsWelcomedAt: null,
+    });
+
+    // Mirrors SmsEnrollmentPage's Subscribe: events + notificationsEnabled together.
+    await patch(user.id, { subscribedEvents: ['ARRIVAL'], notificationsEnabled: true });
+
+    assert.strictEqual(sendText.mock.callCount(), 1);
+    assert.match(sendText.mock.calls[0].arguments[0].body, /now subscribed to SMS notifications/);
+  });
+
+  await t.test('does not text a carrier-opted-out (STOP) user', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser({ notificationsEnabled: true, smsOptedOutAt: new Date() });
+
+    await patch(user.id, { notificationsEnabled: false });
+
+    assert.strictEqual(sendText.mock.callCount(), 0);
+  });
+
+  await t.test('does not text a user with no verified number', async () => {
+    sendText.mock.resetCalls();
+    const user = await makeUser({ notificationsEnabled: true, phoneVerifiedAt: null });
+
+    await patch(user.id, { notificationsEnabled: false });
+
+    assert.strictEqual(sendText.mock.callCount(), 0);
+  });
+});


### PR DESCRIPTION
In this PR:

- When a user toggles their SMS status (`Active` vs `Paused`) in the app, we now send an SMS acknowledgment of this action (just as if the user  had performed the action via SMS to begin with). 
- On the `Edit contact details` page:
  - updated error message copy
  - fixed a font size issue
  - made the Save changes button `primary`
  - made the `Cancel` button `light` (but no longer red)
  - `Save changes` button is now only enabled if you're actually able to save a change (new value is actually different from initial value, and the new value is valid)
 

These are addressing QA items listed here: https://www.figma.com/design/Q8kS4FJXh1TbbM8eDR7Z6Y/CareConnect?node-id=19388-16393&t=LxWPma8KqCgw7wKM-0
