### PR TITLE
Script to apply phone number config

### DIFF
--- a/aws/ecs.json
+++ b/aws/ecs.json
@@ -338,6 +338,22 @@
                 }
               },
               {
+                "Name": "AWS_SMS_INBOUND_TOPIC_ARN",
+                "Value": {
+                  "Fn::ImportValue": {
+                    "Fn::Sub": "${BaseName}-sms-inbound-sns-topic-arn"
+                  }
+                }
+              },
+              {
+                "Name": "AWS_SMS_OPT_OUT_LIST_NAME",
+                "Value": {
+                  "Fn::ImportValue": {
+                    "Fn::Sub": "${BaseName}-sms-opt-out-list-name"
+                  }
+                }
+              },
+              {
                 "Name": "AWS_SMS_ACCESS_KEY_ID",
                 "Value": {
                   "Fn::ImportValue": {

--- a/aws/ecs.json
+++ b/aws/ecs.json
@@ -930,6 +930,22 @@
                 }
               },
               {
+                "Name": "AWS_SMS_INBOUND_TOPIC_ARN",
+                "Value": {
+                  "Fn::ImportValue": {
+                    "Fn::Sub": "${BaseName}-sms-inbound-sns-topic-arn"
+                  }
+                }
+              },
+              {
+                "Name": "AWS_SMS_OPT_OUT_LIST_NAME",
+                "Value": {
+                  "Fn::ImportValue": {
+                    "Fn::Sub": "${BaseName}-sms-opt-out-list-name"
+                  }
+                }
+              },
+              {
                 "Name": "AWS_SMS_ACCESS_KEY_ID",
                 "Value": {
                   "Fn::ImportValue": {

--- a/aws/sms.json
+++ b/aws/sms.json
@@ -19,6 +19,17 @@
         }
       }
     },
+    "SMSInboundSNSTopicARN": {
+      "Description": "ARN for inbound SNS topic",
+      "Value": {
+        "Ref": "SMSInboundSNSTopic"
+      },
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${BaseName}-sms-inbound-sns-topic-arn"
+        }
+      }
+    },
     "SMSUserAccessKeyId": {
       "Description": "Access Key ID for the user",
       "Value": {
@@ -38,6 +49,17 @@
       "Export": {
         "Name": {
           "Fn::Sub": "${BaseName}-sms-user-secret-access-key-arn"
+        }
+      }
+    },
+    "SMSOptOutListName": {
+      "Description": "Name for the SMS opt-out list",
+      "Value": {
+        "Ref": "SMSOptOutList"
+      },
+      "Export": {
+        "Name": {
+          "Fn::Sub": "${BaseName}-sms-opt-out-list-name"
         }
       }
     }
@@ -172,6 +194,14 @@
         "RawMessageDelivery": true,
         "TopicArn": {
           "Ref": "SMSInboundSNSTopic"
+        }
+      }
+    },
+    "SMSOptOutList": {
+      "Type": "AWS::SMSVOICE::OptOutList",
+      "Properties": {
+        "OptOutListName": {
+          "Fn::Sub": "${BaseName}-sms-opt-out-list"
         }
       }
     }

--- a/server/bin/sync-sms-config.js
+++ b/server/bin/sync-sms-config.js
@@ -11,7 +11,15 @@ import {
   UpdatePhoneNumberCommand,
 } from '@aws-sdk/client-pinpoint-sms-voice-v2';
 
-import { KEYWORDS, desiredPhoneNumberSettings, planSettingChanges, planKeywordChanges } from '#lib/smsTfnConfig.js';
+import {
+  KEYWORDS,
+  desiredPhoneNumberSettings,
+  planSettingChanges,
+  planKeywordChanges,
+  formatEnvHelp,
+  missingRequiredEnv,
+  isSmsConfigured,
+} from '#lib/smsTfnConfig.js';
 
 const log = (message) => console.log(`[sms-config] ${message}`);
 const logError = (message) => console.error(`[sms-config] ${message}`);
@@ -19,23 +27,60 @@ const logError = (message) => console.error(`[sms-config] ${message}`);
 // Bring our toll-free number's AWS config (keyword auto-responses + phone-number settings)
 // in line with the desired state declared in lib/smsTfnConfig.js. Idempotent and diff-first:
 // only writes what actually differs, so it's safe to run on every deploy. Targets the number
-// in AWS_SMS_ORIGINATION_NUMBER (per-environment). Pass --dry-run to preview without writing.
+// in AWS_SMS_ORIGINATION_NUMBER (per-environment).
 //
-//   node bin/sync-sms-config.js            # apply
-//   node bin/sync-sms-config.js --dry-run  # preview only
+//   node bin/sync-sms-config.js                        # apply
+//   node bin/sync-sms-config.js --dry-run              # preview only
+//   node bin/sync-sms-config.js --help                 # what to set before running
+//   node bin/sync-sms-config.js --skip-if-unconfigured # no-op when SMS isn't set up (deploys)
+
+const USAGE = `sync-sms-config — apply CareConnect's SMS config to the toll-free number in AWS.
+
+Usage:
+  node bin/sync-sms-config.js [options]
+
+Options:
+  --dry-run               Show what would change; write nothing.
+  --skip-if-unconfigured  Exit 0 instead of failing when no SMS environment is
+                          set at all. Use this for the deploy hook, so
+                          environments without SMS don't fail the deploy.
+  --help                  Show this message.
+
+Also required, but not environment variables:
+  - The opt-out list named by AWS_SMS_OPT_OUT_LIST_NAME must already exist.
+  - The SNS topic named by AWS_SMS_INBOUND_TOPIC_ARN must already exist, and
+    allow sms-voice.amazonaws.com to publish to it.
+`;
 
 const dryRun = process.argv.includes('--dry-run');
-const tfn = process.env.AWS_SMS_ORIGINATION_NUMBER;
+const skipIfUnconfigured = process.argv.includes('--skip-if-unconfigured');
 
-// Skip if SMS not configured in environment
-if (!tfn) {
-  log('AWS_SMS_ORIGINATION_NUMBER not set — nothing to sync.');
+if (process.argv.includes('--help') || process.argv.includes('-h')) {
+  console.log(USAGE);
+  console.log(formatEnvHelp());
   process.exit(0);
 }
-if (!process.env.AWS_SMS_ACCESS_KEY_ID || !process.env.AWS_SMS_SECRET_ACCESS_KEY) {
-  log('AWS SMS credentials not set — skipping.');
-  process.exit(0);
+
+// Preflight. Fail loudly and say exactly what's missing — this script is usually run
+// by hand in an unfamiliar environment, and a silent no-op reads like success.
+const missing = missingRequiredEnv();
+if (missing.length) {
+  if (!isSmsConfigured() && skipIfUnconfigured) {
+    log('no SMS environment set — nothing to sync.');
+    process.exit(0);
+  }
+  logError(`missing required environment variable(s): ${missing.join(', ')}`);
+  if (isSmsConfigured()) {
+    logError('SMS is partially configured in this environment — this is probably a mistake.');
+  }
+  logError('');
+  console.error(formatEnvHelp());
+  console.error('');
+  logError('Run with --help for full usage.');
+  process.exit(1);
 }
+
+const tfn = process.env.AWS_SMS_ORIGINATION_NUMBER;
 
 const client = new PinpointSMSVoiceV2Client({
   credentials: {
@@ -82,6 +127,14 @@ try {
       logError(`Create it once for this environment, then re-run:  aws pinpoint-sms-voice-v2 create-opt-out-list --opt-out-list-name ${settingChanges.OptOutListName}`);
       process.exit(1);
     }
+  }
+
+  // Guard: AWS rejects TwoWayEnabled without a channel ARN. Catch that here with the
+  // fix, rather than letting it surface as a raw ValidationException.
+  if (settingChanges.TwoWayEnabled && !settingChanges.TwoWayChannelArn && !number.TwoWayChannelArn) {
+    logError('Cannot enable two-way SMS: no SNS topic configured for this number.');
+    logError('Set AWS_SMS_INBOUND_TOPIC_ARN to the environment\'s inbound SNS topic ARN, then re-run.');
+    process.exit(1);
   }
 
   if (Object.keys(settingChanges).length) {

--- a/server/bin/sync-sms-config.js
+++ b/server/bin/sync-sms-config.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+import '../config.js';
+import process from 'node:process';
+import {
+  PinpointSMSVoiceV2Client,
+  DescribePhoneNumbersCommand,
+  DescribeKeywordsCommand,
+  DescribeOptOutListsCommand,
+  PutKeywordCommand,
+  UpdatePhoneNumberCommand,
+} from '@aws-sdk/client-pinpoint-sms-voice-v2';
+
+import { KEYWORDS, desiredPhoneNumberSettings, planSettingChanges, planKeywordChanges } from '#lib/smsTfnConfig.js';
+
+const log = (message) => console.log(`[sms-config] ${message}`);
+const logError = (message) => console.error(`[sms-config] ${message}`);
+
+// Bring our toll-free number's AWS config (keyword auto-responses + phone-number settings)
+// in line with the desired state declared in lib/smsTfnConfig.js. Idempotent and diff-first:
+// only writes what actually differs, so it's safe to run on every deploy. Targets the number
+// in AWS_SMS_ORIGINATION_NUMBER (per-environment). Pass --dry-run to preview without writing.
+//
+//   node bin/sync-sms-config.js            # apply
+//   node bin/sync-sms-config.js --dry-run  # preview only
+
+const dryRun = process.argv.includes('--dry-run');
+const tfn = process.env.AWS_SMS_ORIGINATION_NUMBER;
+
+// Skip if SMS not configured in environment
+if (!tfn) {
+  log('AWS_SMS_ORIGINATION_NUMBER not set — nothing to sync.');
+  process.exit(0);
+}
+if (!process.env.AWS_SMS_ACCESS_KEY_ID || !process.env.AWS_SMS_SECRET_ACCESS_KEY) {
+  log('AWS SMS credentials not set — skipping.');
+  process.exit(0);
+}
+
+const client = new PinpointSMSVoiceV2Client({
+  credentials: {
+    accessKeyId: process.env.AWS_SMS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SMS_SECRET_ACCESS_KEY,
+  },
+  region: process.env.AWS_SMS_REGION ?? 'us-west-2',
+});
+
+async function describeAllKeywords (OriginationIdentity) {
+  const keywords = [];
+  let NextToken;
+  do {
+    const resp = await client.send(new DescribeKeywordsCommand({ OriginationIdentity, NextToken }));
+    keywords.push(...(resp.Keywords ?? []));
+    NextToken = resp.NextToken;
+  } while (NextToken);
+  return keywords;
+}
+
+try {
+  // Resolve the number to its PhoneNumberId
+  const phones = await client.send(new DescribePhoneNumbersCommand({}));
+  const number = (phones.PhoneNumbers ?? []).find((p) => p.PhoneNumber === tfn);
+  if (!number) {
+    logError(`Toll-free number ${tfn} not found in this AWS account/region.`);
+    process.exit(1);
+  }
+  const OriginationIdentity = number.PhoneNumberId;
+  log(`${dryRun ? 'DRY RUN — ' : ''}syncing ${tfn} (${OriginationIdentity})`);
+
+  let changes = 0;
+
+  // Phone-number settings (two-way, opt-out management, opt-out list, two-way channel).
+  const settingChanges = planSettingChanges(number, desiredPhoneNumberSettings());
+
+  // Guard: never associate the number with an opt-out list that doesn't exist (a typo, or
+  // a per-env list that hasn't been created yet). Fail loudly with the fix instead.
+  if (settingChanges.OptOutListName) {
+    const lists = await client.send(new DescribeOptOutListsCommand({}));
+    const exists = (lists.OptOutLists ?? []).some((l) => l.OptOutListName === settingChanges.OptOutListName);
+    if (!exists) {
+      logError(`Opt-out list "${settingChanges.OptOutListName}" does not exist in this account/region.`);
+      logError(`Create it once for this environment, then re-run:  aws pinpoint-sms-voice-v2 create-opt-out-list --opt-out-list-name ${settingChanges.OptOutListName}`);
+      process.exit(1);
+    }
+  }
+
+  if (Object.keys(settingChanges).length) {
+    for (const [key, value] of Object.entries(settingChanges)) {
+      log(`setting ${key}: ${JSON.stringify(number[key])} -> ${JSON.stringify(value)}`);
+    }
+    if (!dryRun) await client.send(new UpdatePhoneNumberCommand({ PhoneNumberId: OriginationIdentity, ...settingChanges }));
+    changes += Object.keys(settingChanges).length;
+  } else {
+    log('phone-number settings already in sync.');
+  }
+
+  // Keyword auto-responses
+  const keywordChanges = planKeywordChanges(await describeAllKeywords(OriginationIdentity), KEYWORDS);
+  for (const change of keywordChanges) {
+    log(`keyword ${change.keyword} [${change.action}]: ${JSON.stringify(change.from)} -> ${JSON.stringify(change.message)}`);
+    if (!dryRun) {
+      await client.send(new PutKeywordCommand({
+        OriginationIdentity,
+        Keyword: change.keyword,
+        KeywordMessage: change.message,
+        KeywordAction: change.action,
+      }));
+    }
+    changes += 1;
+  }
+  if (!keywordChanges.length) log('keywords already in sync.');
+
+  log(dryRun
+    ? `DRY RUN complete — ${changes} change(s) would be applied.`
+    : `done — ${changes} change(s) applied.`);
+  process.exit(0);
+} catch (err) {
+  logError(`failed: ${err.message}`);
+  process.exit(1);
+}

--- a/server/bin/sync-sms-config.js
+++ b/server/bin/sync-sms-config.js
@@ -129,14 +129,6 @@ try {
     }
   }
 
-  // Guard: AWS rejects TwoWayEnabled without a channel ARN. Catch that here with the
-  // fix, rather than letting it surface as a raw ValidationException.
-  if (settingChanges.TwoWayEnabled && !settingChanges.TwoWayChannelArn && !number.TwoWayChannelArn) {
-    logError('Cannot enable two-way SMS: no SNS topic configured for this number.');
-    logError('Set AWS_SMS_INBOUND_TOPIC_ARN to the environment\'s inbound SNS topic ARN, then re-run.');
-    process.exit(1);
-  }
-
   if (Object.keys(settingChanges).length) {
     for (const [key, value] of Object.entries(settingChanges)) {
       log(`setting ${key}: ${JSON.stringify(number[key])} -> ${JSON.stringify(value)}`);

--- a/server/example.env
+++ b/server/example.env
@@ -32,15 +32,23 @@ AWS_SES_ACCESS_KEY_ID=
 AWS_SES_REGION=
 AWS_SES_SECRET_ACCESS_KEY=
 # SMS notifications (AWS End User Messaging SMS / pinpoint-sms-voice-v2).
-# IAM user needs "sms-voice:SendTextMessage". ORIGINATION_NUMBER is the leased
-# toll-free number (E.164 or its phone-number ARN).
+# IAM user needs "sms-voice:SendTextMessage" to send. ORIGINATION_NUMBER is the
+# leased toll-free number in E.164.
+# To also run `npm run sms:sync-config -w server` (applies our keyword responses
+# and phone-number settings to the number), the same IAM user additionally needs
+# sms-voice:DescribePhoneNumbers, DescribeKeywords, DescribeOptOutLists,
+# PutKeyword and UpdatePhoneNumber. See `node bin/sync-sms-config.js --help`.
 AWS_SMS_ACCESS_KEY_ID=
 AWS_SMS_SECRET_ACCESS_KEY=
 AWS_SMS_REGION=us-west-2
 AWS_SMS_ORIGINATION_NUMBER=
 AWS_SMS_INBOUND_QUEUE_URL=
-# Opt-out list to clear on an inbound START (AWS never auto-removes on START).
-# Defaults to the number's list name; ours is "Default".
+# SNS topic that inbound (two-way) SMS is published to, which the queue above
+# subscribes to. Required by sms:sync-config to enable two-way on the number.
+AWS_SMS_INBOUND_TOPIC_ARN=
+# Opt-out list to clear on an inbound START (AWS never auto-removes on START),
+# and the list sms:sync-config associates with the number. Must already exist in
+# AWS. Defaults to the number's list name; ours is "Default".
 AWS_SMS_OPT_OUT_LIST_NAME=
 # SMS transport for dev: aws | email | log. Unset = auto (aws if creds present,
 # else email if SMTP enabled, else log). 'email' renders texts to mailcatcher.

--- a/server/lib/smsTfnConfig.js
+++ b/server/lib/smsTfnConfig.js
@@ -88,9 +88,9 @@ export const ENV_VARS = [
   },
   {
     name: 'AWS_SMS_INBOUND_TOPIC_ARN',
-    required: false,
+    required: true,
     summary: 'SNS topic ARN for two-way (inbound) SMS, provisioned as infra per environment.',
-    detail: 'Effectively required unless the number already has two-way enabled: this script turns two-way on, and AWS rejects that without a channel ARN.',
+    detail: 'The topic must already exist. This script enables two-way messaging, which AWS rejects without a channel ARN.',
   },
   {
     name: 'AWS_SMS_REGION',

--- a/server/lib/smsTfnConfig.js
+++ b/server/lib/smsTfnConfig.js
@@ -55,3 +55,73 @@ export function planKeywordChanges (currentKeywords, desired = KEYWORDS) {
   }
   return changes;
 }
+
+// ---------------------------------------------------------------------------
+// Environment contract
+//
+// Single source of truth for what the operator must set before running
+// bin/sync-sms-config.js. Drives both `--help` and the preflight check, so the
+// documentation and the validation can't drift apart.
+export const ENV_VARS = [
+  {
+    name: 'AWS_SMS_ACCESS_KEY_ID',
+    required: true,
+    summary: 'IAM access key for AWS End User Messaging SMS.',
+    detail: 'Needs sms-voice:DescribePhoneNumbers, DescribeKeywords, DescribeOptOutLists, PutKeyword and UpdatePhoneNumber — more than the app itself needs to send texts.',
+  },
+  {
+    name: 'AWS_SMS_SECRET_ACCESS_KEY',
+    required: true,
+    summary: 'Secret for the access key above.',
+  },
+  {
+    name: 'AWS_SMS_ORIGINATION_NUMBER',
+    required: true,
+    summary: 'The toll-free number to configure, in E.164 (e.g. +18337225979).',
+    detail: 'Must be E.164, not a phone-number ARN — the number is matched against DescribePhoneNumbers by its PhoneNumber field.',
+  },
+  {
+    name: 'AWS_SMS_OPT_OUT_LIST_NAME',
+    required: false,
+    summary: 'Opt-out list to associate with the number (per environment).',
+    detail: 'The list must already exist; create it once with: aws pinpoint-sms-voice-v2 create-opt-out-list --opt-out-list-name <name>. If unset, the number keeps whatever list it has — deliberate, so we never force a shared "Default" list across environments.',
+  },
+  {
+    name: 'AWS_SMS_INBOUND_TOPIC_ARN',
+    required: false,
+    summary: 'SNS topic ARN for two-way (inbound) SMS, provisioned as infra per environment.',
+    detail: 'Effectively required unless the number already has two-way enabled: this script turns two-way on, and AWS rejects that without a channel ARN.',
+  },
+  {
+    name: 'AWS_SMS_REGION',
+    required: false,
+    summary: 'AWS region for the SMS API. Defaults to us-west-2.',
+  },
+];
+
+// Required vars that aren't set. Empty = good to go.
+export function missingRequiredEnv (env = process.env) {
+  return ENV_VARS.filter((v) => v.required && !env[v.name]).map((v) => v.name);
+}
+
+// Whether this environment looks like it intends to do SMS at all. Used to tell
+// "SMS isn't set up here" apart from "SMS is half set up", which is a mistake.
+export function isSmsConfigured (env = process.env) {
+  return ENV_VARS.some((v) => env[v.name]);
+}
+
+// Human-readable environment contract, shared by --help and the preflight failure.
+export function formatEnvHelp (env = process.env) {
+  const line = (v) => {
+    const set = env[v.name] ? 'set' : 'NOT SET';
+    const tag = v.required ? 'required' : 'optional';
+    const detail = v.detail ? `\n      ${v.detail}` : '';
+    return `  ${v.name}  (${tag}, currently ${set})\n      ${v.summary}${detail}`;
+  };
+  return [
+    'Environment:',
+    ...ENV_VARS.filter((v) => v.required).map(line),
+    '',
+    ...ENV_VARS.filter((v) => !v.required).map(line),
+  ].join('\n');
+}

--- a/server/lib/smsTfnConfig.js
+++ b/server/lib/smsTfnConfig.js
@@ -1,0 +1,57 @@
+import process from 'node:process';
+
+// This file defines AWS End User Messaging config settings for our toll-free number(s).
+// The settings are applied via bin/sync-sms-config.js.
+
+// Keyword auto-responses. HELP is answered automatically; STOP performs the (carrier-
+// mandated) opt-out and returns this confirmation. Identical across environments.
+export const KEYWORDS = {
+  HELP: {
+    action: 'AUTOMATIC_RESPONSE',
+    message: 'CareConnect: Reply PAUSE to pause notifications, RESUME to resume. For assistance, email careconnect@sfgov.org.',
+  },
+  STOP: {
+    action: 'OPT_OUT',
+    message: 'CareConnect: You are unsubscribed and will no longer receive messages. Reply START to resubscribe.',
+  },
+};
+
+// Phone-number-level settings, as an AWS UpdatePhoneNumber-shaped object.
+// - Enable two-way messaging
+// - Use AWS-managed opt-out lists
+// - Environment-specific pieces:
+//   - OptOutListName: an Opt-Out list name, provisioned separately per environment.
+//   - TwoWayChannelArn: the two-way SNS topic, provisioned as infra per environment.
+export function desiredPhoneNumberSettings (env = process.env) {
+  const settings = {
+    TwoWayEnabled: true,
+    SelfManagedOptOutsEnabled: false,
+  };
+  if (env.AWS_SMS_OPT_OUT_LIST_NAME) settings.OptOutListName = env.AWS_SMS_OPT_OUT_LIST_NAME;
+  if (env.AWS_SMS_INBOUND_TOPIC_ARN) settings.TwoWayChannelArn = env.AWS_SMS_INBOUND_TOPIC_ARN;
+  return settings;
+}
+
+// Diff the live phone-number config (a DescribePhoneNumbers entry) against `desired`,
+// returning only the fields that differ (the UpdatePhoneNumber payload). Empty = in sync.
+export function planSettingChanges (current, desired) {
+  const changes = {};
+  for (const [key, value] of Object.entries(desired)) {
+    if (current?.[key] !== value) changes[key] = value;
+  }
+  return changes;
+}
+
+// Diff the live keywords (a DescribeKeywords list) against the desired KEYWORDS map,
+// returning the keywords that need a PutKeyword (with `from` for logging). Empty = in sync.
+export function planKeywordChanges (currentKeywords, desired = KEYWORDS) {
+  const current = Object.fromEntries((currentKeywords ?? []).map((k) => [k.Keyword, k]));
+  const changes = [];
+  for (const [keyword, want] of Object.entries(desired)) {
+    const have = current[keyword];
+    if (!have || have.KeywordMessage !== want.message || have.KeywordAction !== want.action) {
+      changes.push({ keyword, message: want.message, action: want.action, from: have?.KeywordMessage ?? null });
+    }
+  }
+  return changes;
+}

--- a/server/package.json
+++ b/server/package.json
@@ -24,7 +24,8 @@
     "loadtest:list": "node loadtest/index.js --list",
     "geocode:facilities": "node bin/geocode-facilities.js",
     "worker": "node worker.js",
-    "worker:dev": "npm run prisma:generate && node --watch worker.js"
+    "worker:dev": "npm run prisma:generate && node --watch worker.js",
+    "sms:sync-config": "node bin/sync-sms-config.js"
   },
   "license": "AGPL-3.0-only",
   "dependencies": {

--- a/server/test/lib/smsTfnConfig.test.js
+++ b/server/test/lib/smsTfnConfig.test.js
@@ -1,7 +1,16 @@
 import { test } from 'node:test';
 import * as assert from 'node:assert';
 
-import { KEYWORDS, desiredPhoneNumberSettings, planSettingChanges, planKeywordChanges } from '#lib/smsTfnConfig.js';
+import {
+  KEYWORDS,
+  ENV_VARS,
+  desiredPhoneNumberSettings,
+  planSettingChanges,
+  planKeywordChanges,
+  missingRequiredEnv,
+  isSmsConfigured,
+  formatEnvHelp,
+} from '#lib/smsTfnConfig.js';
 
 // The sync script (bin/sync-sms-config.js) is diff-first and idempotent; these tests pin
 // the pure planning logic that decides what (if anything) to write, so re-running the sync
@@ -79,5 +88,49 @@ test('planKeywordChanges', async (t) => {
   await t.test('the shipped KEYWORDS map has HELP + STOP with the expected actions', () => {
     assert.strictEqual(KEYWORDS.HELP.action, 'AUTOMATIC_RESPONSE');
     assert.strictEqual(KEYWORDS.STOP.action, 'OPT_OUT');
+  });
+});
+
+// The environment contract is what the operator sees in --help and in the preflight
+// failure. Both read from ENV_VARS, so these pin that they stay in agreement.
+test('environment contract', async (t) => {
+  const complete = {
+    AWS_SMS_ACCESS_KEY_ID: 'AKIA...',
+    AWS_SMS_SECRET_ACCESS_KEY: 'secret',
+    AWS_SMS_ORIGINATION_NUMBER: '+18337225979',
+  };
+
+  await t.test('a complete environment is missing nothing', () => {
+    assert.deepStrictEqual(missingRequiredEnv(complete), []);
+  });
+
+  await t.test('names every missing required var, and ignores optional ones', () => {
+    assert.deepStrictEqual(missingRequiredEnv({}), [
+      'AWS_SMS_ACCESS_KEY_ID',
+      'AWS_SMS_SECRET_ACCESS_KEY',
+      'AWS_SMS_ORIGINATION_NUMBER',
+    ]);
+    // Optional vars alone never satisfy the check...
+    assert.deepStrictEqual(
+      missingRequiredEnv({ AWS_SMS_REGION: 'us-west-2', AWS_SMS_OPT_OUT_LIST_NAME: 'CareConnectDev' }),
+      ['AWS_SMS_ACCESS_KEY_ID', 'AWS_SMS_SECRET_ACCESS_KEY', 'AWS_SMS_ORIGINATION_NUMBER']
+    );
+    // ...and omitting them from a complete environment is still fine.
+    assert.deepStrictEqual(missingRequiredEnv({ ...complete }), []);
+  });
+
+  await t.test('distinguishes "no SMS here" from "half-configured"', () => {
+    // Nothing set: the deploy hook is allowed to skip.
+    assert.strictEqual(isSmsConfigured({}), false);
+    // Something set but incomplete: a mistake, never skipped.
+    assert.strictEqual(isSmsConfigured({ AWS_SMS_ORIGINATION_NUMBER: '+18337225979' }), true);
+    assert.ok(missingRequiredEnv({ AWS_SMS_ORIGINATION_NUMBER: '+18337225979' }).length);
+  });
+
+  await t.test('help text lists every var and shows which are set', () => {
+    const help = formatEnvHelp(complete);
+    for (const { name } of ENV_VARS) assert.ok(help.includes(name), `missing ${name}`);
+    assert.match(help, /AWS_SMS_ACCESS_KEY_ID {2}\(required, currently set\)/);
+    assert.match(help, /AWS_SMS_REGION {2}\(optional, currently NOT SET\)/);
   });
 });

--- a/server/test/lib/smsTfnConfig.test.js
+++ b/server/test/lib/smsTfnConfig.test.js
@@ -98,6 +98,7 @@ test('environment contract', async (t) => {
     AWS_SMS_ACCESS_KEY_ID: 'AKIA...',
     AWS_SMS_SECRET_ACCESS_KEY: 'secret',
     AWS_SMS_ORIGINATION_NUMBER: '+18337225979',
+    AWS_SMS_INBOUND_TOPIC_ARN: 'arn:aws:sns:us-west-2:1:careconnect-inbound',
   };
 
   await t.test('a complete environment is missing nothing', () => {
@@ -109,11 +110,12 @@ test('environment contract', async (t) => {
       'AWS_SMS_ACCESS_KEY_ID',
       'AWS_SMS_SECRET_ACCESS_KEY',
       'AWS_SMS_ORIGINATION_NUMBER',
+      'AWS_SMS_INBOUND_TOPIC_ARN',
     ]);
     // Optional vars alone never satisfy the check...
     assert.deepStrictEqual(
       missingRequiredEnv({ AWS_SMS_REGION: 'us-west-2', AWS_SMS_OPT_OUT_LIST_NAME: 'CareConnectDev' }),
-      ['AWS_SMS_ACCESS_KEY_ID', 'AWS_SMS_SECRET_ACCESS_KEY', 'AWS_SMS_ORIGINATION_NUMBER']
+      ['AWS_SMS_ACCESS_KEY_ID', 'AWS_SMS_SECRET_ACCESS_KEY', 'AWS_SMS_ORIGINATION_NUMBER', 'AWS_SMS_INBOUND_TOPIC_ARN']
     );
     // ...and omitting them from a complete environment is still fine.
     assert.deepStrictEqual(missingRequiredEnv({ ...complete }), []);

--- a/server/test/lib/smsTfnConfig.test.js
+++ b/server/test/lib/smsTfnConfig.test.js
@@ -1,0 +1,83 @@
+import { test } from 'node:test';
+import * as assert from 'node:assert';
+
+import { KEYWORDS, desiredPhoneNumberSettings, planSettingChanges, planKeywordChanges } from '#lib/smsTfnConfig.js';
+
+// The sync script (bin/sync-sms-config.js) is diff-first and idempotent; these tests pin
+// the pure planning logic that decides what (if anything) to write, so re-running the sync
+// against an already-correct number is a guaranteed no-op.
+
+test('desiredPhoneNumberSettings', async (t) => {
+  await t.test('defaults: two-way on, AWS-managed opt-outs, and does NOT force an opt-out list', () => {
+    // Never defaulting the list is deliberate — see the comment in the module. Forcing
+    // "Default" would leak opt-outs across environments in a shared AWS account.
+    const s = desiredPhoneNumberSettings({});
+    assert.deepStrictEqual(s, { TwoWayEnabled: true, SelfManagedOptOutsEnabled: false });
+    assert.ok(!('OptOutListName' in s));
+  });
+
+  await t.test('manages the opt-out list + two-way channel only when explicitly set in env', () => {
+    const s = desiredPhoneNumberSettings({
+      AWS_SMS_OPT_OUT_LIST_NAME: 'CareConnectStaging',
+      AWS_SMS_INBOUND_TOPIC_ARN: 'arn:aws:sns:us-west-2:1:careconnect-inbound',
+    });
+    assert.strictEqual(s.OptOutListName, 'CareConnectStaging');
+    assert.strictEqual(s.TwoWayChannelArn, 'arn:aws:sns:us-west-2:1:careconnect-inbound');
+  });
+});
+
+test('planSettingChanges', async (t) => {
+  const desired = { TwoWayEnabled: true, SelfManagedOptOutsEnabled: false, OptOutListName: 'Default' };
+
+  await t.test('returns nothing when already in sync (ignores extra live fields)', () => {
+    const current = { TwoWayEnabled: true, SelfManagedOptOutsEnabled: false, OptOutListName: 'Default', PhoneNumber: '+1833...' };
+    assert.deepStrictEqual(planSettingChanges(current, desired), {});
+  });
+
+  await t.test('returns only the differing fields', () => {
+    const current = { TwoWayEnabled: false, SelfManagedOptOutsEnabled: false, OptOutListName: 'Default' };
+    assert.deepStrictEqual(planSettingChanges(current, desired), { TwoWayEnabled: true });
+  });
+
+  await t.test('treats a missing field as a change', () => {
+    assert.deepStrictEqual(planSettingChanges({}, { OptOutListName: 'Default' }), { OptOutListName: 'Default' });
+  });
+});
+
+test('planKeywordChanges', async (t) => {
+  const desired = {
+    HELP: { action: 'AUTOMATIC_RESPONSE', message: 'help msg' },
+    STOP: { action: 'OPT_OUT', message: 'stop msg' },
+  };
+
+  await t.test('returns nothing when all keywords match', () => {
+    const current = [
+      { Keyword: 'HELP', KeywordAction: 'AUTOMATIC_RESPONSE', KeywordMessage: 'help msg' },
+      { Keyword: 'STOP', KeywordAction: 'OPT_OUT', KeywordMessage: 'stop msg' },
+    ];
+    assert.deepStrictEqual(planKeywordChanges(current, desired), []);
+  });
+
+  await t.test('flags a keyword whose message differs (e.g. the "Default Stop Message" placeholder)', () => {
+    const current = [
+      { Keyword: 'HELP', KeywordAction: 'AUTOMATIC_RESPONSE', KeywordMessage: 'help msg' },
+      { Keyword: 'STOP', KeywordAction: 'OPT_OUT', KeywordMessage: 'Default Stop Message' },
+    ];
+    const changes = planKeywordChanges(current, desired);
+    assert.strictEqual(changes.length, 1);
+    assert.strictEqual(changes[0].keyword, 'STOP');
+    assert.strictEqual(changes[0].message, 'stop msg');
+    assert.strictEqual(changes[0].from, 'Default Stop Message');
+  });
+
+  await t.test('flags a missing keyword, and an action mismatch', () => {
+    const current = [{ Keyword: 'HELP', KeywordAction: 'OPT_OUT', KeywordMessage: 'help msg' }]; // wrong action, STOP absent
+    const changes = planKeywordChanges(current, desired);
+    assert.deepStrictEqual(changes.map((c) => c.keyword).sort(), ['HELP', 'STOP']);
+  });
+
+  await t.test('the shipped KEYWORDS map has HELP + STOP with the expected actions', () => {
+    assert.strictEqual(KEYWORDS.HELP.action, 'AUTOMATIC_RESPONSE');
+    assert.strictEqual(KEYWORDS.STOP.action, 'OPT_OUT');
+  });
+});


### PR DESCRIPTION
Closes #1003 

In this PR:
- `smsTfnConfig.js` contains:
  -  some written copy that is meant to be versioned with the repo, e.g. the exact text of the message we send in reply to the `HELP` keyword. This is effectively part of the app and should be identical across environments.
  - some logic for pulling AWS SMS config info from env vars (for things which must _differ_ across environments, like "which toll-free number are we using?", "what's the name of the opt-out list we want to use?", etc.
- `sync-sms-config.js` is a script that _applies_ those configs to the relevant AWS SMS account. The script can be run standalone, but is intended to be run as part of each deploy. (I may need some advice on how to do that; not sure if we already have a preferred mechanism for running things at deploy-time.)

The script will _associate_ the env-specified opt-out list (`AWS_SMS_OPT_OUT_LIST_NAME`) with the env-specified TFN (`AWS_SMS_ORIGINATION_NUMBER`), but it requires that the opt-out list already exists. I took the liberty of creating these four opt-out lists in our AWS account (though we can easily rename/delete/add any that we want. all these lists are empty right now):
```
CareConnectLocalDev
CareConnectDev
CareConnectStaging
CareConnectProduction
```

## Running the script

```bash
# from the target environment (e.g. shell into the server container)
npm run sms:sync-config -w server
```

If any required env vars are unset, the script aborts and tells you what's missing. 


### Expected env vars
The script relies on these env vars in order to work:

| Var | | Notes |
|---|---|---|
| `AWS_SMS_ACCESS_KEY_ID` | required | Needs the permissions:`DescribePhoneNumbers`, `DescribeKeywords`, `DescribeOptOutLists`, `PutKeyword`, `UpdatePhoneNumber` |
| `AWS_SMS_SECRET_ACCESS_KEY` | required | |
| `AWS_SMS_ORIGINATION_NUMBER` | required | toll-free number in E.164 format (`+1833…`) |
| `AWS_SMS_OPT_OUT_LIST_NAME` | required |  |
| `AWS_SMS_INBOUND_TOPIC_ARN` | required | Needed for two-way messaging |
| `AWS_SMS_REGION` | optional | Defaults to `us-west-2` |

Note that the specified `AWS_SMS_OPT_OUT_LIST_NAME` must already exist in AWS, and the `AWS_SMS_INBOUND_TOPIC_ARN` must also have been created in AWS.