### PR TITLE
Add double-confirmation flow for failing intake

### DIFF
--- a/client/src/lesc/components/care/CompleteIntakeModal.jsx
+++ b/client/src/lesc/components/care/CompleteIntakeModal.jsx
@@ -52,7 +52,7 @@ function CompleteIntakeModal ({
         ? (
           <Stack gap='2xl'>
             <Stack gap='sm'>
-              <Group justify='space-between' align='flex-start' wrap='nowrap'>
+              <Group justify='space-between' align='center' wrap='nowrap'>
                 <Title order={4}>Confirm medical intake</Title>
                 {closeButton}
               </Group>
@@ -88,7 +88,7 @@ function CompleteIntakeModal ({
         : (
           <Stack gap='2xl'>
             <Stack gap='sm'>
-              <Group justify='space-between' align='flex-start' wrap='nowrap'>
+              <Group justify='space-between' align='center' wrap='nowrap'>
                 <Title order={4}>Confirm return to Deputy</Title>
                 {closeButton}
               </Group>

--- a/client/src/lesc/components/care/CompleteIntakeModal.jsx
+++ b/client/src/lesc/components/care/CompleteIntakeModal.jsx
@@ -4,10 +4,8 @@ import { IconX } from '@tabler/icons-react';
 
 // Two-step confirmation for the intake decision. Step 1 asks whether the medical
 // intake was completed. Answering "No" advances to step 2 — a second confirmation —
-// before the destructive "return to Deputy" action fires, since that move is
-// irreversible. The external API is unchanged (a single opened/onClose modal with
-// onConfirmCompleted / onConfirmNotCompleted callbacks); the parent closes the modal
-// on mutation success, so this component only tracks which step is showing.
+// before the destructive "return to Deputy" action fires, since that action is
+// irreversible.
 function CompleteIntakeModal ({
   opened,
   onClose,

--- a/client/src/lesc/components/care/CompleteIntakeModal.jsx
+++ b/client/src/lesc/components/care/CompleteIntakeModal.jsx
@@ -61,12 +61,14 @@ function CompleteIntakeModal ({
               </Text>
             </Stack>
 
-            <Stack gap='sm'>
+            <Stack gap='sm' align='flex-start'>
               <Button
                 data-testid='intake-confirm-btn'
                 color='indigo'
                 size='lg'
                 radius='xl'
+                h={48}
+                px={24}
                 onClick={onConfirmCompleted}
                 loading={loading}
               >
@@ -77,6 +79,8 @@ function CompleteIntakeModal ({
                 color='red'
                 size='lg'
                 radius='xl'
+                h={48}
+                px={24}
                 onClick={() => setStep('returnToDeputy')}
                 disabled={loading}
               >
@@ -97,12 +101,14 @@ function CompleteIntakeModal ({
               </Text>
             </Stack>
 
-            <Stack gap='sm'>
+            <Stack gap='sm' align='flex-start'>
               <Button
                 variant='outline'
                 color='indigo'
                 size='lg'
                 radius='xl'
+                h={48}
+                px={24}
                 onClick={onClose}
                 disabled={loading}
               >
@@ -113,6 +119,8 @@ function CompleteIntakeModal ({
                 color='red'
                 size='lg'
                 radius='xl'
+                h={48}
+                px={24}
                 onClick={onConfirmNotCompleted}
                 loading={loading}
               >

--- a/client/src/lesc/components/care/CompleteIntakeModal.jsx
+++ b/client/src/lesc/components/care/CompleteIntakeModal.jsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { ActionIcon, Button, Group, Modal, Stack, Text, Title } from '@mantine/core';
 import { IconX } from '@tabler/icons-react';
 
+// Two-step confirmation for the intake decision. Step 1 asks whether the medical
+// intake was completed. Answering "No" advances to step 2 — a second confirmation —
+// before the destructive "return to Deputy" action fires, since that move is
+// irreversible. The external API is unchanged (a single opened/onClose modal with
+// onConfirmCompleted / onConfirmNotCompleted callbacks); the parent closes the modal
+// on mutation success, so this component only tracks which step is showing.
 function CompleteIntakeModal ({
   opened,
   onClose,
@@ -9,6 +15,29 @@ function CompleteIntakeModal ({
   onConfirmNotCompleted,
   loading = false,
 }) {
+  const [step, setStep] = useState('confirm'); // 'confirm' | 'returnToDeputy'
+
+  // Always start on step 1 when the modal (re)opens.
+  useEffect(() => {
+    if (opened) setStep('confirm');
+  }, [opened]);
+
+  const closeButton = (
+    <ActionIcon
+      onClick={onClose}
+      bg='rgba(134, 142, 150, 0.1)'
+      c='black'
+      radius='xl'
+      w={40}
+      h={40}
+      ml='auto'
+      disabled={loading}
+      aria-label='Close'
+    >
+      <IconX size={16} />
+    </ActionIcon>
+  );
+
   return (
     <Modal
       opened={opened}
@@ -18,54 +47,80 @@ function CompleteIntakeModal ({
       centered
       lockScroll
       withCloseButton={false}
-      padding='md'
     >
-      <Stack gap='xl'>
-        <Stack gap='sm'>
-          <Group justify='space-between' align='flex-start' wrap='nowrap'>
-            <Title order={4}>Update intake status</Title>
-            <ActionIcon
-              onClick={onClose}
-              bg='rgba(134, 142, 150, 0.1)'
-              c='black'
-              radius='xl'
-              w={40}
-              h={40}
-              ml='auto'
-              disabled={loading}
-              aria-label='Close'
-            >
-              <IconX size={16} />
-            </ActionIcon>
-          </Group>
-          <Text size='sm' c='dimmed'>
-            Were you able to complete the full medical intake for this person? If not, person will be returned to Deputy's custody for further handling - this is irreversible.
-          </Text>
-        </Stack>
+      {step === 'confirm'
+        ? (
+          <Stack gap='2xl'>
+            <Stack gap='sm'>
+              <Group justify='space-between' align='flex-start' wrap='nowrap'>
+                <Title order={4}>Confirm medical intake</Title>
+                {closeButton}
+              </Group>
+              <Text size='sm' c='dimmed'>
+                Were you able to complete the full medical intake for this person?
+              </Text>
+            </Stack>
 
-        <Stack gap='sm'>
-          <Button
-            variant='outline'
-            color='red'
-            size='lg'
-            radius='xl'
-            onClick={onConfirmNotCompleted}
-            loading={loading}
-          >
-            Failed intake - return to Deputy
-          </Button>
-          <Button
-            data-testid='intake-confirm-btn'
-            color='indigo'
-            size='lg'
-            radius='xl'
-            onClick={onConfirmCompleted}
-            loading={loading}
-          >
-            Yes, intake completed
-          </Button>
-        </Stack>
-      </Stack>
+            <Stack gap='sm'>
+              <Button
+                data-testid='intake-confirm-btn'
+                color='indigo'
+                size='lg'
+                radius='xl'
+                onClick={onConfirmCompleted}
+                loading={loading}
+              >
+                Yes, intake completed
+              </Button>
+              <Button
+                variant='outline'
+                color='red'
+                size='lg'
+                radius='xl'
+                onClick={() => setStep('returnToDeputy')}
+                disabled={loading}
+              >
+                No, return to Deputy
+              </Button>
+            </Stack>
+          </Stack>
+          )
+        : (
+          <Stack gap='2xl'>
+            <Stack gap='sm'>
+              <Group justify='space-between' align='flex-start' wrap='nowrap'>
+                <Title order={4}>Confirm return to Deputy</Title>
+                {closeButton}
+              </Group>
+              <Text size='sm' c='dimmed'>
+                This will mark medical intake as not completed and move this person back to Deputy review for release or exit. This is irreversible.
+              </Text>
+            </Stack>
+
+            <Stack gap='sm'>
+              <Button
+                variant='outline'
+                color='indigo'
+                size='lg'
+                radius='xl'
+                onClick={onClose}
+                disabled={loading}
+              >
+                Cancel
+              </Button>
+              <Button
+                data-testid='intake-return-btn'
+                color='red'
+                size='lg'
+                radius='xl'
+                onClick={onConfirmNotCompleted}
+                loading={loading}
+              >
+                Confirm return to Deputy
+              </Button>
+            </Stack>
+          </Stack>
+          )}
     </Modal>
   );
 }

--- a/client/src/lesc/components/care/CompleteIntakeModal.test.jsx
+++ b/client/src/lesc/components/care/CompleteIntakeModal.test.jsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MantineProvider } from '@mantine/core';
+
+import CompleteIntakeModal from './CompleteIntakeModal';
+
+function renderModal (props = {}) {
+  const handlers = {
+    onClose: vi.fn(),
+    onConfirmCompleted: vi.fn(),
+    onConfirmNotCompleted: vi.fn(),
+  };
+  const utils = render(
+    <MantineProvider>
+      <CompleteIntakeModal opened {...handlers} {...props} />
+    </MantineProvider>
+  );
+  return { ...utils, ...handlers };
+}
+
+describe('CompleteIntakeModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('opens on the "Confirm medical intake" step', () => {
+    renderModal();
+    expect(screen.getByText('Confirm medical intake')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Yes, intake completed' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'No, return to Deputy' })).toBeInTheDocument();
+    // Step 2's confirmation is not shown yet.
+    expect(screen.queryByText('Confirm return to Deputy')).not.toBeInTheDocument();
+  });
+
+  it('"Yes, intake completed" completes intake without a second step', () => {
+    const { onConfirmCompleted, onConfirmNotCompleted } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, intake completed' }));
+    expect(onConfirmCompleted).toHaveBeenCalledTimes(1);
+    expect(onConfirmNotCompleted).not.toHaveBeenCalled();
+  });
+
+  it('"No, return to Deputy" advances to the second confirmation without acting yet', () => {
+    const { onConfirmNotCompleted, onClose } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'No, return to Deputy' }));
+
+    // The destructive action has NOT fired — we only advanced steps.
+    expect(onConfirmNotCompleted).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('heading', { name: 'Confirm return to Deputy' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm return to Deputy' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('the second-step "Confirm return to Deputy" fires the destructive action', () => {
+    const { onConfirmNotCompleted } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'No, return to Deputy' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm return to Deputy' }));
+    expect(onConfirmNotCompleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('the second-step "Cancel" closes without acting', () => {
+    const { onClose, onConfirmNotCompleted } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'No, return to Deputy' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirmNotCompleted).not.toHaveBeenCalled();
+  });
+
+  it('the close (X) button closes the modal', () => {
+    const { onClose } = renderModal();
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets to the first step when reopened', () => {
+    const handlers = {
+      onClose: vi.fn(),
+      onConfirmCompleted: vi.fn(),
+      onConfirmNotCompleted: vi.fn(),
+    };
+    const { rerender } = render(
+      <MantineProvider>
+        <CompleteIntakeModal opened {...handlers} />
+      </MantineProvider>
+    );
+
+    // Advance to step 2, then close.
+    fireEvent.click(screen.getByRole('button', { name: 'No, return to Deputy' }));
+    expect(screen.getByRole('heading', { name: 'Confirm return to Deputy' })).toBeInTheDocument();
+    rerender(
+      <MantineProvider>
+        <CompleteIntakeModal opened={false} {...handlers} />
+      </MantineProvider>
+    );
+
+    // Reopen — we should be back on step 1, not the return-to-Deputy confirmation.
+    rerender(
+      <MantineProvider>
+        <CompleteIntakeModal opened {...handlers} />
+      </MantineProvider>
+    );
+    expect(screen.getByText('Confirm medical intake')).toBeInTheDocument();
+    expect(screen.queryByText('Confirm return to Deputy')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Resolves #995 

Based on the changes specified in [this design](https://www.figma.com/design/Q8kS4FJXh1TbbM8eDR7Z6Y/CareConnect?node-id=19420-36858&t=iGd0U9kNSXnZ7zOD-0). 

https://github.com/user-attachments/assets/25160450-5349-4afc-a225-921517d881b8

