### PR TITLE
Explicitly fail a facilities request with invalid type

### DIFF
--- a/server/routes/api/facilities/list.js
+++ b/server/routes/api/facilities/list.js
@@ -9,7 +9,10 @@ export default async function (fastify, opts) {
       schema: {
         description: 'Returns a list of facilities with detailed metadata.',
         querystring: z.object({
-          type: z.string().optional(),
+          // Clients (e.g. the facility selector) send `type=` with no value to mean
+          // "no filter", so treat an empty string as absent; any other non-enum value
+          // is rejected as a 422 rather than reaching Prisma.
+          type: z.preprocess((v) => (v === '' ? undefined : v), z.enum(Object.values(Facility.Type)).optional()),
           include: z.string().optional(),
           page: z.coerce.number().optional(),
           perPage: z.coerce.number().optional(),

--- a/server/routes/api/facilities/list.js
+++ b/server/routes/api/facilities/list.js
@@ -9,9 +9,7 @@ export default async function (fastify, opts) {
       schema: {
         description: 'Returns a list of facilities with detailed metadata.',
         querystring: z.object({
-          // Clients (e.g. the facility selector) send `type=` with no value to mean
-          // "no filter", so treat an empty string as absent; any other non-enum value
-          // is rejected as a 422 rather than reaching Prisma.
+          // Treat an empty type value as undefined; otherwise type must be in FacilityType enum
           type: z.preprocess((v) => (v === '' ? undefined : v), z.enum(Object.values(Facility.Type)).optional()),
           include: z.string().optional(),
           page: z.coerce.number().optional(),

--- a/server/test/routes/api/facilities.test.js
+++ b/server/test/routes/api/facilities.test.js
@@ -63,6 +63,29 @@ test('/api/facilities', async (t) => {
       assert.ok(facilityNames.includes('General Facility 1'));
       assert.ok(facilityNames.includes('General Facility 2'));
     });
+
+    await t.test('rejects a type outside the enum with a validation error, not a 500', async () => {
+      // A value not in FacilityTypeEnum must fail schema validation up front (422 via the
+      // error handler), rather than reaching Prisma and throwing a PrismaClientValidationError (500).
+      const response = await app.inject()
+        .get('/api/facilities?type=INVALID')
+        .headers(userHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.UNPROCESSABLE_ENTITY);
+    });
+
+    await t.test('treats an empty type= as no filter (returns all facilities, not a 422)', async () => {
+      // The facility selector sends `type=` with no value; that must be accepted as
+      // "no filter" rather than failing enum validation.
+      const response = await app.inject()
+        .get('/api/facilities?type=')
+        .headers(userHeaders);
+
+      assert.deepStrictEqual(response.statusCode, StatusCodes.OK);
+      const facilities = JSON.parse(response.body);
+      assert.ok(Array.isArray(facilities));
+      assert.ok(facilities.length >= 4); // all facilities, unfiltered
+    });
   });
 
   await t.test('GET /:id', async (t) => {


### PR DESCRIPTION
Closes #999 

PostHog shows 43 recent instances of the server throwing a 500 because a call to `facilities` (handled by `facilities/list.js`) had an invalid value for `type`.

Interestingly, there are a variety of _different_ types that were used, including:

- `INVALID`
- `INVALID_TYPE`
- `DIDO'`
- `DIDO\`
- `ABC`
- `SHELTER`

The **proximate cause** of the errors is that our code receives a `facilities` request turns that into a DB query without validating whether the passed `type` argument is valid. When it's invalid, Prisma throws a `PrismaClientValidationError`, and an error shows up in PostHog.

This PR solves that problem by validating the `type` argument against the FacilityType enum. If a `facilities` request has an invalid type, we will now throw a regular 422 failure, rather than attempting to execute an invalid DB query and generating an unexpected 500 error.

A **deeper mystery** is how these weirdo requests are getting generated in the first place. I do not think our code is doing it. But the `facilities` endpoint is public, so I can only assume this is being done by scanners trying to probe public application endpoints for potential vulnerabilities. I imagine this is common for any app placed on the internet, and 43 is not a big number in the scheme of things; but reliably evaluating whether this is a real attacker or mere background noise is outside my expertise.

