### PR TITLE
Prevent failed dynamic import

### DIFF
--- a/client/src/AppRoutes.jsx
+++ b/client/src/AppRoutes.jsx
@@ -3,6 +3,7 @@ import { Route, Routes } from 'react-router';
 import { Container, Loader } from '@mantine/core';
 
 import AppRedirects from './AppRedirects';
+import ChunkErrorBoundary from './components/ChunkErrorBoundary';
 import { useFacilityContext } from './FacilityContext';
 import { useStaticContext } from './StaticContext';
 
@@ -31,23 +32,25 @@ function AppRoutes () {
         path='*'
         element={
           <AppRedirects>
-            <Suspense fallback={<Container ta='center'><Loader /></Container>}>
-              <Routes>
-                <Route path='/login' element={<Login />} />
-                <Route path='/units' element={<UnitSelector />} />
-                <Route path='/passwords/*' element={<PasswordsRoutes />} />
-                <Route path='/invites/*' element={<InvitesRoutes />} />
-                {staticContext?.env?.VITE_FEATURE_REGISTRATION === 'true' && <Route path='/register' element={<Register />} />}
-                <Route path='/feedback' element={<FeedbackViewer />} />
-                <Route path='/feedback/list' element={<FeedbackList />} />
-                <Route path='/profile/*' element={<UserProfileRoutes />} />
-                <Route path='/manage-users/*' element={<ManageUsersRoutes />} />
-                <Route path='/admin/*' element={<AdminRoutes />} />
-                {!facility && <Route path='/*' element={<DIDORoutes />} />}
-                {facility?.type === 'LESC' && <Route path='/*' element={<LESCRoutes />} />}
-                <Route path='/*' element={<NotFound />} />
-              </Routes>
-            </Suspense>
+            <ChunkErrorBoundary>
+              <Suspense fallback={<Container ta='center'><Loader /></Container>}>
+                <Routes>
+                  <Route path='/login' element={<Login />} />
+                  <Route path='/units' element={<UnitSelector />} />
+                  <Route path='/passwords/*' element={<PasswordsRoutes />} />
+                  <Route path='/invites/*' element={<InvitesRoutes />} />
+                  {staticContext?.env?.VITE_FEATURE_REGISTRATION === 'true' && <Route path='/register' element={<Register />} />}
+                  <Route path='/feedback' element={<FeedbackViewer />} />
+                  <Route path='/feedback/list' element={<FeedbackList />} />
+                  <Route path='/profile/*' element={<UserProfileRoutes />} />
+                  <Route path='/manage-users/*' element={<ManageUsersRoutes />} />
+                  <Route path='/admin/*' element={<AdminRoutes />} />
+                  {!facility && <Route path='/*' element={<DIDORoutes />} />}
+                  {facility?.type === 'LESC' && <Route path='/*' element={<LESCRoutes />} />}
+                  <Route path='/*' element={<NotFound />} />
+                </Routes>
+              </Suspense>
+            </ChunkErrorBoundary>
           </AppRedirects>
         }
       />

--- a/client/src/components/ChunkErrorBoundary.jsx
+++ b/client/src/components/ChunkErrorBoundary.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Button, Center, Stack, Text, Title } from '@mantine/core';
+
+import { isChunkLoadError, reloadOnceForStaleChunk } from '../utils/chunkReload';
+
+// Catches the "stale chunk after deploy" error thrown when a lazy route's chunk
+// fails to load, and recovers by reloading once to the current build (guarded
+// against reload loops). If we've already reloaded and it still fails (offline, or
+// a broken deploy), it shows a static refresh prompt instead of looping. Any error
+// that is NOT a chunk-load error is re-thrown so normal error handling still applies.
+class ChunkErrorBoundary extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = { error: null, gaveUp: false };
+  }
+
+  static getDerivedStateFromError (error) {
+    return { error };
+  }
+
+  componentDidCatch (error) {
+    if (isChunkLoadError(error)) {
+      // reloadOnceForStaleChunk returns false if it declined to reload (already did
+      // so recently) — in that case we've "given up" and render the fallback.
+      this.setState({ gaveUp: !reloadOnceForStaleChunk() });
+    }
+  }
+
+  render () {
+    const { error, gaveUp } = this.state;
+    if (!error) return this.props.children;
+
+    // Not a stale-chunk error — let it propagate to normal error handling.
+    if (!isChunkLoadError(error)) throw error;
+
+    // A reload has been (or is about to be) triggered; show a neutral placeholder
+    // until the navigation happens, rather than a scary error.
+    if (!gaveUp) {
+      return (
+        <Center h='100vh'>
+          <Text c='dimmed'>Updating to the latest version…</Text>
+        </Center>
+      );
+    }
+
+    // We already reloaded once and it still failed — offer a manual retry.
+    return (
+      <Center h='100vh' p='xl'>
+        <Stack align='center' gap='sm' maw={360}>
+          <Title order={4}>Couldn’t load this page</Title>
+          <Text size='sm' c='dimmed' ta='center'>
+            You may be offline, or a new version is being deployed. Please check your connection and try again.
+          </Text>
+          <Button radius='xl' onClick={() => window.location.reload()}>Refresh</Button>
+        </Stack>
+      </Center>
+    );
+  }
+}
+
+export default ChunkErrorBoundary;

--- a/client/src/entry-client.jsx
+++ b/client/src/entry-client.jsx
@@ -12,6 +12,16 @@ import './i18n';
 import App from './App';
 import { defaultValue } from './StaticContext';
 import StaticContextProvider from './StaticContextProvider';
+import { reloadOnceForStaleChunk } from './utils/chunkReload';
+
+// Recover from stale code-split chunks after a deploy: when a dynamic import() for a
+// lazy route fails (its hashed file no longer exists on the server), Vite fires this
+// event. Reload once to the current build; the guard prevents a reload loop. This is
+// the early catch; ChunkErrorBoundary is the render-time backstop. See utils/chunkReload.
+window.addEventListener('vite:preloadError', (event) => {
+  event.preventDefault(); // don't let it surface as an unhandled rejection
+  reloadOnceForStaleChunk();
+});
 
 // PostHog's exception auto-capture calls preventDefault on unhandledrejection
 // and error events, which suppresses the browser's default console log. In

--- a/client/src/utils/chunkReload.js
+++ b/client/src/utils/chunkReload.js
@@ -1,0 +1,52 @@
+// Recovery for the "stale chunk after deploy" failure.
+//
+// The app is code-split into content-hashed chunks (e.g. AdminRoutes-<hash>.js).
+// A browser session left open across a deploy keeps running the old build's JS,
+// which references old chunk filenames. Navigating to a not-yet-loaded lazy route
+// then fetches a URL that 404s, throwing "Failed to fetch dynamically imported
+// module". Because index.html is served no-cache, a single full reload pulls the
+// current build's HTML + chunk hashes and recovers.
+//
+// The guard makes reloading safe: it reloads at most once per RELOAD_WINDOW_MS, so
+// a chunk that genuinely can't be fetched (offline, or a broken deploy) can't cause
+// a reload loop — after one attempt the caller shows a static "refresh" fallback
+// instead. The marker lives in sessionStorage because a reload wipes in-memory
+// state; it's scoped to the tab and clears when the tab closes.
+
+const RELOAD_MARKER = 'chunkReloadAt';
+const RELOAD_WINDOW_MS = 10_000;
+
+// True for the errors browsers throw when a dynamic import() / modulepreload can't
+// be fetched or parsed (i.e. a code-split chunk that no longer exists after a deploy).
+export function isChunkLoadError (error) {
+  const message = (error && (error.message || String(error))) || '';
+  return (
+    /Failed to fetch dynamically imported module/i.test(message) ||
+    /error loading dynamically imported module/i.test(message) ||
+    /Importing a module script failed/i.test(message) // Safari's wording
+  );
+}
+
+// Reload once to pick up the current build. Returns true if it triggered a reload,
+// or false if we already reloaded within the window — in which case the caller
+// should surface a fallback rather than loop.
+export function reloadOnceForStaleChunk () {
+  let lastReloadAt = 0;
+  try {
+    lastReloadAt = Number(window.sessionStorage.getItem(RELOAD_MARKER)) || 0;
+  } catch {
+    // sessionStorage can throw in some privacy modes; treat as "not reloaded yet".
+  }
+
+  if (Date.now() - lastReloadAt < RELOAD_WINDOW_MS) {
+    return false; // already reloaded very recently — don't loop
+  }
+
+  try {
+    window.sessionStorage.setItem(RELOAD_MARKER, String(Date.now()));
+  } catch {
+    // ignore — a failed write just means the next error may reload again
+  }
+  window.location.reload();
+  return true;
+}

--- a/client/src/utils/chunkReload.test.js
+++ b/client/src/utils/chunkReload.test.js
@@ -1,0 +1,66 @@
+/* @vitest-environment jsdom */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { isChunkLoadError, reloadOnceForStaleChunk } from './chunkReload';
+
+describe('isChunkLoadError', () => {
+  it('matches the dynamic-import fetch failures browsers throw for stale chunks', () => {
+    expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module: https://x/assets/AdminRoutes-abc.js'))).toBe(true);
+    expect(isChunkLoadError(new Error('error loading dynamically imported module'))).toBe(true);
+    expect(isChunkLoadError(new Error('Importing a module script failed.'))).toBe(true); // Safari
+  });
+
+  it('does not match unrelated errors', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+    expect(isChunkLoadError(undefined)).toBe(false);
+  });
+});
+
+describe('reloadOnceForStaleChunk (loop guard)', () => {
+  let reloadMock;
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    reloadMock = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { reload: reloadMock },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('reloads on the first stale-chunk error and records the attempt', () => {
+    const didReload = reloadOnceForStaleChunk();
+
+    expect(didReload).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(window.sessionStorage.getItem('chunkReloadAt')).toBeTruthy();
+  });
+
+  it('does NOT reload again within the window — prevents an infinite loop', () => {
+    reloadOnceForStaleChunk(); // first attempt reloads
+    reloadMock.mockClear();
+
+    const didReload = reloadOnceForStaleChunk(); // immediate second attempt
+
+    expect(didReload).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it('reloads again once the window has elapsed (e.g. a later deploy)', () => {
+    reloadOnceForStaleChunk();
+    reloadMock.mockClear();
+
+    // Simulate the previous reload happening well outside the 10s window.
+    window.sessionStorage.setItem('chunkReloadAt', String(Date.now() - 20_000));
+
+    const didReload = reloadOnceForStaleChunk();
+
+    expect(didReload).toBe(true);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Closes #1002, addressing the recurring PostHog error `TypeError: Failed to fetch dynamically imported module`.

Dynamic loading is an area where I don't have a ton of expertise, so relied a lot on Claude for assistance figuring out how this works.

**Cause, as I understand it:** 
- Certain assets get a dynamic hashed route with each deploy.
- The app loads a listing of those routes, but fetches the actual modules lazily (only when each one is needed).
- When there's a deploy, the route to each module changes (gets a new hash). If the user doesn't hard-reload, then the next time they need to load an unloaded module, they'll attempt to fetch it from the stale route, causing this error. 

**Fix:** When we hit this preload error, attempt to reload the routes listing.
- we listen for `vite:preloadError`
- if we hit that error, try to fully reload the page (which should fetch the new URL and then allow us to grab the resource from its updated location)
- track last reload time (to prevent an infinite loop if the resource is actually unloadable)


